### PR TITLE
feat: add jj-aware statusline with setup/remove commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,15 @@
-<!-- jj-project-setup:start -->
+<!-- jj-project-setup:start hash:422ef786 -->
 ## VCS — jj (Jujutsu)
 
 This project uses **jj (Jujutsu)** as its VCS. Never use raw git commands. Use jj equivalents instead (e.g. `jj log`, `jj status`, `jj diff`). The only exceptions are `jj git` subcommands (e.g. `jj git push`) and the `gh` CLI for GitHub operations.
+
+### Superpowers overrides
+
+When superpowers skills reference git-based workflows, use these jj-native replacements:
+
+| Superpowers skill | Use instead | Why |
+|---|---|---|
+| `finishing-a-development-branch` | `/finish` | jj-native: bookmarks, `jj git push`, workspace cleanup |
 <!-- jj-project-setup:end -->
 
 # CLAUDE.md

--- a/plugins/project-setup-jj/commands/statusline-jj-remove.md
+++ b/plugins/project-setup-jj/commands/statusline-jj-remove.md
@@ -1,0 +1,37 @@
+---
+description: Remove jj statusline from this project
+allowed-tools: Bash(jj:*), Bash(rm:*), Bash(cat:*), Bash(jq:*), Read, Write
+---
+
+**CRITICAL: This is a jj (Jujutsu) plugin. You MUST NOT use ANY raw git commands — not even for context discovery. Always use jj equivalents. The only exceptions are `jj git` subcommands and `gh` CLI.**
+
+## Your Task
+
+Remove the jj statusline script and configuration from this project.
+
+### Step 1: Detect context
+
+1. Determine the project root using `jj root`. If it fails, tell the user this command requires a jj repository and stop.
+
+### Step 2: Remove statusline script
+
+```bash
+rm -f "$(jj root)/.claude/scripts/statusline-jj.sh"
+```
+
+### Step 3: Remove statusLine from settings
+
+Read `.claude/settings.local.json`. If it has a `statusLine` key, remove it using `jq`:
+
+```bash
+jq 'del(.statusLine)' .claude/settings.local.json > .claude/settings.local.json.tmp && mv .claude/settings.local.json.tmp .claude/settings.local.json
+```
+
+If no `statusLine` key exists, skip — nothing to remove.
+
+### Step 4: Confirm to user
+
+Show:
+- Statusline script removed (or was not present)
+- `statusLine` config removed from settings (or was not present)
+- **Restart Claude Code** for the change to take effect

