### PR TITLE
fix: exclude empty changes from statusline trunk count

### DIFF
--- a/plugins/project-setup-jj/scripts/statusline-jj.sh
+++ b/plugins/project-setup-jj/scripts/statusline-jj.sh
@@ -40,12 +40,18 @@ else
   if [ "$ON_TRUNK" = "yes" ]; then
     TRUNK_STATE="@trunk"
   else
-    # Count changes between trunk and @
-    AHEAD=$(jj log -r 'trunk()..@' --no-graph -T '"x"' 2>/dev/null | wc -c | tr -d ' ')
+    # Count non-empty changes between trunk and @
+    AHEAD=$(jj log -r '(trunk()..@) ~ empty()' --no-graph -T '"x"' 2>/dev/null | wc -c | tr -d ' ')
     if [ "$AHEAD" -gt 0 ] 2>/dev/null; then
       TRUNK_STATE="+${AHEAD}"
     else
-      TRUNK_STATE="⎇"
+      # All changes are empty — check if descended from trunk at all
+      ALL=$(jj log -r 'trunk()..@' --no-graph -T '"x"' 2>/dev/null | wc -c | tr -d ' ')
+      if [ "$ALL" -gt 0 ] 2>/dev/null; then
+        TRUNK_STATE="@trunk"
+      else
+        TRUNK_STATE="⎇"
+      fi
     fi
   fi
 


### PR DESCRIPTION
## Summary
- Empty `@` change on top of trunk was incorrectly showing `+1` instead of `@trunk` in the statusline
- Changed revset from `trunk()..@` to `(trunk()..@) ~ empty()` to skip empty changes
- When all changes between trunk and `@` are empty, now correctly shows `@trunk`

## Test plan
- [ ] Open a jj repo with an empty `@` on trunk — statusline should show `@trunk`
- [ ] Create a non-empty change on trunk — statusline should show `+1`
- [ ] Create 2 non-empty changes + empty `@` — statusline should show `+2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)