### PR TITLE
feat(statusline): add 2x promo badge and Claude Code status indicator

### DIFF
--- a/plugins/project-setup-jj/scripts/statusline-jj.sh
+++ b/plugins/project-setup-jj/scripts/statusline-jj.sh
@@ -3,12 +3,16 @@
 # Receives JSON session data on stdin, outputs a single status line
 #
 # Layout:
-#   [Model] bookmark change-id description TRUNK_STATE | N%
+#   [Model] bookmark change-id description TRUNK_STATE | N% [2x] status
 #
 # Trunk states:
 #   @trunk  — sitting on trunk
 #   +N      — N changes ahead of trunk (linear)
 #   ⎇       — divergent (not descended from trunk)
+#
+# Extras (after context %):
+#   2x      — Claude March 2026 2x usage promotion is active
+#   ✓/⚠/✗  — Claude API status (none/minor/major+critical)
 
 set -euo pipefail
 
@@ -87,4 +91,41 @@ else
   printf '%s\n%s' "$CACHE_KEY" "$JJ_INFO" > "$CACHE_FILE"
 fi
 
-printf '[%s] %s | %s%%' "$MODEL" "$JJ_INFO" "$PCT"
+# 2x window: Claude March 2026 usage promotion
+PROMO_BADGE=""
+if [ "$(date +%Y-%m)" = "2026-03" ]; then
+  PROMO_BADGE="2x"
+fi
+
+# Claude Code status (cached 5 min at /tmp/statusline-claude-status)
+STATUS_CACHE="/tmp/statusline-claude-status"
+CLAUDE_STATUS=""
+if [ -f "$STATUS_CACHE" ]; then
+  CACHE_MTIME=$(stat -f '%m' "$STATUS_CACHE" 2>/dev/null || echo "0")
+  NOW=$(date +%s)
+  AGE=$(( NOW - CACHE_MTIME ))
+  if [ "$AGE" -lt 300 ]; then
+    CLAUDE_STATUS=$(cat "$STATUS_CACHE" 2>/dev/null || echo "")
+  fi
+fi
+if [ -z "$CLAUDE_STATUS" ]; then
+  COMPONENTS_JSON=$(curl -sf --max-time 2 "https://status.claude.com/api/v2/components.json" 2>/dev/null || echo "")
+  if [ -n "$COMPONENTS_JSON" ]; then
+    INDICATOR=$(echo "$COMPONENTS_JSON" | jq -r '.components[] | select(.name == "Claude Code") | .status' 2>/dev/null || echo "unknown")
+    case "$INDICATOR" in
+      operational)                    CLAUDE_STATUS="✓" ;;
+      degraded_performance|partial_outage) CLAUDE_STATUS="⚠" ;;
+      major_outage)                   CLAUDE_STATUS="✗" ;;
+      *)                              CLAUDE_STATUS="?" ;;
+    esac
+  else
+    CLAUDE_STATUS="?"
+  fi
+  printf '%s' "$CLAUDE_STATUS" > "$STATUS_CACHE"
+fi
+
+# Build extras: "2x ✓", "✓", "2x ⚠", etc.
+EXTRAS="$CLAUDE_STATUS"
+[ -n "$PROMO_BADGE" ] && EXTRAS="$PROMO_BADGE $EXTRAS"
+
+printf '[%s] %s | %s%% %s' "$MODEL" "$JJ_INFO" "$PCT" "$EXTRAS"


### PR DESCRIPTION
## Summary
- Adds **2x** badge to statusline during the March 2026 Claude usage promotion window
- Adds live **Claude Code** component status from status.claude.com (`✓`/`⚠`/`✗`)
- Status is cached for 5 minutes to avoid excessive API calls
- Layout: `[Model] jj-info | N% 2x ✓`

## Test plan
- [x] Smoke tested — output: `[Claude Opus 4.6] zuzurmzu (no intent) +1 | 12% 2x ✓`
- [x] Verified status fetches from `/api/v2/components.json` and matches "Claude Code" component
- [x] Cache invalidation works (cleared `/tmp/statusline-claude-status` and re-ran)

🤖 Generated with [Claude Code](https://claude.com/claude-code)