--- a/plugins/project-setup-jj/commands/statusline-jj-setup.md
+++ b/plugins/project-setup-jj/commands/statusline-jj-setup.md
@@ -1,0 +1,55 @@
+---
+description: Add jj-aware statusline to this project
+allowed-tools: Bash(jj:*), Bash(cp:*), Bash(chmod:*), Bash(mkdir:*), Bash(cat:*), Bash(jq:*), Read, Write
+---
+
+**CRITICAL: This is a jj (Jujutsu) plugin. You MUST NOT use ANY raw git commands — not even for context discovery. Always use jj equivalents. The only exceptions are `jj git` subcommands and `gh` CLI.**
+
+## Your Task
+
+Install the jj-aware statusline script and configure it in this project's `.claude/settings.local.json`.
+
+### Step 1: Detect context
+
+1. Verify this is a jj repo by running `jj root`. If it fails, tell the user this command requires a jj repository and stop.
+2. Find the plugin's scripts directory. Look for the directory containing this command file — it will be something like `~/.claude/plugins/cache/muloka-claude-plugins/project-setup-jj/<hash>/`. The scripts are in `scripts/` relative to the plugin root.
+3. Determine the project root using `jj root`.
+4. Ensure `.claude/scripts/` exists in the project root:
+   ```bash
+   mkdir -p "$(jj root)/.claude/scripts"
+   ```
+
+### Step 2: Copy statusline script
+
+Copy `statusline-jj.sh` from the plugin's `scripts/` directory to the project's `.claude/scripts/`:
+
+```bash
+cp <plugin-scripts-dir>/statusline-jj.sh "$(jj root)/.claude/scripts/"
+chmod +x "$(jj root)/.claude/scripts/statusline-jj.sh"
+```
+
+### Step 3: Update `.claude/settings.local.json`
+
+Read the current `.claude/settings.local.json` (may not exist). Deep-merge the following configuration using `jq`, preserving all existing keys:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "<project-root>/.claude/scripts/statusline-jj.sh"
+  }
+}
+```
+
+Replace `<project-root>` with the actual absolute path from `jj root`.
+
+**Merge strategy:** If a `statusLine` key already exists, replace it. Preserve all other keys.
+
+### Step 4: Confirm to user
+
+Show:
+- Statusline script copied to `.claude/scripts/statusline-jj.sh`
+- `statusLine` config added to `.claude/settings.local.json`
+- **Restart Claude Code** for the statusline to appear
+
+The statusline shows: `[Model] bookmark-or-change-id description | N% ctx | $cost`

--- a/plugins/project-setup-jj/scripts/statusline-jj.sh
+++ b/plugins/project-setup-jj/scripts/statusline-jj.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# jj-aware statusline for Claude Code
+# Receives JSON session data on stdin, outputs a single status line
+#
+# Layout:
+#   [Model] bookmark change-id description TRUNK_STATE | N% | $cost
+#
+# Trunk states:
+#   @trunk  — sitting on trunk
+#   +N      — N changes ahead of trunk (linear)
+#   ⎇       — divergent (not descended from trunk)
+
+set -euo pipefail
+
+input=$(cat)
+
+# Session info from stdin JSON
+MODEL=$(echo "$input" | jq -r '.model.display_name // "unknown"')
+PCT=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
+COST=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
+
+# Quick bail if not a jj repo
+if ! jj root >/dev/null 2>&1; then
+  printf '[%s] %s%% | $%s' "$MODEL" "$PCT" "$COST"
+  exit 0
+fi
+
+# Cache: only re-query jj if repo state changed
+CACHE_FILE="/tmp/statusline-jj-$$-cache"
+JJ_DIR="$(jj root 2>/dev/null)/.jj"
+CACHE_KEY="$(stat -f '%m' "$JJ_DIR/repo" 2>/dev/null || echo "0")"
+
+if [ -f "$CACHE_FILE" ] && [ "$(head -1 "$CACHE_FILE")" = "$CACHE_KEY" ]; then
+  JJ_INFO=$(tail -1 "$CACHE_FILE")
+else
+  CHANGE_ID=$(jj log -r @ --no-graph -T 'self.change_id().short(8)' 2>/dev/null || echo "")
+  DESC=$(jj log -r @ --no-graph -T 'description.first_line()' 2>/dev/null || echo "")
+  BOOKMARK=$(jj log -r @ --no-graph -T 'bookmarks' 2>/dev/null || echo "")
+
+  # Trunk state detection
+  ON_TRUNK=$(jj log -r '@ & trunk()' --no-graph -T '"yes"' 2>/dev/null || echo "")
+  if [ "$ON_TRUNK" = "yes" ]; then
+    TRUNK_STATE="@trunk"
+  else
+    # Count changes between trunk and @
+    AHEAD=$(jj log -r 'trunk()..@' --no-graph -T '"x"' 2>/dev/null | wc -c | tr -d ' ')
+    if [ "$AHEAD" -gt 0 ] 2>/dev/null; then
+      TRUNK_STATE="+${AHEAD}"
+    else
+      TRUNK_STATE="⎇"
+    fi
+  fi
+
+  # Build jj segment: bookmark change-id description trunk-state
+  JJ_INFO=""
+
+  # Bookmark (if exists)
+  if [ -n "$BOOKMARK" ]; then
+    JJ_INFO="$BOOKMARK"
+  fi
+
+  # Change ID
+  if [ -n "$CHANGE_ID" ]; then
+    if [ -n "$JJ_INFO" ]; then
+      JJ_INFO="$JJ_INFO $CHANGE_ID"
+    else
+      JJ_INFO="$CHANGE_ID"
+    fi
+  fi
+
+  # Description (truncated to 30 chars, or "(no intent)" if empty)
+  if [ -n "$DESC" ]; then
+    DESC=$(echo "$DESC" | cut -c1-30)
+    JJ_INFO="$JJ_INFO $DESC"
+  else
+    JJ_INFO="$JJ_INFO (no intent)"
+  fi
+
+  # Trunk state
+  JJ_INFO="$JJ_INFO $TRUNK_STATE"
+
+  # Cache it
+  printf '%s\n%s' "$CACHE_KEY" "$JJ_INFO" > "$CACHE_FILE"
+fi
+
+printf '[%s] %s | %s%% | $%s' "$MODEL" "$JJ_INFO" "$PCT" "$COST"


### PR DESCRIPTION
## Summary
- Add `statusline-jj.sh` — jj-aware statusline script showing model, change ID, bookmark, description, trunk state (`@trunk`, `+N`, `⎇`), context %, and cost
- Add `/statusline-jj-setup` command — copies script and wires `statusLine` in `.claude/settings.local.json`
- Add `/statusline-jj-remove` command — removes statusline config and script
- Includes repo-state caching to avoid redundant jj queries
- Graceful fallback for non-jj directories

## Test plan
- [x] Tested statusline output for all three trunk states (+N, @trunk, ⎇)
- [x] Tested setup flow (copy script + add settings key)
- [x] Tested remove flow (delete settings key + remove script)
- [x] Tested non-jj fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)