### PR TITLE
Skip require-jj-workflow warning in read-only sessions

### DIFF
--- a/plugins/project-setup-jj/templates/hookify.require-jj-workflow.local.md
+++ b/plugins/project-setup-jj/templates/hookify.require-jj-workflow.local.md
@@ -7,6 +7,9 @@ conditions:
   - field: transcript
     operator: not_contains
     pattern: jj new
+  - field: transcript
+    operator: regex_match
+    pattern: Edit|Write|NotebookEdit
 ---
 
 **Reminder:** `jj new` was not detected in this session.


### PR DESCRIPTION
## Summary

- Adds second condition to the `require-jj-workflow` hookify rule requiring file-modifying tools (`Edit|Write|NotebookEdit`) in the transcript
- Rule now only fires when edits happened but `jj new` wasn't run
- Silent in plan mode and other read-only sessions

## Test plan

- [ ] Plan-mode-only session, exit — no warning
- [ ] Session with edits but no `jj new`, exit — warning fires
- [ ] Session with `jj new` + edits, exit — no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)