### PR TITLE
Fix hookify event filter: always filter rules by event type

### DIFF
--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -216,12 +216,10 @@ def load_rules(event: Optional[str] = None) -> List[Rule]:
             if not rule:
                 continue
 
-            # Filter by event if specified
-            # Use `is not None` so event=None (unrecognized tools in
-            # PostToolUse) still filters out stop/bash/file rules
-            if event is not None:
-                if rule.event != 'all' and rule.event != event:
-                    continue
+            # Always filter by event type. When event=None (unrecognized
+            # tools like Read/Agent), only 'all' rules pass through.
+            if rule.event != 'all' and rule.event != event:
+                continue
 
             # Only include enabled rules
             if rule.enabled:


### PR DESCRIPTION
## Summary

Fixes the event filter in `config_loader.py` to **always** run, not just when `event` is truthy.

## Problem

PR #10 changed `if event:` to `if event is not None:`, but this still skips the filter when `event=None` (since `None is not None` is `False`). The `stop` rule `require-jj-workflow` was still firing on PreToolUse/PostToolUse for Read, Agent, Glob, etc.

## Fix

Remove the guard entirely — always run the filter:

```python
# Before (broken)
if event is not None:
    if rule.event != 'all' and rule.event != event:
        continue

# After (correct)
if rule.event != 'all' and rule.event != event:
    continue
```

When `event=None`: `rule.event != None` is `True` for all event-specific rules (`stop`, `bash`, `file`), so they're skipped. Only `event: 'all'` rules pass through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)