### PR TITLE
Fix hookify imports for plugin install paths

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from typing import List, Dict, Any, Optional
 
 # Import from local module
-from hookify.core.config_loader import Rule, Condition
+from core.config_loader import Rule, Condition
 
 
 # Cache compiled regexes (max 128 patterns)
@@ -275,7 +275,7 @@ class RuleEngine:
 
 # For testing
 if __name__ == '__main__':
-    from hookify.core.config_loader import Condition, Rule
+    from core.config_loader import Condition, Rule
 
     # Test rule evaluation
     rule = Rule(

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -9,18 +9,14 @@ import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
+# Add plugin root to Python path for imports
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+if PLUGIN_ROOT and PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -9,22 +9,14 @@ import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
-# We need to add the parent of the plugin directory so Python can find "hookify" package
+# Add plugin root to Python path for imports
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    # Add the parent directory of the plugin
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-
-    # Also add PLUGIN_ROOT itself in case we have other scripts
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+if PLUGIN_ROOT and PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     # If imports fail, allow operation and log error
     error_msg = {"systemMessage": f"Hookify import error: {e}"}

--- a/plugins/hookify/hooks/stop.py
+++ b/plugins/hookify/hooks/stop.py
@@ -9,18 +9,14 @@ import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
+# Add plugin root to Python path for imports
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+if PLUGIN_ROOT and PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/userpromptsubmit.py
+++ b/plugins/hookify/hooks/userpromptsubmit.py
@@ -9,18 +9,14 @@ import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
+# Add plugin root to Python path for imports
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+if PLUGIN_ROOT and PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)


### PR DESCRIPTION
## Summary

- Reverts hookify imports from absolute (`from hookify.core...`) to relative (`from core...`)
- Fixes `No module named 'hookify'` error when installed via marketplace

## Problem

The upstream hookify `main` branch changed imports to `from hookify.core.config_loader`, which assumes the parent of `CLAUDE_PLUGIN_ROOT` contains a `hookify/` directory. This works in development but breaks when installed as a plugin, where the cache path is `.../hookify/0.1.0/` — the parent dir is `.../hookify/`, not a directory containing `hookify/`.

## Fix

Use relative imports (`from core...`) with just `PLUGIN_ROOT` on `sys.path`, which works regardless of install path structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)