### PR TITLE
feat: enrich diff templates with line counts and bytes delta

### DIFF
--- a/plugins/commit-commands-jj/commands/commit.md
+++ b/plugins/commit-commands-jj/commands/commit.md
@@ -9,6 +9,7 @@ description: Finalize the current jj change with a description
 
 - Current jj status: !`jj status`
 - Changed files (JSON): !`jj diff -T '"{ \"path\": " ++ self.path().display().escape_json() ++ ", \"status\": " ++ self.status().escape_json() ++ " }\n"'`
+- Change stats (JSON): !`jj log -r @ --no-graph -T 'self.diff().stat().files().map(|entry| "{ \"path\": " ++ entry.path().display().escape_json() ++ ", \"lines_added\": " ++ entry.lines_added() ++ ", \"lines_removed\": " ++ entry.lines_removed() ++ ", \"bytes_delta\": " ++ entry.bytes_delta() ++ " }\n")'`
 - Current change (JSON): !`jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
 - Recent changes (JSON): !`jj log --limit 10 --no-graph -T 'json(self) ++ "\n"'`
 

--- a/plugins/commit-commands-jj/commands/describe.md
+++ b/plugins/commit-commands-jj/commands/describe.md
@@ -9,6 +9,7 @@ description: Set or update the description of the current jj change
 
 - Current jj status: !`jj status`
 - Changed files (JSON): !`jj diff -T '"{ \"path\": " ++ self.path().display().escape_json() ++ ", \"status\": " ++ self.status().escape_json() ++ " }\n"'`
+- Change stats (JSON): !`jj log -r @ --no-graph -T 'self.diff().stat().files().map(|entry| "{ \"path\": " ++ entry.path().display().escape_json() ++ ", \"lines_added\": " ++ entry.lines_added() ++ ", \"lines_removed\": " ++ entry.lines_removed() ++ ", \"bytes_delta\": " ++ entry.bytes_delta() ++ " }\n")'`
 - Current change (JSON): !`jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
 - Recent changes (JSON): !`jj log --limit 10 --no-graph -T 'json(self) ++ "\n"'`
 

--- a/plugins/commit-commands-jj/commands/squash.md
+++ b/plugins/commit-commands-jj/commands/squash.md
@@ -10,6 +10,7 @@ description: Squash the current jj change into its parent
 - Current change (JSON): !`jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
 - Parent change (JSON): !`jj log -r @- --no-graph -T 'json(self) ++ "\n"'`
 - Changed files (JSON): !`jj diff -T '"{ \"path\": " ++ self.path().display().escape_json() ++ ", \"status\": " ++ self.status().escape_json() ++ " }\n"'`
+- Change stats (JSON): !`jj log -r @ --no-graph -T 'self.diff().stat().files().map(|entry| "{ \"path\": " ++ entry.path().display().escape_json() ++ ", \"lines_added\": " ++ entry.lines_added() ++ ", \"lines_removed\": " ++ entry.lines_removed() ++ ", \"bytes_delta\": " ++ entry.bytes_delta() ++ " }\n")'`
 - Current status: !`jj status`
 
 ## Git → jj translation

--- a/plugins/pr-review-toolkit-jj/commands/review-pr.md
+++ b/plugins/pr-review-toolkit-jj/commands/review-pr.md
@@ -10,6 +10,7 @@ allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
 
 - Current jj status: !`jj status`
 - Changed files (JSON): !`jj diff -T '"{ \"path\": " ++ self.path().display().escape_json() ++ ", \"status\": " ++ self.status().escape_json() ++ " }\n"'`
+- Change stats (JSON): !`jj log -r @ --no-graph -T 'self.diff().stat().files().map(|entry| "{ \"path\": " ++ entry.path().display().escape_json() ++ ", \"lines_added\": " ++ entry.lines_added() ++ ", \"lines_removed\": " ++ entry.lines_removed() ++ ", \"bytes_delta\": " ++ entry.bytes_delta() ++ " }\n")'`
 - Current change (JSON): !`jj log -r @ --no-graph -T 'json(self) ++ "\n"'`
 - Open PRs: !`gh pr list --state open --limit 5`
 


### PR DESCRIPTION
## Summary

- Add per-file `lines_added`, `lines_removed`, and `bytes_delta` to diff context in `/commit`, `/describe`, `/squash`, and `/review-pr` commands
- Uses `self.diff().stat().files()` → `DiffStatEntry` template path (discovered during UAT)
- Existing path + status template retained alongside new stats line

## Why

Gives Claude Code immediate visibility into change magnitude per file without reading full diffs. Enables better commit descriptions ("3-line fix" vs "500-line rewrite") and smarter PR review prioritization.

## Test plan

- [ ] `/commit` context includes change stats with line counts
- [ ] `/describe` context includes change stats with line counts
- [ ] `/squash` context includes change stats with line counts
- [ ] `/review-pr` context includes change stats with line counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)