### PR TITLE
Copy workspace scripts to stable project path in /workspace-setup

### DIFF
--- a/plugins/workspace-jj/commands/workspace-setup.md
+++ b/plugins/workspace-jj/commands/workspace-setup.md
@@ -1,6 +1,6 @@
 ---
 description: Configure jj workspace hooks for worktree isolation in the current project
-allowed-tools: Bash(cat:*), Bash(jq:*), Read, Write
+allowed-tools: Bash(cp:*), Bash(chmod:*), Bash(mkdir:*), Bash(cat:*), Bash(jq:*), Read, Write
 ---
 
 ## Your Task
@@ -11,39 +11,56 @@ Configure the `WorktreeCreate` and `WorktreeRemove` hooks in the current project
 
 ## Steps
 
-1. **Read the current settings** at `.claude/settings.local.json` (it may not exist yet, or may have existing content to preserve).
+1. **Find the plugin's installed scripts.** Look for the directory containing this command file — it will be something like `~/.claude/plugins/cache/muloka-claude-plugins/workspace-jj/<hash>/scripts/`. The scripts are:
+   - `jj-worktree-create.sh`
+   - `jj-worktree-remove.sh`
 
-2. **Merge the following hooks** into the settings JSON, preserving any existing keys:
+2. **Copy the scripts to a stable project location.** Copy both scripts to `.claude/scripts/` in the project root. This avoids pointing hooks at the plugin cache (which changes on every plugin update).
 
-```json
-{
-  "hooks": {
-    "WorktreeCreate": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/jj-worktree-create.sh"
-          }
-        ]
-      }
-    ],
-    "WorktreeRemove": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/jj-worktree-remove.sh"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
+   ```bash
+   mkdir -p .claude/scripts
+   cp <plugin-scripts-dir>/jj-worktree-create.sh .claude/scripts/
+   cp <plugin-scripts-dir>/jj-worktree-remove.sh .claude/scripts/
+   chmod +x .claude/scripts/jj-worktree-create.sh .claude/scripts/jj-worktree-remove.sh
+   ```
 
-**IMPORTANT:** `${CLAUDE_PLUGIN_ROOT}` must be resolved to the actual absolute path of this plugin's installed location. To find it, look for the directory containing this command file — it will be something like `~/.claude/plugins/cache/muloka-claude-plugins/workspace-jj/<hash>/`. Use that resolved path in the settings.
+3. **Read the current settings** at `.claude/settings.local.json` (it may not exist yet, or may have existing content to preserve).
 
-3. **Write the updated settings** to `.claude/settings.local.json`.
+4. **Merge the following hooks** into the settings JSON, preserving any existing keys. Use the **absolute path** to the project's `.claude/scripts/` directory:
 
-4. **Confirm** by showing the user what was written and remind them to restart their Claude Code session for the hooks to take effect.
+   ```json
+   {
+     "hooks": {
+       "WorktreeCreate": [
+         {
+           "hooks": [
+             {
+               "type": "command",
+               "command": "<project-root>/.claude/scripts/jj-worktree-create.sh"
+             }
+           ]
+         }
+       ],
+       "WorktreeRemove": [
+         {
+           "hooks": [
+             {
+               "type": "command",
+               "command": "<project-root>/.claude/scripts/jj-worktree-remove.sh"
+             }
+           ]
+         }
+       ]
+     }
+   }
+   ```
+
+   Replace `<project-root>` with the actual absolute path to the project root.
+
+5. **Write the updated settings** to `.claude/settings.local.json`.
+
+6. **Confirm** by showing the user:
+   - The scripts copied to `.claude/scripts/`
+   - The hooks configured in `.claude/settings.local.json`
+   - Remind them to restart their Claude Code session for the hooks to take effect
+   - Suggest adding `.claude/scripts/` to `.gitignore` if they don't want to track the scripts in version control


### PR DESCRIPTION
## Summary

- `/workspace-setup` now copies hook scripts to `.claude/scripts/` in the project instead of pointing at the plugin cache path
- Hooks survive plugin updates without needing to re-run setup
- Re-running `/workspace-setup` refreshes the scripts from the latest plugin version

## Test plan

- [x] Run `/workspace-setup` — scripts copied to `.claude/scripts/`, hooks updated
- [x] `claude --worktree test-name` creates a jj workspace successfully
- [x] `jj workspace list` shows the workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)