### PR TITLE
fix: remove unsupported --no-graph from jj show command

### DIFF
--- a/plugins/commit-commands-jj/commands/show.md
+++ b/plugins/commit-commands-jj/commands/show.md
@@ -7,7 +7,7 @@ description: Inspect a single jj revision with JSON output
 
 ## Context
 
-- Revision metadata (JSON): !`jj show -r @ --no-graph -T 'json(self) ++ "\n"' -s`
+- Revision metadata (JSON): !`jj show -r @ -T 'json(self) ++ "\n"' -s`
 
 ## Git → jj translation
 
@@ -20,7 +20,7 @@ description: Inspect a single jj revision with JSON output
 
 Show a summary of the specified revision (default: `@`).
 
-1. If an argument was provided, run `jj show -r <arg> --no-graph -T 'json(self) ++ "\n"' -s` for that revision instead
+1. If an argument was provided, run `jj show -r <arg> -T 'json(self) ++ "\n"' -s` for that revision instead
 2. Present the revision metadata: change ID, commit ID, author, description, and parent(s)
 3. Show the file-level summary (added/modified/deleted files)
 4. If the user wants the full diff, run `jj diff -r <rev>`


### PR DESCRIPTION
## Summary

- Remove `--no-graph` flag from `/show` command context and task instructions
- `jj show` doesn't support `--no-graph` (it always shows a single revision)
- `jj evolog` and `jj op show` support it — those are unchanged

## Test plan

- [ ] `/show` loads and executes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)