### PR TITLE
feat(fan-flames): add prior wave context and formatter step to agent prompts

### DIFF
--- a/plugins/workspace-jj/skills/fan-flames.md
+++ b/plugins/workspace-jj/skills/fan-flames.md
@@ -160,6 +160,8 @@ Agent tool:
 
     <any project context needed: CLAUDE.md, relevant file contents, etc.>
 
+    <if wave > 1, include prior wave context — see "Prior Wave Context" below>
+
     CRITICAL: You MUST NOT use ANY raw git commands — not even for context
     discovery. Always use jj equivalents (jj log, jj diff, jj status, etc.).
     The only exceptions are `jj git` subcommands and `gh` CLI.
@@ -172,6 +174,7 @@ Agent tool:
     - Quality: are names clear, code maintainable?
     - Discipline: did I avoid overbuilding (YAGNI)?
     - Testing: do tests verify behavior, not just mock it?
+    - Formatting: run the project's formatter/linter (e.g., cargo fmt, prettier, ruff) and fix any issues
 
     If you find issues, fix them now before reporting.
 
@@ -208,6 +211,23 @@ Agent tool:
 - Provide each subagent with the full task text, not a summary
 - Include relevant project context (CLAUDE.md rules, key file contents)
 - If the plan uses superpowers skills (TDD, code review), include those references in the subagent prompt
+
+**Prior wave context (Wave 2+ only):**
+
+For waves after the first, include a summary of what prior waves built. The orchestrator has this data from prior COLLECT phases — paste it into each agent's prompt:
+
+```
+## Changes from prior waves (already in your working copy)
+
+Wave 1 completed:
+- <file>: added <functions/types/modules>
+- <file>: updated <what changed>
+
+These changes are already in your working copy. Build on top of them,
+don't duplicate or conflict with them.
+```
+
+This prevents Wave 2+ agents from reimplementing or conflicting with prior wave work. Keep the summary concise — list files, functions added/changed, and key APIs. Don't paste full diffs.
 
 **Progress tracking:**
 - After dispatch, report how many subagents are running:


### PR DESCRIPTION
## Summary

- Add prior wave context section to Phase 2 dispatch template — Wave 2+ agents get a summary of what prior waves built (files, functions, APIs) so they build on top of existing work instead of conflicting
- Add formatter/linter step to agent self-review checklist (e.g., `cargo fmt`, `prettier`, `ruff`)

## Why

Real-world UAT showed Wave 2 agent didn't see Wave 1's `decompose_spacing` function despite correct sequencing (op log confirmed 2-minute gap between Wave 1 squash and Wave 2 dispatch). The workspace had the code, but the agent wasn't told about it. Prior wave context in the prompt fixes this.

Formatter step addresses agents producing non-standard formatting that required manual `cargo fmt` after merge.

## Test plan

- [ ] Run fan-flames on a multi-wave plan, verify Wave 2 agent prompt includes Wave 1 summary
- [ ] Verify agents run formatter before reporting

🤖 Generated with [Claude Code](https://claude.com/claude-code)