### PR TITLE
feat: make all jj output JSON by default for Claude Code

### DIFF
--- a/plugins/code-review-jj/commands/code-review.md
+++ b/plugins/code-review-jj/commands/code-review.md
@@ -12,7 +12,7 @@ disable-model-invocation: false
 ## Context
 
 - Open pull requests: !`gh pr list --state open --limit 5`
-- Current change: !`jj log -r @ --no-graph`
+- Current change (JSON): !`jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
 
 If the user provided a PR number/URL as $ARGUMENTS, use that. Otherwise, use the open PR list above.
 

--- a/plugins/commit-commands-jj/commands/abandon.md
+++ b/plugins/commit-commands-jj/commands/abandon.md
@@ -7,7 +7,7 @@ description: Discard a jj change (current or specified revision)
 
 ## Context
 
-- Current change: !`jj log -r @ --no-graph`
+- Current change (JSON): !`jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
 - Current diff stats: !`jj diff --stat`
 - Current status: !`jj status`
 
@@ -28,7 +28,7 @@ In jj, `jj abandon` discards a change entirely. Descendants are rebased onto its
    - If it does, warn the user that the change has uncommitted work that will be lost
 2. Run `jj abandon`
    - If the user specified a revision, run `jj abandon <revision>` instead
-3. Show the result: `jj log --limit 5` and `jj status`
+3. Show the result: `jj log --limit 5 --no-graph -T 'json(self) ++ "\n"'` and `jj status`
 4. Remind the user: run `/undo` if this was a mistake
 
 Notes:

--- a/plugins/commit-commands-jj/commands/clean_stale.md
+++ b/plugins/commit-commands-jj/commands/clean_stale.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(jj bookmark:*), Bash(jj workspace:*), Bash(jj git fetch:*)
 
 ## Context
 
-- Current bookmarks: !`jj bookmark list --all`
+- Current bookmarks (JSON): !`jj bookmark list --all -T 'json(self) ++ "\n"'`
 - Current workspaces: !`jj workspace list`
 
 ## Your Task
@@ -27,7 +27,7 @@ You need to execute the following commands to clean up stale local bookmarks and
 2. **List all bookmarks to find stale ones**
    Execute this command:
    ```bash
-   jj bookmark list --all
+   jj bookmark list --all -T 'json(self) ++ "\n"'
    ```
 
    Look for local bookmarks whose remote counterpart has been deleted. These appear as bookmarks that exist locally but have no corresponding remote tracking bookmark, or bookmarks marked as deleted on remote.

--- a/plugins/commit-commands-jj/commands/commit-push-pr.md
+++ b/plugins/commit-commands-jj/commands/commit-push-pr.md
@@ -8,8 +8,8 @@ description: Commit, push, and open a PR using jj
 ## Context
 
 - Current jj status: !`jj status`
-- Current jj diff (working copy changes): !`jj diff`
-- Current change: !`jj log -r @ --no-graph`
+- Changed files (JSON): !`jj diff -T '"{ \"path\": " ++ self.path().display().escape_json() ++ ", \"status\": " ++ self.status().escape_json() ++ " }\n"'`
+- Current change (JSON): !`jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
 - Bookmarks on current change: !`jj log -r @ --no-graph -T 'bookmarks'`
 
 ## Your task
@@ -17,7 +17,7 @@ description: Commit, push, and open a PR using jj
 Based on the above changes:
 
 1. `jj commit -m "<msg>"` — finalize the working copy with an appropriate description
-2. Check if building on trunk: `jj log -r '@- & trunk()' --no-graph` — if this returns a result, the change is directly on trunk and needs a bookmark
+2. Check if building on trunk: `jj log -r '@- & trunk()' --no-graph -T 'json(self) ++ "\n"'` — if this returns a result, the change is directly on trunk and needs a bookmark
 3. Check if `@-` already has a bookmark: `jj log -r @- --no-graph -T 'bookmarks'`
 4. If no bookmark exists on `@-`: `jj bookmark create <descriptive-name> -r @-` (use a short kebab-case name derived from the commit message)
 5. Push: `jj git push --bookmark <name> --allow-new`

--- a/plugins/commit-commands-jj/commands/commit.md
+++ b/plugins/commit-commands-jj/commands/commit.md
@@ -8,9 +8,9 @@ description: Finalize the current jj change with a description
 ## Context
 
 - Current jj status: !`jj status`
-- Current jj diff (working copy changes): !`jj diff`
-- Current change: !`jj log -r @ --no-graph`
-- Recent changes: !`jj log --limit 10`
+- Changed files (JSON): !`jj diff -T '"{ \"path\": " ++ self.path().display().escape_json() ++ ", \"status\": " ++ self.status().escape_json() ++ " }\n"'`
+- Current change (JSON): !`jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
+- Recent changes (JSON): !`jj log --limit 10 --no-graph -T 'json(self) ++ "\n"'`
 
 ## Git → jj translation
 

