### PR TITLE
Fix require-jj-new hook: stop repeated permission prompts

### DIFF
--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -15,15 +15,6 @@
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/block-raw-git.sh"
           }
         ]
-      },
-      {
-        "matcher": "Edit|Write|NotebookEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/require-jj-new.sh"
-          }
-        ]
       }
     ]
   }

--- a/plugins/project-setup-jj/scripts/require-jj-new.sh
+++ b/plugins/project-setup-jj/scripts/require-jj-new.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# PreToolUse hook: Warn if editing into a non-empty jj change
-# Reminds to run `jj new` before making edits to keep changes isolated
+# PreToolUse hook: Advise Claude if editing into a non-empty jj change
+# Outputs an informational message — does NOT block or prompt the user
 
 # Only fire in jj repos
 jj root >/dev/null 2>&1 || exit 0
@@ -9,16 +9,7 @@ jj root >/dev/null 2>&1 || exit 0
 status=$(jj log -r @ --no-graph -T 'if(empty, "empty", "has-content")' 2>/dev/null)
 
 if [ "$status" = "has-content" ]; then
-  cat <<'EOF'
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PreToolUse",
-    "permissionDecision": "ask",
-    "permissionDecisionReason": "Current jj change already has content. Consider running `jj new` first to start a fresh change, keeping your work isolated and easy to undo.\n\nWorkflow:\n1. `jj new` — start fresh change\n2. `jj describe -m \"...\"` — set intent\n3. Make your edits"
-  }
-}
-EOF
-  exit 0
+  echo "Note: Current jj change already has content. Consider running \`jj new\` to start a fresh change if appropriate."
 fi
 
 exit 0


### PR DESCRIPTION
## Summary
- Make `require-jj-new.sh` informational-only instead of using `permissionDecision: "ask"`, which caused a prompt on every Edit/Write/NotebookEdit when the jj change had content
- Remove redundant Edit|Write|NotebookEdit hook from `plugin.json` — the `/project-setup` command already installs this hook per-project

Fixes the issue where users were prompted "Do you want to make this edit?" on every single edit, even after selecting "allow all edits during this session".

## Test plan
- [x] Verify hook outputs informational text only (no JSON permission decision)
- [ ] Restart Claude Code in a project with the updated script and confirm no repeated prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)