### PR TITLE
feat: adopt jj 0.40-0.43 improvements (statusline, workspace-list, fan-flames)

### DIFF
--- a/plugins/project-setup-jj/scripts/statusline-jj.sh
+++ b/plugins/project-setup-jj/scripts/statusline-jj.sh
@@ -61,7 +61,7 @@ MODEL=$(echo "$input" | jq -r '.model.display_name // "unknown"')
 PCT=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
 
 # Quick bail if not a jj repo
-if ! jj root >/dev/null 2>&1; then
+if ! jj root --ignore-working-copy >/dev/null 2>&1; then
   SEG_TXT=(" $MODEL "); SEG_BG=("$MDL_BG"); SEG_FG=("$MDL_FG")
   SEG_TXT+=(" ${PCT}% "); SEG_BG+=("$HLT_BG"); SEG_FG+=("$HLT_FG")
   render
@@ -71,26 +71,26 @@ fi
 # Cache: only re-query jj if repo state changed
 # Stores raw pipe-delimited values for segment building
 CACHE_FILE="/tmp/statusline-jj-$$-cache"
-JJ_DIR="$(jj root 2>/dev/null)/.jj"
+JJ_DIR="$(jj root --ignore-working-copy 2>/dev/null)/.jj"
 CACHE_KEY="$(stat -f '%m' "$JJ_DIR/repo" 2>/dev/null || echo "0")"
 
 if [ -f "$CACHE_FILE" ] && [ "$(head -1 "$CACHE_FILE")" = "$CACHE_KEY" ]; then
   IFS='|' read -r BOOKMARK CHANGE_ID DESC TRUNK_LABEL TRUNK_CLR < <(tail -1 "$CACHE_FILE") || true
 else
-  CHANGE_ID=$(jj log -r @ --no-graph -T 'self.change_id().short(8)' 2>/dev/null || echo "")
-  DESC=$(jj log -r @ --no-graph -T 'description.first_line()' 2>/dev/null || echo "")
-  BOOKMARK=$(jj log -r @ --no-graph -T 'bookmarks' 2>/dev/null || echo "")
+  CHANGE_ID=$(jj log --ignore-working-copy -r @ --no-graph -T 'self.change_id().short(8)' 2>/dev/null || echo "")
+  DESC=$(jj log --ignore-working-copy -r @ --no-graph -T 'description.first_line()' 2>/dev/null || echo "")
+  BOOKMARK=$(jj log --ignore-working-copy -r @ --no-graph -T 'bookmarks' 2>/dev/null || echo "")
 
   # Trunk state
-  ON_TRUNK=$(jj log -r '@ & trunk()' --no-graph -T '"yes"' 2>/dev/null || echo "")
+  ON_TRUNK=$(jj log --ignore-working-copy -r '@ & trunk()' --no-graph -T '"yes"' 2>/dev/null || echo "")
   if [ "$ON_TRUNK" = "yes" ]; then
     TRUNK_LABEL="@trunk"; TRUNK_CLR="healthy"
   else
-    AHEAD=$(jj log -r '(trunk()..@) ~ empty()' --no-graph -T '"x"' 2>/dev/null | wc -c | tr -d ' ')
+    AHEAD=$(jj log --ignore-working-copy -r '(trunk()..@) ~ empty()' --no-graph -T '"x"' 2>/dev/null | wc -c | tr -d ' ')
     if [ "$AHEAD" -gt 0 ] 2>/dev/null; then
       TRUNK_LABEL="+${AHEAD}"; TRUNK_CLR="attention"
     else
-      ALL=$(jj log -r 'trunk()..@' --no-graph -T '"x"' 2>/dev/null | wc -c | tr -d ' ')
+      ALL=$(jj log --ignore-working-copy -r 'trunk()..@' --no-graph -T '"x"' 2>/dev/null | wc -c | tr -d ' ')
       if [ "$ALL" -gt 0 ] 2>/dev/null; then
         TRUNK_LABEL="@trunk"; TRUNK_CLR="healthy"
       else
@@ -101,7 +101,7 @@ else
 
   # Detect if trunk bookmark needs pushing (local ahead of origin)
   for _bm in main master; do