--- a/plugins/commit-commands-jj/commands/describe.md
+++ b/plugins/commit-commands-jj/commands/describe.md
@@ -8,9 +8,9 @@ description: Set or update the description of the current jj change
 ## Context
 
 - Current jj status: !`jj status`
-- Current jj diff (working copy changes): !`jj diff`
-- Current change: !`jj log -r @ --no-graph`
-- Recent changes: !`jj log --limit 10`
+- Changed files (JSON): !`jj diff -T '"{ \"path\": " ++ self.path().display().escape_json() ++ ", \"status\": " ++ self.status().escape_json() ++ " }\n"'`
+- Current change (JSON): !`jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
+- Recent changes (JSON): !`jj log --limit 10 --no-graph -T 'json(self) ++ "\n"'`
 
 ## Git → jj translation
 

--- a/plugins/commit-commands-jj/commands/edit.md
+++ b/plugins/commit-commands-jj/commands/edit.md
@@ -7,8 +7,8 @@ description: Edit an earlier jj change by moving the working copy to it
 
 ## Context
 
-- Current change: !`jj log -r @ --no-graph`
-- Recent changes: !`jj log --limit 15`
+- Current change (JSON): !`jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
+- Recent changes (JSON): !`jj log --limit 15 --no-graph -T 'json(self) ++ "\n"'`
 - Current status: !`jj status`
 
 ## Git → jj translation

