### PR TITLE
fix(workspace-jj): pin workspaces to parent rev + capture workspace names

### DIFF
--- a/plugins/workspace-jj/scripts/jj-workspace-create.sh
+++ b/plugins/workspace-jj/scripts/jj-workspace-create.sh
@@ -12,9 +12,18 @@ cwd=$(echo "$input" | jq -r '.cwd')
 DIR="$cwd/.claude/workspaces/$name"
 mkdir -p "$(dirname "$DIR")"
 
-# Create jj workspace at the directory, branching from the current working copy's parents
-# Use -R to operate on the repo at cwd, redirect jj output to stderr
-jj -R "$cwd" workspace add "$DIR" --name "workspace-$name" >&2
+# Pin workspace to the current working copy's parents (not the working copy itself).
+# Without --revision, concurrent workspaces can see each other's changes and chain
+# instead of branching independently. Pinning ensures each workspace creates an
+# independent change from the same base — the fan-out pattern fan-flames expects.
+parent_rev=$(jj -R "$cwd" log -r '@-' --no-graph -T 'commit_id' 2>/dev/null || echo "")
+
+if [ -n "$parent_rev" ]; then
+  jj -R "$cwd" workspace add "$DIR" --name "workspace-$name" --revision "$parent_rev" >&2
+else
+  # Fallback: no parent found (empty repo?), use default behavior
+  jj -R "$cwd" workspace add "$DIR" --name "workspace-$name" >&2
+fi
 
 # Print the absolute path for Claude Code
 echo "$DIR"

--- a/plugins/workspace-jj/skills/fan-flames.md
+++ b/plugins/workspace-jj/skills/fan-flames.md
@@ -69,12 +69,14 @@ Agent tool:
 
     <any project context needed: CLAUDE.md, relevant file contents, etc.>
 
-    IMPORTANT: Before reporting back, capture your change ID:
+    IMPORTANT: Before reporting back, capture your change ID and workspace name:
     jj log -r @ --no-graph -T 'change_id'
+    basename "$PWD"
 
     When done, report:
     - Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
     - Change ID: <the change_id from above>
+    - Workspace directory: <the basename from above>
     - Files changed (list paths)
     - Test results (if applicable)
     - Any concerns
@@ -110,7 +112,7 @@ As subagents return, classify each result:
 | NEEDS_CONTEXT | Provide context, re-dispatch |
 | BLOCKED | Note failure, preserve workspace |
 
-Track which tasks succeeded and which failed. **Capture the change ID from each subagent's report** — these are needed for fan-in.
+Track which tasks succeeded and which failed. **Capture the change ID and workspace directory name from each subagent's report** — change IDs are needed for fan-in squash, workspace names for cleanup.
 
 ### Recovery: Missing Change IDs
 
@@ -164,8 +166,9 @@ If conflicts exist:
 3. **Clean up the workspace (if it still exists):**
 
 ```bash
+# Use the workspace directory name reported by the subagent
 # May already be cleaned up by WorktreeRemove hook — that's fine
-jj workspace forget workspace-<task-name> 2>/dev/null || true
+jj workspace forget workspace-<workspace-dir-name> 2>/dev/null || true
 ```
 
 **For each failed task:**


### PR DESCRIPTION
## Summary

Fixes two issues discovered during the first fan-flames test run:

- **Workspace chaining:** Without `--revision`, concurrent jj workspaces see each other's changes and chain instead of branching independently. Now pins each workspace to `@-` (parent of working copy) at creation time, ensuring the fan-out pattern fan-flames expects.
- **Workspace name mismatch:** Claude Code assigns auto-generated agent IDs as workspace names (`workspace-agent-a4eeb8f4`), not predictable task names. Subagents now report their workspace directory name (`basename $PWD`) alongside their change ID, enabling accurate cleanup by the orchestrator.

## Test plan

- [ ] Run fan-flames with 3 independent tasks — verify changes branch from same parent (not chain)
- [ ] Verify `jj log` shows 3 independent changes off the same parent after fan-out
- [ ] Verify orchestrator can clean up workspaces using reported names

🤖 Generated with [Claude Code](https://claude.com/claude-code)