### PR TITLE
Add workspace-jj plugin for jj worktree isolation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "muloka-claude-plugins",
-  "description": "jj (Jujutsu) plugins for Claude Code — commit workflows, code review, PR review, and feature development",
+  "description": "jj (Jujutsu) plugins for Claude Code — commit workflows, code review, PR review, feature development, and workspace isolation",
   "owner": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"
@@ -50,6 +50,17 @@
       "source": "./plugins/feature-dev-jj",
       "category": "productivity",
       "homepage": "https://github.com/muloka/claude-plugins/tree/main/plugins/feature-dev-jj"
+    },
+    {
+      "name": "workspace-jj",
+      "description": "Enables Claude Code worktree isolation for jj (Jujutsu) repositories using jj workspaces",
+      "author": {
+        "name": "muloka",
+        "email": "muloka@users.noreply.github.com"
+      },
+      "source": "./plugins/workspace-jj",
+      "category": "productivity",
+      "homepage": "https://github.com/muloka/claude-plugins/tree/main/plugins/workspace-jj"
     }
   ]
 }

--- a/plugins/workspace-jj/.claude-plugin/plugin.json
+++ b/plugins/workspace-jj/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "workspace-jj",
+  "description": "Enables Claude Code worktree isolation for jj (Jujutsu) repositories using jj workspaces",
+  "author": {
+    "name": "muloka",
+    "email": "muloka@users.noreply.github.com"
+  }
+}

