### PR TITLE
fix(fan-flames): update stale prerequisite check

### DIFF
--- a/plugins/commit-commands-jj/commands/commit-push-pr.md
+++ b/plugins/commit-commands-jj/commands/commit-push-pr.md
@@ -21,7 +21,7 @@ Based on the above changes:
 3. Check if `@-` already has a bookmark: `jj log -r @- --no-graph -T 'bookmarks'`
 4. If no bookmark exists on `@-`: `jj bookmark create <descriptive-name> -r @-` (use a short kebab-case name derived from the change description)
 5. Push: `jj git push --bookmark <name> --allow-new`
-6. Create a pull request: `gh pr create` with an appropriate title and body
+6. Create a pull request: `gh pr create --head <bookmark-name>` with an appropriate title and body (the `--head` flag is required because jj uses detached HEAD, so `gh` can't auto-detect the branch)
 
 For colocated repos (`.jj/` + `.git/`), `gh` works directly. For non-colocated repos, if `gh` fails, advise the user to set `GIT_DIR=.jj/repo/store/git` or run `jj git export` first.
 

--- a/plugins/commit-commands-jj/commands/finish.md
+++ b/plugins/commit-commands-jj/commands/finish.md
@@ -86,7 +86,7 @@ What would you like to do?
 
 4. Create the PR:
    ```bash
-   gh pr create --title "<title>" --body "$(cat <<'EOF'
+   gh pr create --head <bookmark-name> --title "<title>" --body "$(cat <<'EOF'
    ## Summary
    <2-3 bullets from the diff>
 

--- a/plugins/workspace-jj/skills/fan-flames.md
+++ b/plugins/workspace-jj/skills/fan-flames.md
@@ -66,7 +66,7 @@ If only one wave (no overlaps), this is equivalent to v1 behavior plus review.
 Before starting, verify:
 
 1. **jj repo** — confirm this is a jj repository (`jj root` succeeds)
-2. **workspace-jj installed** — confirm WorktreeCreate hooks are configured (`/workspace-list` works or `.claude/settings.local.json` has WorktreeCreate hooks)
+2. **jj workspaces available** — confirm `jj workspace list` succeeds (orchestrator creates workspaces directly, hooks are not involved)
 3. **Clean working copy** — current change should have a description and be a sensible parent for the parallel work
 
 If any prerequisite fails, explain what's missing and how to fix it.


### PR DESCRIPTION
## Summary
- Update fan-flames prerequisite from checking WorktreeCreate hooks to checking `jj workspace list`
- Aligns with v3 design where orchestrator manages workspaces directly (hooks are uninvolved)

## Test plan
- [ ] Verify fan-flames skill loads correctly
- [ ] Run fan-flames and confirm prerequisite check passes without hooks configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)