### PR TITLE
fix(commit-push-pr,finish): drop removed --allow-new flag

### DIFF
--- a/plugins/commit-commands-jj/commands/commit-push-pr.md
+++ b/plugins/commit-commands-jj/commands/commit-push-pr.md
@@ -20,7 +20,7 @@ Based on the above changes:
 2. Check if building on trunk: `jj log -r '@- & trunk()' --no-graph -T 'json(self) ++ "\n"'` — if this returns a result, the change is directly on trunk and needs a bookmark
 3. Check if `@-` already has a bookmark: `jj log -r @- --no-graph -T 'bookmarks'`
 4. If no bookmark exists on `@-`: `jj bookmark create <descriptive-name> -r @-` (use a short kebab-case name derived from the change description)
-5. Push: `jj git push --bookmark <name> --allow-new`
+5. Push: `jj git push --bookmark <name>`
 6. Create a pull request: `gh pr create --head <bookmark-name>` with an appropriate title and body (the `--head` flag is required because jj uses detached HEAD, so `gh` can't auto-detect the branch)
 
 For colocated repos (`.jj/` + `.git/`), `gh` works directly. For non-colocated repos, if `gh` fails, advise the user to set `GIT_DIR=.jj/repo/store/git` or run `jj git export` first.

--- a/plugins/commit-commands-jj/commands/finish.md
+++ b/plugins/commit-commands-jj/commands/finish.md
@@ -81,7 +81,7 @@ What would you like to do?
 
 3. Push the bookmark:
    ```bash
-   jj git push --bookmark <name> --allow-new
+   jj git push --bookmark <name>
    ```
 
 4. Create the PR:


### PR DESCRIPTION
## Summary

jj 0.42 removed `jj git push --allow-new` (deprecated since ~0.39). The `/finish` and `/commit-push-pr` commands still passed it, so their pushes fail with an unknown-flag error on jj ≥ 0.42. Since 0.42, `--bookmark` auto-tracks bookmarks that aren't tracking anything yet, so simply dropping the flag restores the exact previous behavior.

Audited the other 0.40–0.43 removals against the plugins: `jj describe --no-edit` removal doesn't affect us (peer-review uses `jj new --no-edit`, which is unrelated and still supported); no usage of `refs/heads/…` symbols, `git.auto-local-bookmark`, or `<kind>:<bookmark>@<remote>` track patterns.

## Test plan
- [x] `grep -rn "allow-new" plugins/` → empty
- [x] This PR's own branch was pushed with the new flagless form on jj 0.43.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)