### PR TITLE
feat(fan-flames): add selective rejection for Pattern A using jj abandon

### DIFF
--- a/plugins/workspace-jj/skills/fan-flames.md
+++ b/plugins/workspace-jj/skills/fan-flames.md
@@ -375,6 +375,32 @@ jj parallelize <change-id-1>::<change-id-N>
 This retroactively converts the chain into siblings off the shared parent.
 Only do this if the user cares about history topology — content is identical either way.
 
+### Step 2a-reject: Pattern A — Selective rejection
+
+If some tasks in the auto-chain failed review, remove them from the chain:
+
+```bash
+jj abandon <rejected-change-id>   # descendants rebase onto its parent automatically
+jj log -r 'conflicts()'           # verify no conflicts in rebased descendants
+```
+
+`jj abandon` removes the change and rebases all descendants onto its parent — as if the rejected task never existed. If the rebased descendants conflict (because they touched lines the rejected task introduced), resolve before proceeding.
+
+For partial acceptance (keep some changes from a rejected task):
+
+```bash
+jj diffedit -r <change-id>        # remove unwanted parts from the diff
+```
+
+Or split by file path, then abandon the unwanted half:
+
+```bash
+jj split -r <change-id> paths/to/keep
+jj abandon <reject-half-change-id>
+```
+
+Note: `jj revert -r <change-id>` (formerly `jj backout`) is the alternative when history is immutable (already pushed). For local workspace chains, `abandon` is idiomatic.
+
 ### Step 2b: Pattern B — Independent branches (squash needed)
 
 If changes are independent siblings, squash each into `@`.


### PR DESCRIPTION
## Summary

- Add Step 2a-reject to Phase 5 for selectively rejecting tasks from Pattern A auto-chains
- `jj abandon` removes a failed task and auto-rebases descendants — one command
- `jj diffedit` / `jj split` for partial file acceptance from a rejected task
- Note on `jj revert` (formerly `backout`) for immutable history cases

## Why

Pattern A (auto-chained) means all task content is baked into a linear chain. Previously the skill had no path for rejecting one task from the middle of a chain without losing downstream work. Research confirmed `jj abandon` is the idiomatic answer — it rebases descendants automatically.

## Test plan

- [ ] Verify `jj abandon` on middle of a 3-commit chain rebases descendants correctly
- [ ] Verify `jj log -r 'conflicts()'` catches conflicts after selective rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)