### PR TITLE
Add project-setup-jj plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,12 +1,23 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "muloka-claude-plugins",
-  "description": "jj (Jujutsu) plugins for Claude Code — commit workflows, code review, PR review, feature development, and workspace isolation",
+  "description": "jj (Jujutsu) plugins for Claude Code — project setup, commit workflows, code review, PR review, feature development, and workspace isolation",
   "owner": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"
   },
   "plugins": [
+    {
+      "name": "project-setup-jj",
+      "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
+      "author": {
+        "name": "muloka",
+        "email": "muloka@users.noreply.github.com"
+      },
+      "source": "./plugins/project-setup-jj",
+      "category": "productivity",
+      "homepage": "https://github.com/muloka/claude-plugins/tree/main/plugins/project-setup-jj"
+    },
     {
       "name": "commit-commands-jj",
       "description": "Commands for jj (Jujutsu) commit workflows including commit, push, and PR creation",

--- a/docs/plans/project-setup-jj.md
+++ b/docs/plans/project-setup-jj.md
@@ -1,0 +1,174 @@
+# Plan: `project-setup-jj` Plugin
+
+## Context
+
+When starting a new Claude Code project that uses jj (Jujutsu), there's no automated way to bootstrap jj workflow enforcement. The existing plugins (commit-commands-jj, workspace-jj, etc.) provide commands and git-blocking hooks, but nothing that:
+- Shows jj context when a session starts
+- Configures hookify rules for workflow reminders
+- Sets up CLAUDE.md with jj instructions
+- Pre-configures permissions for jj commands
+
+This plugin adds a `/project-setup` command that does all of the above in one step, following the established pattern of `/workspace-setup`.
+
+## Implementation Workflow (jj)
+
+Before writing any code, follow the jj workflow:
+
+```bash
+jj new                                        # start a fresh change
+jj describe -m "Add project-setup-jj plugin"  # set intent upfront
+# ... do all the implementation work ...
+jj diff                                       # review before finalizing
+# then use /commit-push-pr to finalize + open PR
+```
+
+This plan itself should be implemented following this pattern.
+
+---
+
+## New Plugin: `project-setup-jj`
+
+### File Structure
+
+```
+plugins/project-setup-jj/
+├── .claude-plugin/
+│   └── plugin.json
+├── commands/
+│   └── project-setup.md
+├── scripts/
+│   ├── block-raw-git.sh          # copied from commit-commands-jj
+│   └── jj-session-start.sh       # NEW: SessionStart hook
+├── templates/
+│   ├── CLAUDE.md.template         # jj workflow instructions
+│   ├── hookify.warn-raw-git.local.md
+│   ├── hookify.require-jj-workflow.local.md
+│   └── hookify.warn-git-internals.local.md
+├── README.md
+└── LICENSE
+```
+
+### What `/project-setup` Does (6 Steps)
+
+**Step 1: Detect context**
+- Verify jj repo (`jj root`)
+- Locate plugin's scripts/templates directory (relative to command file)
+- Ensure `.claude/` and `.claude/scripts/` exist in project root
+
+**Step 2: Copy SessionStart hook script**
+- Copy `jj-session-start.sh` → project's `.claude/scripts/`
+- `chmod +x`
+
+**Step 3: Update `.claude/settings.local.json`**
+- Deep-merge using `jq` (same approach as workspace-setup)
+- Add SessionStart hook pointing to `.claude/scripts/jj-session-start.sh`
+- Add permissions: allow jj commands + gh CLI, deny raw git
+- Deduplicate entries, preserve existing config
+
+**Step 4: Create hookify rules**
+- Copy 3 template `.local.md` files → project's `.claude/`
+- Skip if identical file already exists
+
+**Step 5: Create/update CLAUDE.md**
+- If no CLAUDE.md exists: create from template
+- If CLAUDE.md exists with `<!-- jj-project-setup:start -->` marker: replace that section
+- If CLAUDE.md exists without marker: prepend jj section with markers, preserve existing content
+
+**Step 6: Confirm to user**
+- Show what was created/updated
+- Remind to restart Claude Code for SessionStart hook
+- Mention `/workspace-setup` as optional next step for worktree isolation
+
+---
+
+## Key Files to Create
+
+### 1. `plugin.json`
+
+Standard manifest with PreToolUse hook for block-raw-git (matching all other jj plugins).
+
+### 2. `jj-session-start.sh` (SessionStart hook)
+
+**Informational only** — does NOT auto-run `jj new`. Outputs:
+
+```
+== jj Session Context ==
+
+Current change:
+<output of jj log -r @ --no-graph>
+
+Working copy status:
+<output of jj status>
+
+== jj Workflow Reminder ==
+- Use `jj new` to start a fresh change before making edits
+- Use `jj describe -m "..."` to set intent on the current change
+- Use `jj diff` to review working copy changes
+- Never use raw git commands — use jj equivalents
+```
+
+Output format: JSON with `additionalContext` field, following the superpowers SessionStart hook pattern (`escape_for_json()` for proper escaping).
+
+If not in a jj repo (`jj root` fails), exits silently.
+
+### 3. Hookify Rules (3 templates)
+
+| Rule | Event | Action | Purpose |
+|------|-------|--------|---------|
+| `warn-raw-git` | bash | warn | Nudge message when git detected (actual blocking done by plugin hook) |
+| `require-jj-workflow` | stop | warn | Remind if `jj new` was never run during the session |
+| `warn-git-internals` | bash | warn | Catch `.git/` access, `git config`, `git rev-parse` |
+
+All rules use `action: warn` (not block) — the plugin-level `block-raw-git.sh` handles hard blocking. Hookify provides supplementary reminders.
+
+### 4. CLAUDE.md Template
+
+Contains:
+- jj-only VCS policy
+- 7-step workflow guide (status → new → describe → work → diff → commit → push)
+- Full Git→jj translation table (18 commands)
+- Key jj concepts (no staging, changes vs commits, bookmarks, undo)
+
+Wrapped in `<!-- jj-project-setup:start/end -->` markers for idempotent updates.
+
+### 5. Permissions Config
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(jj status*)", "Bash(jj diff*)", "Bash(jj log*)",
+      "Bash(jj new*)", "Bash(jj commit*)", "Bash(jj describe*)",
+      "Bash(jj bookmark*)", "Bash(jj git push*)", "Bash(jj git fetch*)",
+      "Bash(jj rebase*)", "Bash(jj squash*)", "Bash(jj edit*)",
+      "Bash(jj abandon*)", "Bash(jj undo*)", "Bash(jj op log*)",
+      "Bash(jj resolve*)", "Bash(jj root*)", "Bash(jj file*)",
+      "Bash(jj split*)", "Bash(jj config*)", "Bash(jj git remote*)",
+      "Bash(gh *)"
+    ],
+    "deny": ["Bash(git *)"]
+  }
+}
+```
+
+---
+
+## Reference Files
+
+- **Pattern to follow:** `plugins/workspace-jj/commands/workspace-setup.md` — command structure, frontmatter, step-by-step format
+- **SessionStart hook format:** Anthropic's superpowers plugin SessionStart hook — JSON output with `additionalContext`, `escape_for_json()`
+- **Block script:** `plugins/commit-commands-jj/scripts/block-raw-git.sh` — copy directly
+- **Hookify rules engine:** `hookify/core/rule_engine.py` — confirms `transcript` field only works in Stop events
+- **Real-world settings example:** `tokotoko/.claude/settings.local.json` — shows configured hook JSON structure
+
+## Verification
+
+1. Install the plugin, run `/project-setup` in a jj repo
+2. Verify `.claude/scripts/jj-session-start.sh` exists and is executable
+3. Verify `.claude/settings.local.json` has SessionStart hook + permissions
+4. Verify `.claude/hookify.*.local.md` files exist (3 rules)
+5. Verify CLAUDE.md has jj workflow section
+6. Restart Claude Code — confirm SessionStart shows jj context
+7. Try a raw `git status` — confirm it's blocked
+8. Run a session without `jj new`, then stop — confirm workflow reminder appears
+9. Re-run `/project-setup` — confirm idempotent (no duplicates)

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "project-setup-jj",
+  "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
+  "author": {
+    "name": "muloka",
+    "email": "muloka@users.noreply.github.com"
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/block-raw-git.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/project-setup-jj/LICENSE
+++ b/plugins/project-setup-jj/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/project-setup-jj/README.md
+++ b/plugins/project-setup-jj/README.md
@@ -1,0 +1,85 @@
+# Project Setup Plugin (jj)
+
+Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single `/project-setup` command.
+
+## Overview
+
+When starting a new Claude Code project that uses jj, there's no automated way to set up jj workflow enforcement. This plugin adds a `/project-setup` command that configures everything in one step:
+
+- **SessionStart hook** — shows current jj change, status, and workflow reminder when a session starts
+- **Hookify rules** — 3 warn-level rules that nudge toward jj best practices
+- **CLAUDE.md template** — jj policy, workflow guide, and Git→jj translation table
+- **Permissions** — pre-allows jj commands and gh CLI, denies raw git
+
+## Installation
+
+```bash
+claude plugins add muloka/claude-plugins:project-setup-jj
+```
+
+## Usage
+
+Run the setup command in any jj project:
+
+```
+/project-setup
+```
+
+This creates/updates the following in your project:
+
+| File | Purpose |
+|------|---------|
+| `.claude/scripts/jj-session-start.sh` | SessionStart hook showing jj context |
+| `.claude/settings.local.json` | Hook registration + jj permissions |
+| `.claude/hookify.warn-raw-git.local.md` | Warn when raw git commands detected |
+| `.claude/hookify.require-jj-workflow.local.md` | Remind to run `jj new` before edits |
+| `.claude/hookify.warn-git-internals.local.md` | Warn on `.git/` access or git plumbing |
+| `CLAUDE.md` | jj workflow instructions (created or updated) |
+
+**Restart Claude Code** after running `/project-setup` for the SessionStart hook to take effect.
+
+## What the SessionStart Hook Shows
+
+On every session start, you'll see:
+
+```
+== jj Session Context ==
+
+Current change:
+<current change details>
+
+Working copy status:
+<modified/added files>
+
+== jj Workflow Reminder ==
+- Use `jj new` to start a fresh change before making edits
+- Use `jj describe -m "..."` to set intent on the current change
+- Use `jj diff` to review working copy changes
+- Never use raw git commands — use jj equivalents
+```
+
+## Idempotent
+
+Running `/project-setup` multiple times is safe. It will:
+- Overwrite scripts with the latest version
+- Merge settings without duplicating entries
+- Update hookify rules to the latest version
+- Update the jj section in CLAUDE.md (via markers) without touching other content
+
+## Related Plugins
+
+- **[workspace-jj](../workspace-jj)** — worktree isolation via jj workspaces (optional, run `/workspace-setup` after)
+- **[commit-commands-jj](../commit-commands-jj)** — commit, push, and PR workflows for jj
+
+## Requirements
+
+- [jj (Jujutsu)](https://martinvonz.github.io/jj/) must be installed
+- [jq](https://jqlang.github.io/jq/) must be installed (for JSON merging)
+
+## Author
+
+[muloka](https://github.com/muloka)
+
+## Version
+
+1.0.0

--- a/plugins/project-setup-jj/commands/project-setup.md
+++ b/plugins/project-setup-jj/commands/project-setup.md
@@ -1,0 +1,114 @@
+---
+description: Bootstrap jj (Jujutsu) workflow enforcement for this project
+allowed-tools: Bash(jj:*), Bash(cp:*), Bash(chmod:*), Bash(mkdir:*), Bash(cat:*), Bash(jq:*), Bash(ls:*), Bash(dirname:*), Bash(realpath:*), Read, Write
+---
+
+## Your Task
+
+Bootstrap jj (Jujutsu) workflow enforcement for the current project. This sets up a SessionStart hook, hookify rules, permissions, and CLAUDE.md instructions so that every Claude Code session in this project uses jj properly.
+
+**CRITICAL: This is a jj (Jujutsu) plugin. You MUST NOT use ANY raw git commands — not even for context discovery. Always use jj equivalents. The only exceptions are `jj git` subcommands and `gh` CLI.**
+
+## Steps
+
+### Step 1: Detect context
+
+1. Verify this is a jj repo by running `jj root`. If it fails, tell the user this command requires a jj repository and stop.
+2. Find the plugin's templates/scripts directory. Look for the directory containing this command file — it will be something like `~/.claude/plugins/cache/muloka-claude-plugins/project-setup-jj/<hash>/`. The templates are in `templates/` and scripts in `scripts/` relative to the plugin root.
+3. Determine the project root using `jj root`.
+4. Ensure `.claude/` and `.claude/scripts/` directories exist in the project root:
+   ```bash
+   mkdir -p "$(jj root)/.claude/scripts"
+   ```
+
+### Step 2: Copy SessionStart hook script
+
+Copy `jj-session-start.sh` from the plugin's `scripts/` directory to the project's `.claude/scripts/`:
+
+```bash
+cp <plugin-scripts-dir>/jj-session-start.sh "$(jj root)/.claude/scripts/"
+chmod +x "$(jj root)/.claude/scripts/jj-session-start.sh"
+```
+
+### Step 3: Update `.claude/settings.local.json`
+
+Read the current `.claude/settings.local.json` (may not exist). Deep-merge the following configuration using `jq`, preserving all existing keys and deduplicating entries:
+
+**SessionStart hook:**
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "<project-root>/.claude/scripts/jj-session-start.sh",
+            "async": false
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Permissions:**
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(jj status*)", "Bash(jj diff*)", "Bash(jj log*)",
+      "Bash(jj new*)", "Bash(jj commit*)", "Bash(jj describe*)",
+      "Bash(jj bookmark*)", "Bash(jj git push*)", "Bash(jj git fetch*)",
+      "Bash(jj rebase*)", "Bash(jj squash*)", "Bash(jj edit*)",
+      "Bash(jj abandon*)", "Bash(jj undo*)", "Bash(jj op log*)",
+      "Bash(jj resolve*)", "Bash(jj root*)", "Bash(jj file*)",
+      "Bash(jj split*)", "Bash(jj config*)", "Bash(jj git remote*)",
+      "Bash(gh *)"
+    ],
+    "deny": ["Bash(git *)"]
+  }
+}
+```
+
+Replace `<project-root>` with the actual absolute path from `jj root`.
+
+**Merge strategy:** Use `jq` to deep-merge. For array fields (`allow`, `deny`, hook arrays), concatenate and deduplicate. For object fields, merge recursively. Preserve any existing settings not related to jj.
+
+### Step 4: Create hookify rules
+
+Copy the 3 hookify rule templates from the plugin's `templates/` directory to `.claude/` in the project root:
+
+- `hookify.warn-raw-git.local.md`
+- `hookify.require-jj-workflow.local.md`
+- `hookify.warn-git-internals.local.md`
+
+For each file: if an identical file already exists, skip it. If a different version exists, overwrite it (the plugin version is canonical).
+
+### Step 5: Create or update CLAUDE.md
+
+Read the CLAUDE.md template from the plugin's `templates/CLAUDE.md.template`.
+
+Then handle three cases:
+
+1. **No CLAUDE.md exists:** Create it from the template.
+2. **CLAUDE.md exists with `<!-- jj-project-setup:start -->` marker:** Replace the section between `<!-- jj-project-setup:start -->` and `<!-- jj-project-setup:end -->` (inclusive) with the template content.
+3. **CLAUDE.md exists without the marker:** Prepend the template content followed by a blank line, preserving all existing content.
+
+The CLAUDE.md file is at the project root (from `jj root`).
+
+### Step 6: Confirm to user
+
+Show a summary of what was set up:
+
+- SessionStart hook script copied to `.claude/scripts/jj-session-start.sh`
+- Settings updated in `.claude/settings.local.json` (SessionStart hook + permissions)
+- Hookify rules created in `.claude/` (list the 3 files)
+- CLAUDE.md created/updated with jj workflow instructions
+
+Remind the user to:
+- **Restart Claude Code** for the SessionStart hook to take effect
+- Optionally run `/workspace-setup` if they want worktree isolation via jj workspaces
+- Optionally add `.claude/scripts/` and `.claude/*.local.md` to their ignore patterns if they don't want to track these in version control

