### PR TITLE
docs(workspace-jj): update README with dual-topology and change-ID fan-in

### DIFF
--- a/plugins/workspace-jj/README.md
+++ b/plugins/workspace-jj/README.md
@@ -8,10 +8,10 @@ Claude Code uses git worktrees by default for isolated parallel sessions. This p
 
 ## How It Works
 
-- **WorktreeCreate**: Runs `jj workspace add` to create an isolated workspace at `.claude/worktrees/<name>/`
+- **WorktreeCreate**: Runs `jj workspace add --revision @-` to create an isolated workspace at `.claude/workspaces/<name>/`, pinned to the parent revision for independent branching
 - **WorktreeRemove**: Runs `jj workspace forget` and removes the directory on cleanup
 
-Workspaces share the same repository store, so they're lightweight and fast to create.
+Workspaces share the same repository store (lightweight, fast to create) but each gets an independent working copy pinned to the same parent revision.
 
 ## Installation
 
@@ -78,9 +78,16 @@ Parallel workspace orchestration — fan out tasks to isolated jj workspaces, fa
 - "Run these tasks in parallel with isolation"
 - "Dispatch subagents for these independent tasks"
 
-**Merge order:** Smallest diff first (by files touched). Override with `--merge-order task-3,task-1,task-2`.
+**Dual-topology handling:** jj workspaces share a single DAG. Concurrent subagents may auto-chain (building on each other's commits) or create independent branches. Fan-flames detects which pattern occurred and handles both:
+
+- **Auto-chained:** Content already merged — skip squash, optionally `jj parallelize` for clean history
+- **Independent branches:** Squash each into `@`, smallest diff first (by files touched)
+
+Override merge order with `--merge-order task-3,task-1,task-2`.
 
 **Failure handling:** Partial success is preserved. Failed workspaces stay alive for inspection via `/workspace-list`.
+
+**Change-ID based fan-in:** Subagents report their change ID and workspace directory name (`basename $PWD`) before returning. Fan-in uses change IDs (not workspace revsets) because the WorktreeRemove hook may clean up workspaces before the orchestrator runs squash.
 
 See [design spec](../../docs/specs/2026-03-18-permission-gateway-and-fan-flames-design.md) for full details.
 


### PR DESCRIPTION
## Summary

- Fix workspace path: `.claude/worktrees/` → `.claude/workspaces/`
- Document `--revision @-` pinning for independent branching
- Add dual-topology handling section (auto-chained vs independent branches)
- Document change-ID based fan-in and workspace name reporting

🤖 Generated with [Claude Code](https://claude.com/claude-code)