### PR TITLE
fix(fan-flames): pin Opus as the model ceiling

### DIFF
--- a/plugins/workspace-jj/skills/fan-flames.md
+++ b/plugins/workspace-jj/skills/fan-flames.md
@@ -195,9 +195,9 @@ most capable and most expensive.
 |------|-------|
 | Implementer — brief contains the complete code to write (transcription + tests) | `haiku` |
 | Implementer — prose spec, 1-2 files | `sonnet` |
-| Implementer — multi-file integration or design judgment | session model (omit) |
+| Implementer — multi-file integration or design judgment | `opus` |
 | Reviewer — small mechanical wave | `sonnet` |
-| Reviewer — subtle/risky changes, or the final wave (covers the combined result) | `opus` or session model |
+| Reviewer — subtle/risky changes, or the final wave (covers the combined result) | `opus` |
 | Fix subagent | same model as the task's implementer |
 
 **Turn count beats token price.** Cost scales with how many turns a subagent


### PR DESCRIPTION
## Summary

The fan-flames Model Selection table had two rows that let dispatched agents inherit the **session model**:
- Implementer — multi-file integration or design judgment → `session model (omit)`
- Reviewer — subtle/risky changes or the final wave → `opus` or session model

On a high-tier session (e.g. Fable 5), "session model" silently fans the most expensive model across every workspace, every reviewer, and every fix loop. Both rows now name `opus` explicitly, so no fan-flames agent can inherit a model heavier than Opus 4.8. The table is now fully explicit — every role pins a concrete model, none omit.

**Before → after**

| Role | Before | After |
|------|--------|-------|
| Implementer — multi-file / design judgment | session model (omit) | `opus` |
| Reviewer — subtle/risky or final wave | `opus` or session model | `opus` |

The intro prose (why you must specify `model` explicitly — an omitted `model` inherits the session's model) stays, now reinforcing a table with zero omit rows.

## Context

Surfaced when a fan-flames run inherited Fable 5 on every dispatch: a stale plugin-cache snapshot predating the Model Selection section caused agents to omit `model`. The cache side was addressed separately (snapshot cleanup + reinstall); this PR closes the remaining leak in the source so even a current snapshot can't inherit a Mythos-class session model.

## Test plan
- [x] Model Selection table contains no "session model" or "(omit)" rows
- [ ] Reviewer: confirm `opus` is the intended ceiling (vs. reserving session model for design judgment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)