--- a/plugins/project-setup-jj/scripts/block-raw-git.sh
+++ b/plugins/project-setup-jj/scripts/block-raw-git.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# PreToolUse hook: Block raw git commands in jj plugins
+# Allows: jj git *, gh *, and any non-git commands
+# Blocks: git * (bare git commands, not jj git subcommands)
+
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // ""')
+
+# Normalize: collapse newlines
+command_normalized=$(echo "$command" | tr '\n' ';')
+
+# Check for bare "git " commands (not preceded by "jj ")
+has_raw_git=false
+if echo "$command_normalized" | grep -qE '(^|[;&|]\s*)git\s'; then
+  if ! echo "$command_normalized" | grep -qE '(^|[;&|]\s*)jj\s+git\s'; then
+    has_raw_git=true
+  fi
+fi
+
+if [ "$has_raw_git" = true ]; then
+  cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "BLOCKED: Raw git commands are not allowed in jj plugins. Use jj equivalents instead: git log → jj log, git diff → jj diff, git status → jj status, git blame → jj file annotate, git remote → jj git remotes list, git push → jj git push. For GitHub operations, use gh CLI."
+  }
+}
+EOF
+  exit 0
+fi
+
+exit 0

--- a/plugins/project-setup-jj/scripts/jj-session-start.sh
+++ b/plugins/project-setup-jj/scripts/jj-session-start.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SessionStart hook: Show jj context and workflow reminder
+# Outputs JSON with additionalContext for Claude Code
+
+set -euo pipefail
+
+# Exit silently if not in a jj repo
+if ! jj root >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Gather jj context
+current_change=$(jj log -r @ --no-graph 2>/dev/null || echo "(unable to read current change)")
+working_status=$(jj status 2>/dev/null || echo "(unable to read status)")
+
+# Escape string for JSON embedding
+escape_for_json() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '%s' "$s"
+}
+
+context="== jj Session Context ==
+
+Current change:
+${current_change}
+
+Working copy status:
+${working_status}
+
+== jj Workflow Reminder ==
+- Use \`jj new\` to start a fresh change before making edits
+- Use \`jj describe -m \"...\"\` to set intent on the current change
+- Use \`jj diff\` to review working copy changes
+- Never use raw git commands — use jj equivalents"
+
+escaped_context=$(escape_for_json "$context")
+
+cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "${escaped_context}"
+  }
+}
+EOF
+
+exit 0

--- a/plugins/project-setup-jj/templates/CLAUDE.md.template
+++ b/plugins/project-setup-jj/templates/CLAUDE.md.template
@@ -1,0 +1,45 @@
+<!-- jj-project-setup:start -->
+# jj (Jujutsu) VCS Policy
+
+This project uses **jj (Jujutsu)** as its version control system. **Never use raw git commands.** Use jj equivalents instead. The only exceptions are `jj git` subcommands (e.g. `jj git push`, `jj git fetch`) and the `gh` CLI for GitHub operations.
+
+## Workflow
+
+1. **Check status:** `jj status`
+2. **Start a fresh change:** `jj new`
+3. **Set intent:** `jj describe -m "what you're doing"`
+4. **Make your changes** (edit files normally)
+5. **Review changes:** `jj diff`
+6. **Commit:** `jj commit -m "message"` (or let the change auto-commit)
+7. **Push:** `jj git push`
+
+## Git → jj Translation
+
+| Git | jj |
+|-----|-----|
+| `git status` | `jj status` |
+| `git diff` | `jj diff` |
+| `git log` | `jj log` |
+| `git add` | _(not needed — jj tracks all files automatically)_ |
+| `git commit -m "msg"` | `jj commit -m "msg"` |
+| `git commit --amend` | `jj describe -m "msg"` (amend description) or `jj squash` (fold into parent) |
+| `git push` | `jj git push` |
+| `git pull` / `git fetch` | `jj git fetch` |
+| `git checkout -b branch` | `jj new` + `jj bookmark create branch -r @` |
+| `git branch` | `jj bookmark list` |
+| `git branch -d name` | `jj bookmark delete name` |
+| `git merge` | `jj new branch1 branch2` (create merge commit) |
+| `git rebase` | `jj rebase -d destination` |
+| `git stash` | _(not needed — every change is automatically saved)_ |
+| `git blame file` | `jj file annotate file` |
+| `git remote -v` | `jj git remote list` |
+| `git rev-parse HEAD` | `jj log -r @ --no-graph -T commit_id` |
+| `git reset --hard` | `jj undo` or `jj restore` |
+
+## Key jj Concepts
+
+- **No staging area:** jj tracks all file changes automatically. No `git add` needed.
+- **Changes vs commits:** A "change" is a mutable working unit. It becomes a "commit" when you move past it with `jj new` or `jj commit`.
+- **Bookmarks (not branches):** jj uses "bookmarks" instead of git "branches". They point to changes.
+- **Undo anything:** `jj undo` reverts the last jj operation. `jj op log` shows operation history.
+<!-- jj-project-setup:end -->

--- a/plugins/project-setup-jj/templates/hookify.require-jj-workflow.local.md
+++ b/plugins/project-setup-jj/templates/hookify.require-jj-workflow.local.md
@@ -1,0 +1,21 @@
+---
+name: require-jj-workflow
+enabled: true
+event: stop
+action: warn
+conditions:
+  - field: transcript
+    operator: not_contains
+    pattern: jj new
+---
+
+**Reminder:** `jj new` was not detected in this session.
+
+Best practice is to start a fresh change with `jj new` before making edits. This keeps your work isolated and easy to undo.
+
+Workflow:
+1. `jj new` — start a fresh change
+2. `jj describe -m "..."` — set intent
+3. Make your changes
+4. `jj diff` — review
+5. `jj commit` or proceed to push

--- a/plugins/project-setup-jj/templates/hookify.warn-git-internals.local.md
+++ b/plugins/project-setup-jj/templates/hookify.warn-git-internals.local.md
@@ -1,0 +1,15 @@
+---
+name: warn-git-internals
+enabled: true
+event: bash
+action: warn
+pattern: (\.git/|\.git\b|git\s+config|git\s+rev-parse)
+---
+
+**Git internals access detected.** This project uses jj (Jujutsu).
+
+Avoid accessing `.git/` directly or using git plumbing commands. Use jj equivalents:
+- `git rev-parse HEAD` → `jj log -r @ --no-graph -T commit_id`
+- `git config` → `jj config list` / `jj config set`
+- `ls .git/` → not needed; use `jj root` to find the repo root
+- `git remote -v` → `jj git remote list`

--- a/plugins/project-setup-jj/templates/hookify.warn-raw-git.local.md
+++ b/plugins/project-setup-jj/templates/hookify.warn-raw-git.local.md
@@ -1,0 +1,19 @@
+---
+name: warn-raw-git
+enabled: true
+event: bash
+action: warn
+pattern: (^|[;&|]\s*)git\s
+---
+
+**Raw git command detected.** This project uses jj (Jujutsu) as its VCS.
+
+Use jj equivalents instead:
+- `git status` → `jj status`
+- `git diff` → `jj diff`
+- `git log` → `jj log`
+- `git add` / `git commit` → `jj commit` or `jj describe` + `jj new`
+- `git push` → `jj git push`
+- `git fetch` → `jj git fetch`
+
+The only allowed git commands are `jj git` subcommands and `gh` CLI.


### PR DESCRIPTION
## Summary

- Adds new `project-setup-jj` plugin that bootstraps jj (Jujutsu) workflow enforcement for any Claude Code project with a single `/project-setup` command
- Configures SessionStart hook (shows jj context + workflow reminder), hookify rules (3 warn-level rules), CLAUDE.md template (jj policy + Git→jj translation table), and permissions (allow jj/gh, deny raw git)
- Follows established patterns from `workspace-jj` and `commit-commands-jj` plugins

## What's included

| File | Purpose |
|------|---------|
| `plugin.json` | Plugin manifest with PreToolUse hook |
| `block-raw-git.sh` | Standard git-blocking hook (shared across jj plugins) |
| `jj-session-start.sh` | SessionStart hook — shows jj change, status, workflow reminder |
| 3 hookify templates | Warn on raw git, missing `jj new`, git internals access |
| `CLAUDE.md.template` | jj policy, 7-step workflow, 18-command Git→jj table |
| `project-setup.md` | `/project-setup` command — 6-step setup orchestration |
| `marketplace.json` | Updated with new plugin entry |

## Test plan

- [ ] Install plugin, run `/project-setup` in a jj repo
- [ ] Verify `.claude/scripts/jj-session-start.sh` exists and is executable
- [ ] Verify `.claude/settings.local.json` has SessionStart hook + permissions
- [ ] Verify `.claude/hookify.*.local.md` files exist (3 rules)
- [ ] Verify CLAUDE.md has jj workflow section with markers
- [ ] Restart Claude Code — confirm SessionStart shows jj context
- [ ] Re-run `/project-setup` — confirm idempotent (no duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)