### PR TITLE
fix: replace shell param substitution in command contexts

### DIFF
--- a/plugins/commit-commands-jj/commands/evolog.md
+++ b/plugins/commit-commands-jj/commands/evolog.md
@@ -7,7 +7,7 @@ description: Show how a jj change has evolved over time
 
 ## Context
 
-- Evolution log (JSON): !`jj evolog -r ${1:-@} --no-graph -T 'json(self) ++ "\n"'`
+- Evolution log (JSON): !`jj evolog -r @ --no-graph -T 'json(self) ++ "\n"'`
 - Current change (JSON): !`jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
 
 ## Git → jj translation
@@ -20,9 +20,10 @@ description: Show how a jj change has evolved over time
 
 Show the evolution history of a change (default: `@`). In jj, every modification to a change (rebase, describe, squash, conflict resolution) creates a new version. `jj evolog` shows all versions.
 
-1. Present the evolution entries from context above in chronological order
-2. For each entry, highlight: what changed (description update, rebase, content change), when, and by which operation
-3. Summarize the change's journey (e.g., "created → described → rebased onto main → squashed fixup")
+1. If an argument was provided, run `jj evolog -r <arg> --no-graph -T 'json(self) ++ "\n"'` for that revision instead
+2. Present the evolution entries in chronological order
+3. For each entry, highlight: what changed (description update, rebase, content change), when, and by which operation
+4. Summarize the change's journey (e.g., "created → described → rebased onto main → squashed fixup")
 
 Notes:
 - This is jj's equivalent of per-commit reflog — it shows the full history of a single change

--- a/plugins/commit-commands-jj/commands/op-show.md
+++ b/plugins/commit-commands-jj/commands/op-show.md
@@ -20,7 +20,7 @@ description: Inspect a single jj operation with JSON output
 
 Inspect a specific operation from the operation log. If no operation ID is given, show the most recent operation.
 
-1. If an operation ID was provided as an argument, run `jj op show ${1} -T 'json(self) ++ "\n"'`
+1. If an operation ID was provided as an argument, run `jj op show <arg> -T 'json(self) ++ "\n"'`
 2. If no argument, use the most recent operation from the context above
 3. Present the operation details: ID, timestamp, user, description, and what changes it made
 4. If the user wants to understand the impact, suggest `jj op diff --from <prev-op> --to <op>`

--- a/plugins/commit-commands-jj/commands/show.md
+++ b/plugins/commit-commands-jj/commands/show.md
@@ -7,7 +7,7 @@ description: Inspect a single jj revision with JSON output
 
 ## Context
 
-- Revision metadata (JSON): !`jj show -r ${1:-@} --no-graph -T 'json(self) ++ "\n"' -s`
+- Revision metadata (JSON): !`jj show -r @ --no-graph -T 'json(self) ++ "\n"' -s`
 
 ## Git → jj translation
 
@@ -20,9 +20,10 @@ description: Inspect a single jj revision with JSON output
 
 Show a summary of the specified revision (default: `@`).
 
-1. Present the revision metadata from context above: change ID, commit ID, author, description, and parent(s)
-2. Show the file-level summary (added/modified/deleted files)
-3. If the user wants the full diff, run `jj diff -r ${1:-@}`
+1. If an argument was provided, run `jj show -r <arg> --no-graph -T 'json(self) ++ "\n"' -s` for that revision instead
+2. Present the revision metadata: change ID, commit ID, author, description, and parent(s)
+3. Show the file-level summary (added/modified/deleted files)
+4. If the user wants the full diff, run `jj diff -r <rev>`
 
 Notes:
 - `jj show` combines commit metadata + diff in one command


### PR DESCRIPTION
## Summary

- Replace `${1:-@}` with static `@` in `!` backtick context sections for `/show`, `/evolog`, and `/op-show` commands
- Claude Code's `!` backtick execution doesn't support shell parameter substitution
- Commands now default to `@` in context and handle arguments via task instructions + Bash tool

## Test plan

- [ ] `/show` loads without error
- [ ] `/evolog` loads without error
- [ ] `/op-show` loads without error
- [ ] `/show <rev>` still works via task step that runs the command with the argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)