--- a/plugins/commit-commands-jj/commands/new.md
+++ b/plugins/commit-commands-jj/commands/new.md
@@ -7,8 +7,8 @@ description: Start a new jj change on top of the current one (or a specified rev
 
 ## Context
 
-- Current change: !`jj log -r @ --no-graph`
-- Recent changes: !`jj log --limit 10`
+- Current change (JSON): !`jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
+- Recent changes (JSON): !`jj log --limit 10 --no-graph -T 'json(self) ++ "\n"'`
 - Current status: !`jj status`
 
 ## Git → jj translation
@@ -27,7 +27,7 @@ In jj, `jj new` creates a new empty change on top of the current working copy ch
 1. Run `jj new` to create a new empty change on top of the current one
    - If the user specifies a target revision, run `jj new <revision>` instead
 2. If the user stated what they intend to work on, describe the new change: `jj describe -m "<intent>"`
-3. Confirm the new change with `jj log -r @ --no-graph`
+3. Confirm the new change with `jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
 
 Notes:
 - `jj new` does NOT require the current change to be committed first — jj auto-snapshots the working copy

--- a/plugins/commit-commands-jj/commands/squash.md
+++ b/plugins/commit-commands-jj/commands/squash.md
@@ -7,9 +7,9 @@ description: Squash the current jj change into its parent
 
 ## Context
 
-- Current change: !`jj log -r @ --no-graph`
-- Parent change: !`jj log -r @- --no-graph`
-- Current diff: !`jj diff`
+- Current change (JSON): !`jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
+- Parent change (JSON): !`jj log -r @- --no-graph -T 'json(self) ++ "\n"'`
+- Changed files (JSON): !`jj diff -T '"{ \"path\": " ++ self.path().display().escape_json() ++ ", \"status\": " ++ self.status().escape_json() ++ " }\n"'`
 - Current status: !`jj status`
 
 ## Git → jj translation
@@ -29,9 +29,9 @@ In jj, `jj squash` moves all changes from the current change into its parent and
    - If the current change is empty (no diff), report "nothing to squash" and stop
 2. Run `jj squash`
    - If the user specified a target revision, run `jj squash --into <rev>` instead
-3. Review the combined description on the parent change: `jj log -r @ --no-graph`
+3. Review the combined description on the parent change: `jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
    - If the combined description looks awkward (e.g., duplicated text or concatenated fragments), clean it up with `jj describe -m "<cleaned-up-msg>"`
-4. Show the result: `jj log --limit 5`
+4. Show the result: `jj log --limit 5 --no-graph -T 'json(self) ++ "\n"'`
 
 Notes:
 - After squashing, the working copy moves to the (now-combined) parent change

--- a/plugins/commit-commands-jj/commands/sync.md
+++ b/plugins/commit-commands-jj/commands/sync.md
@@ -7,9 +7,9 @@ description: Fetch from remote and rebase the current change onto trunk
 
 ## Context
 
-- Current change: !`jj log -r @ --no-graph`
+- Current change (JSON): !`jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
 - Current status: !`jj status`
-- Trunk state: !`jj log -r 'trunk()' --no-graph --limit 1`
+- Trunk state (JSON): !`jj log -r 'trunk()' --no-graph --limit 1 -T 'json(self) ++ "\n"'`
 
 ## Git → jj translation
 
@@ -27,10 +27,10 @@ Sync fetches the latest remote state and rebases your current work onto trunk. T
 1. Fetch from the remote: `jj git fetch`
 2. Rebase onto trunk: `jj rebase -d main@origin`
    - If that fails (e.g., remote is not named `origin` or branch is not `main`), fall back to `jj rebase -d trunk()`
-3. Check for conflicts: `jj log -r 'conflicts()'`
+3. Check for conflicts: `jj log -r 'conflicts()' --no-graph -T 'json(self) ++ "\n"'`
    - If conflicts exist, report them clearly so the user can resolve them
    - If no conflicts, report success
-4. Show the final state: `jj log --limit 10`
+4. Show the final state: `jj log --limit 10 --no-graph -T 'json(self) ++ "\n"'`
 
 Notes:
 - `jj git fetch` auto-prunes deleted remote tracking refs

--- a/plugins/commit-commands-jj/commands/undo.md
+++ b/plugins/commit-commands-jj/commands/undo.md
@@ -7,8 +7,8 @@ description: Undo the last jj operation
 
 ## Context
 
-- Recent operations: !`jj op log --limit 5`
-- Current change: !`jj log -r @ --no-graph`
+- Recent operations (JSON): !`jj op log --limit 5 --no-graph -T 'json(self) ++ "\n"'`
+- Current change (JSON): !`jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
 - Current status: !`jj status`
 
 ## Git → jj translation
@@ -26,7 +26,7 @@ In jj, every operation is recorded in the operation log, and `jj undo` reverses 
 
 1. Review the operation log (shown in context above) to identify the last operation
 2. Run `jj undo`
-3. Confirm the result with `jj status` and `jj log --limit 5`
+3. Confirm the result with `jj status` and `jj log --limit 5 --no-graph -T 'json(self) ++ "\n"'`
 4. Report what was undone (describe the operation that was reversed)
 
 Notes:

--- a/plugins/pr-review-toolkit-jj/commands/review-pr.md
+++ b/plugins/pr-review-toolkit-jj/commands/review-pr.md
@@ -9,8 +9,8 @@ allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
 ## Context
 
 - Current jj status: !`jj status`
-- Changed files: !`jj diff --summary`
-- Current change: !`jj log -r @ --no-graph`
+- Changed files (JSON): !`jj diff -T '"{ \"path\": " ++ self.path().display().escape_json() ++ ", \"status\": " ++ self.status().escape_json() ++ " }\n"'`
+- Current change (JSON): !`jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
 - Open PRs: !`gh pr list --state open --limit 5`
 
 # Comprehensive PR Review
@@ -37,7 +37,7 @@ Run a comprehensive pull request review using multiple specialized agents, each 
    - **all** - Run all applicable reviews (default)
 
 3. **Identify Changed Files**
-   - Run `jj diff --summary` to see modified files
+   - Run `jj diff -T '"{ \"path\": " ++ self.path().display().escape_json() ++ ", \"status\": " ++ self.status().escape_json() ++ " }\n"'` to see modified files as JSON
    - Check if PR already exists: `gh pr view`
    - Identify file types and what reviews apply
 

--- a/plugins/project-setup-jj/scripts/jj-session-start.sh
+++ b/plugins/project-setup-jj/scripts/jj-session-start.sh
@@ -10,7 +10,7 @@ if ! jj root >/dev/null 2>&1; then
 fi
 
 # Gather jj context
-current_change=$(jj log -r @ --no-graph 2>/dev/null || echo "(unable to read current change)")
+current_change=$(jj log -r @ --no-graph -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read current change)")
 working_status=$(jj status 2>/dev/null || echo "(unable to read status)")
 
 # Escape string for JSON embedding


### PR DESCRIPTION
## Summary

- Convert all jj output commands across 6 plugins to use structured JSON templates (`json(self)`, `.escape_json()`) instead of human-readable text
- `jj log`, `jj bookmark list`, `jj op log` use `-T 'json(self) ++ "\n"'` for native JSON serialization
- `jj diff` uses a hand-rolled JSON template (path + status) since `TreeDiffEntry` doesn't implement `Serialize`
- Commands without template support (`jj status`) and visual output (`jj diff --stat`) are left unchanged

## Files changed (13)

- `project-setup-jj/scripts/jj-session-start.sh`
- `commit-commands-jj/commands/{new,commit,commit-push-pr,describe,sync,squash,edit,abandon,undo,clean_stale}.md`
- `code-review-jj/commands/code-review.md`
- `pr-review-toolkit-jj/commands/review-pr.md`

## Test plan

- [x] All 4 JSON templates produce valid JSON (verified with `python3 -m json.tool`)
- [x] Session-start hook runs correctly with JSON output embedded
- [x] Spec reviewer confirmed all 13 files match specification
- [x] Requires jj >= 0.31.0 (current: 0.38.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)