--- a/plugins/workspace-jj/LICENSE
+++ b/plugins/workspace-jj/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/workspace-jj/README.md
+++ b/plugins/workspace-jj/README.md
@@ -1,0 +1,61 @@
+# Workspace Plugin (jj)
+
+Enables Claude Code's worktree isolation (`--worktree` flag and `isolation: "worktree"` for subagents) in jj (Jujutsu) repositories using jj workspaces.
+
+## Overview
+
+Claude Code uses git worktrees by default for isolated parallel sessions. This plugin replaces that with jj workspaces via `WorktreeCreate` and `WorktreeRemove` hooks, so `--worktree` works natively in jj repos.
+
+## How It Works
+
+- **WorktreeCreate**: Runs `jj workspace add` to create an isolated workspace at `.claude/worktrees/<name>/`
+- **WorktreeRemove**: Runs `jj workspace forget` and removes the directory on cleanup
+
+Workspaces share the same repository store, so they're lightweight and fast to create.
+
+## Installation
+
+```bash
+claude plugins add muloka/claude-plugins:workspace-jj
+```
+
+## Setup
+
+After installing, run the setup command in your jj project:
+
+```
+/workspace-setup
+```
+
+This configures the `WorktreeCreate` and `WorktreeRemove` hooks in your project's `.claude/settings.local.json`. Restart your Claude Code session after setup.
+
+**Why is this needed?** Claude Code currently doesn't pick up `WorktreeCreate`/`WorktreeRemove` hooks from plugins — they must be in project or user settings. The `/workspace-setup` command handles this for you.
+
+## Usage
+
+```bash
+# Start Claude in an isolated jj workspace
+claude --worktree feature-auth
+
+# Auto-generated name
+claude --worktree
+```
+
+Subagents can also use workspace isolation with `isolation: "worktree"` in their frontmatter.
+
+## Requirements
+
+- [jj (Jujutsu)](https://martinvonz.github.io/jj/) must be installed
+- [jq](https://jqlang.github.io/jq/) must be installed (for JSON parsing in hooks)
+
+## Cleanup
+
+Workspaces are cleaned up automatically when you exit a session and choose to remove the worktree. For manual cleanup of stale workspaces, use the `/clean_stale` command from the [commit-commands-jj](../commit-commands-jj) plugin.
+
+## Author
+
+[muloka](https://github.com/muloka)
+
+## Version
+
+1.0.0

--- a/plugins/workspace-jj/commands/workspace-setup.md
+++ b/plugins/workspace-jj/commands/workspace-setup.md
@@ -1,0 +1,49 @@
+---
+description: Configure jj workspace hooks for worktree isolation in the current project
+allowed-tools: Bash(cat:*), Bash(jq:*), Read, Write
+---
+
+## Your Task
+
+Configure the `WorktreeCreate` and `WorktreeRemove` hooks in the current project's `.claude/settings.local.json` so that `--worktree` uses jj workspaces instead of git worktrees.
+
+**Why this is needed:** Claude Code doesn't pick up `WorktreeCreate`/`WorktreeRemove` hooks from plugins — they must be in project or user settings.
+
+## Steps
+
+1. **Read the current settings** at `.claude/settings.local.json` (it may not exist yet, or may have existing content to preserve).
+
+2. **Merge the following hooks** into the settings JSON, preserving any existing keys:
+
+```json
+{
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/jj-worktree-create.sh"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/jj-worktree-remove.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**IMPORTANT:** `${CLAUDE_PLUGIN_ROOT}` must be resolved to the actual absolute path of this plugin's installed location. To find it, look for the directory containing this command file — it will be something like `~/.claude/plugins/cache/muloka-claude-plugins/workspace-jj/<hash>/`. Use that resolved path in the settings.
+
+3. **Write the updated settings** to `.claude/settings.local.json`.
+
+4. **Confirm** by showing the user what was written and remind them to restart their Claude Code session for the hooks to take effect.

--- a/plugins/workspace-jj/scripts/jj-worktree-create.sh
+++ b/plugins/workspace-jj/scripts/jj-worktree-create.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WorktreeCreate hook: Create a jj workspace for Claude Code worktree isolation
+# Input (stdin): JSON with "name" and "cwd" fields
+# Output (stdout): Absolute path to created worktree directory
+
+input=$(cat)
+name=$(echo "$input" | jq -r '.name')
+cwd=$(echo "$input" | jq -r '.cwd')
+
+DIR="$cwd/.claude/worktrees/$name"
+mkdir -p "$(dirname "$DIR")"
+
+# Create jj workspace at the directory, branching from the current working copy's parents
+# Use -R to operate on the repo at cwd, redirect jj output to stderr
+jj -R "$cwd" workspace add "$DIR" --name "worktree-$name" >&2
+
+# Print the absolute path for Claude Code
+echo "$DIR"

--- a/plugins/workspace-jj/scripts/jj-worktree-remove.sh
+++ b/plugins/workspace-jj/scripts/jj-worktree-remove.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WorktreeRemove hook: Remove a jj workspace created by WorktreeCreate
+# Input (stdin): JSON with "worktree_path" and "cwd" fields
+
+input=$(cat)
+worktree_path=$(echo "$input" | jq -r '.worktree_path')
+cwd=$(echo "$input" | jq -r '.cwd')
+
+# Extract workspace name from directory name
+name=$(basename "$worktree_path")
+
+# Forget the workspace in jj (stop tracking it)
+# Use -R to target the repo, ignore errors if workspace already forgotten
+jj -R "$cwd" workspace forget "worktree-$name" 2>/dev/null || true
+
+# Remove the worktree directory
+rm -rf "$worktree_path"


### PR DESCRIPTION
## Summary

- Adds new `workspace-jj` plugin that enables Claude Code's `--worktree` flag and `isolation: "worktree"` for subagents to use jj workspaces instead of git worktrees
- Includes `WorktreeCreate`/`WorktreeRemove` hook scripts that call `jj workspace add` and `jj workspace forget`
- Adds `/workspace-setup` command to configure hooks in project settings (needed because Claude Code doesn't pick up these hook events from plugin.json)
- Updates marketplace.json with the new plugin

## Test plan

- [ ] Install plugin: `claude plugins add muloka/claude-plugins:workspace-jj`
- [ ] Run `/workspace-setup` in a jj project
- [ ] Verify `.claude/settings.local.json` has WorktreeCreate/WorktreeRemove hooks
- [ ] Run `claude --worktree test-name` and verify `jj workspace list` shows the workspace
- [ ] Exit session and verify cleanup removes the workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)