-    _ct=$( (jj log -r "${_bm} ~ ${_bm}@origin" --no-graph -T '"x"' 2>/dev/null || true) | wc -c | tr -d ' ')
+    _ct=$( (jj log --ignore-working-copy -r "${_bm} ~ ${_bm}@origin" --no-graph -T '"x"' 2>/dev/null || true) | wc -c | tr -d ' ')
     if [ "${_ct:-0}" -gt 0 ] 2>/dev/null; then
       TRUNK_LABEL="${TRUNK_LABEL}*"; TRUNK_CLR="attention"
       break

--- a/plugins/workspace-jj/commands/workspace-list.md
+++ b/plugins/workspace-jj/commands/workspace-list.md
@@ -5,15 +5,21 @@ allowed-tools: Bash(jj:*)
 
 ## Context
 
-- Active workspaces (JSON): !`jj workspace list --no-pager -T 'json(self) ++ "\n"'`
+- Active workspaces (JSON): !`jj workspace list --ignore-working-copy --no-pager -T 'json(self) ++ "\n"'`
+- Workspace roots: !`jj workspace list --ignore-working-copy --no-pager -T 'self.name() ++ ": " ++ self.root() ++ "\n"'`
 
 ## Your Task
 
 Present the workspace list to the user in a clear summary. For each workspace, show:
 
 - **Name**: The workspace name
+- **Root**: The absolute path to the workspace directory (from the roots list)
 - **Change ID**: The target change ID
 - **Description**: The change description (or "(no description)" if empty)
 - **Author**: Who created it
+
+If a root shows an `<Error: Failed to resolve workspace root: ...>` entry, the
+recorded directory no longer exists (moved or deleted) — flag that workspace
+as stale and suggest `jj workspace forget <name>` (or `/clean_stale`).
 
 If there are multiple workspaces, note which ones may be stale (no recent description or activity).

--- a/plugins/workspace-jj/skills/fan-flames.md
+++ b/plugins/workspace-jj/skills/fan-flames.md
@@ -491,7 +491,10 @@ Compare against the change ID the agent reported.
 **Step 3:** If mismatch detected, flag as `WORKSPACE_LEAK`:
 1. Report: "Workspace integrity failure — Task N's edits landed in the orchestrator's workspace instead of workspace-<task-name>."
 2. Determine if changes are in `@` (recoverable — skip squash for this task) or lost (treat as BLOCKED)
-3. Report to user before proceeding to review
+3. Diagnose with `jj op log` — each operation is attributed to the workspace
+   it was created from (jj ≥ 0.40), which identifies exactly which agent
+   produced the leaked operation
+4. Report to user before proceeding to review
 
 > **Safety net context:** This check replaces the former Pattern C edge case handler. Pattern C was caused by dual isolation mechanisms (`isolation: "worktree"` + jj workspace hook). With orchestrator-managed workspaces (v3), the root cause is eliminated. This check catches `cd` failures, which are the remaining risk vector.
 


### PR DESCRIPTION
## Summary

Follow-up to the jj 0.39 → 0.43 upgrade audit (correctness fix landed in #62):

- **statusline-jj.sh:** all 9 jj invocations now pass `--ignore-working-copy`. Previously every prompt render snapshotted the working copy and wrote an operation to the op log — and those writes could invalidate the mtime-keyed cache the statusline itself maintains. Read-only display should never mutate repo state (the problem 0.41's `--no-integrate-operation` release note calls out for background tooling).
- **/workspace-list:** adds each workspace's root path via `WorkspaceRef.root()` (new in jj 0.40). Bonus: a root-resolve error in the output identifies moved/deleted workspace directories — the command now flags those as stale and suggests `jj workspace forget` / `/clean_stale`. (Validated on this repo, whose default-workspace root is itself stale from a past move.)
- **fan-flames:** the WORKSPACE_LEAK diagnosis now uses `jj op log`'s per-operation workspace attribution (jj 0.40) to identify exactly which agent produced a leaked operation, instead of inferring from diffs.

Deliberately deferred: `jj run` (first release in 0.43; fan-flames workspaces host interactive agents, not one-shot commands — revisit for the test gate once it matures).

## Test plan
- [x] Statusline smoke-tested with sample stdin JSON — renders correctly with all flags
- [x] `workspace list` root template validated on this repo (including the stale-root error path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)