### PR TITLE
fix(statusline): pink for active description, dark slate for (no intent)

### DIFF
--- a/plugins/project-setup-jj/scripts/statusline-jj.sh
+++ b/plugins/project-setup-jj/scripts/statusline-jj.sh
@@ -196,7 +196,7 @@ SEG_TXT+=(" $MODEL ");    SEG_BG+=("$MDL_BG"); SEG_FG+=("$MDL_FG")
 }
 
 if [ -n "${DESC:-}" ]; then
-  SEG_TXT+=(" $DESC ");       SEG_BG+=("$MDL_BG"); SEG_FG+=("$MDL_FG")
+  SEG_TXT+=(" $DESC ");       SEG_BG+=("$SPC_BG"); SEG_FG+=("$SPC_FG")
 else
   SEG_TXT+=(" (no intent) "); SEG_BG+=("$MUT_BG"); SEG_FG+=("$MUT_FG")
 fi


### PR DESCRIPTION
## Summary
- Active description uses **special/pink** (`#f472b6`) — intent pops visually
- Empty `(no intent)` stays **muted/dark slate** (`#3b3557`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)