### PR TITLE
Slim down CLAUDE.md template to policy-only

### DIFF
--- a/plugins/project-setup-jj/README.md
+++ b/plugins/project-setup-jj/README.md
@@ -8,7 +8,7 @@ When starting a new Claude Code project that uses jj, there's no automated way t
 
 - **SessionStart hook** — shows current jj change, status, and workflow reminder when a session starts
 - **Hookify rules** — 3 warn-level rules that nudge toward jj best practices
-- **CLAUDE.md template** — jj policy, workflow guide, and Git→jj translation table
+- **CLAUDE.md template** — slim jj VCS policy directive
 - **Permissions** — pre-allows jj commands and gh CLI, denies raw git
 
 ## Installation
@@ -34,7 +34,7 @@ This creates/updates the following in your project:
 | `.claude/hookify.warn-raw-git.local.md` | Warn when raw git commands detected |
 | `.claude/hookify.require-jj-workflow.local.md` | Remind to run `jj new` before edits |
 | `.claude/hookify.warn-git-internals.local.md` | Warn on `.git/` access or git plumbing |
-| `CLAUDE.md` | jj workflow instructions (created or updated) |
+| `CLAUDE.md` | jj VCS policy directive (created or updated) |
 
 **Restart Claude Code** after running `/project-setup` for the SessionStart hook to take effect.
 

--- a/plugins/project-setup-jj/commands/project-setup.md
+++ b/plugins/project-setup-jj/commands/project-setup.md
@@ -89,7 +89,7 @@ For each file: if an identical file already exists, skip it. If a different vers
 
 ### Step 5: Create or update CLAUDE.md
 
-Read the CLAUDE.md template from the plugin's `templates/CLAUDE.md.template`.
+Read the CLAUDE.md template from the plugin's `templates/CLAUDE.md.template`. The template is a slim policy directive (~5 lines) — not a full reference guide. It uses an `## VCS` heading (h2) so it fits naturally into any existing CLAUDE.md heading hierarchy.
 
 Then handle three cases:
 

--- a/plugins/project-setup-jj/templates/CLAUDE.md.template
+++ b/plugins/project-setup-jj/templates/CLAUDE.md.template
@@ -1,45 +1,5 @@
 <!-- jj-project-setup:start -->
-# jj (Jujutsu) VCS Policy
+## VCS — jj (Jujutsu)
 
-This project uses **jj (Jujutsu)** as its version control system. **Never use raw git commands.** Use jj equivalents instead. The only exceptions are `jj git` subcommands (e.g. `jj git push`, `jj git fetch`) and the `gh` CLI for GitHub operations.
-
-## Workflow
-
-1. **Check status:** `jj status`
-2. **Start a fresh change:** `jj new`
-3. **Set intent:** `jj describe -m "what you're doing"`
-4. **Make your changes** (edit files normally)
-5. **Review changes:** `jj diff`
-6. **Commit:** `jj commit -m "message"` (or let the change auto-commit)
-7. **Push:** `jj git push`
-
-## Git → jj Translation
-
-| Git | jj |
-|-----|-----|
-| `git status` | `jj status` |
-| `git diff` | `jj diff` |
-| `git log` | `jj log` |
-| `git add` | _(not needed — jj tracks all files automatically)_ |
-| `git commit -m "msg"` | `jj commit -m "msg"` |
-| `git commit --amend` | `jj describe -m "msg"` (amend description) or `jj squash` (fold into parent) |
-| `git push` | `jj git push` |
-| `git pull` / `git fetch` | `jj git fetch` |
-| `git checkout -b branch` | `jj new` + `jj bookmark create branch -r @` |
-| `git branch` | `jj bookmark list` |
-| `git branch -d name` | `jj bookmark delete name` |
-| `git merge` | `jj new branch1 branch2` (create merge commit) |
-| `git rebase` | `jj rebase -d destination` |
-| `git stash` | _(not needed — every change is automatically saved)_ |
-| `git blame file` | `jj file annotate file` |
-| `git remote -v` | `jj git remote list` |
-| `git rev-parse HEAD` | `jj log -r @ --no-graph -T commit_id` |
-| `git reset --hard` | `jj undo` or `jj restore` |
-
-## Key jj Concepts
-
-- **No staging area:** jj tracks all file changes automatically. No `git add` needed.
-- **Changes vs commits:** A "change" is a mutable working unit. It becomes a "commit" when you move past it with `jj new` or `jj commit`.
-- **Bookmarks (not branches):** jj uses "bookmarks" instead of git "branches". They point to changes.
-- **Undo anything:** `jj undo` reverts the last jj operation. `jj op log` shows operation history.
+This project uses **jj (Jujutsu)** as its VCS. Never use raw git commands. Use jj equivalents instead (e.g. `jj log`, `jj status`, `jj diff`). The only exceptions are `jj git` subcommands (e.g. `jj git push`) and the `gh` CLI for GitHub operations.
 <!-- jj-project-setup:end -->


### PR DESCRIPTION
## Summary

- Replaces the 45-line CLAUDE.md template (workflow steps, 18-row translation table, concepts section) with a 5-line policy-only directive
- Uses `## VCS` heading (h2) instead of `# jj VCS Policy` (h1) to fit naturally into existing CLAUDE.md hierarchy
- The removed content is redundant: SessionStart hook already shows workflow reminders, block-raw-git hook + hookify rules handle enforcement at runtime

## Test plan

- [ ] Re-run `/project-setup` on a project with existing markers — verify old section replaced with slim version
- [ ] Run `/project-setup` on a fresh project — verify clean 5-line section created

🤖 Generated with [Claude Code](https://claude.com/claude-code)