### PR TITLE
New plugin: agent-helpers-jj — read-only jj query helpers for agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -50,6 +50,17 @@
       "source": "./plugins/workspace-jj",
       "category": "productivity",
       "homepage": "https://github.com/muloka/claude-plugins/tree/main/plugins/workspace-jj"
+    },
+    {
+      "name": "agent-helpers-jj",
+      "description": "Machine-level jj (Jujutsu) query shortcuts for agents — read-only helpers that bake in --ignore-working-copy so concurrent workspaces don't race",
+      "author": {
+        "name": "muloka",
+        "email": "muloka@users.noreply.github.com"
+      },
+      "source": "./plugins/agent-helpers-jj",
+      "category": "productivity",
+      "homepage": "https://github.com/muloka/claude-plugins/tree/main/plugins/agent-helpers-jj"
     }
   ]
 }

--- a/docs/plans/2026-07-14-agent-helpers-jj-plan.md
+++ b/docs/plans/2026-07-14-agent-helpers-jj-plan.md
@@ -1,0 +1,675 @@
+# agent-helpers-jj Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use workspace-jj:fan-flames (per CLAUDE.md override of superpowers:subagent-driven-development) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Tasks are independent enough to review one at a time; Tasks 2–4 build on Task 1's directory.
+
+**Goal:** Ship a new `agent-helpers-jj` plugin that installs six read-only jj query shortcuts (each wrapping `jj --ignore-working-copy …`) into the user's shell, so concurrent fan-flames workspaces never race on the working-copy snapshot / op-log.
+
+**Architecture:** A single-purpose plugin. The six functions live in one sourced shell file. The risky part — a consent-gated, idempotent, machine-level installer that edits three `$HOME` files — is realized as a **testable shell script** (`scripts/agent-helpers-install.sh`) with `install`/`remove` subcommands, driven by thin markdown command wrappers that own consent + reporting. Everything is marker-fenced for surgical removal.
+
+**Tech Stack:** POSIX-ish bash/zsh shell, `jq` for JSON, `jj` (Jujutsu) 0.43. No new runtime dependencies.
+
+Design source: `docs/specs/2026-07-14-agent-helpers-jj-design.md` (read it before starting).
+
+> **Revision (2026-07-14, during execution):** reduced from six helpers to **four**. TDD proved that under `--ignore-working-copy` a helper reads jj's *last snapshot*, not live disk edits — which makes the two working-copy helpers (`jjclean`, `jjfiles`) report stale "am I clean / what changed?" answers. They were cut; the four structural helpers (`jjctx`, `jjstack`, `jjconflicts`, `jjcheckpoint`) query committed / op-log state where the flag is strictly correct. Task 2's shipped code, catalog, and tests reflect four; Task 3's allowlist is four values. Some Task 2 code blocks below still show the original six — the committed code is authoritative.
+
+## Global Constraints
+
+- **VCS is jj, never git.** Commit with `jj describe -m "…"` then `jj new`. The only exceptions are `jj git` subcommands and `gh`.
+- **Four functions only** — `jjctx`, `jjstack`, `jjconflicts`, `jjcheckpoint` — plus the private `_jjq`. No mutation wrappers, no workspace helpers, no `jjhelp`, no working-copy helpers (`jjclean`/`jjfiles` cut — see Revision note).
+- **Function bodies are bash+zsh compatible** (use `printf`, `[ … ]`, `local` — not zsh-only `print`/`typeset`), so the bash test harness can source them while they still install into `~/.zshrc`. Install target is zsh only (`~/.zshrc`); bash install is a non-goal.
+- **The installer uses `$HOME` explicitly** (never literal `~`) for every target path, so tests can override `HOME`. Targets: `~/.config/jj-agent-helpers/jj-agent-helpers.sh`, `~/.zshrc`, `~/.claude/CLAUDE.md`, `~/.claude/settings.json`.
+- **Every read-only function body must contain `--ignore-working-copy`** (via `_jjq`). This is the feature's reason to exist; a test enforces it.
+- **All prose in this repo's own words.**
+- **Marker fences** (exact strings, used verbatim by the installer and tests):
+  - zshrc: `# >>> jj-agent-helpers (managed by agent-helpers-jj) >>>` … `# <<< jj-agent-helpers <<<`
+  - CLAUDE.md: `<!-- BEGIN jj-agent-helpers (agent-helpers-jj) -->` … `<!-- END jj-agent-helpers -->`
+  - settings.json allowlist values (four): `Bash(jjctx:*)`, `Bash(jjstack:*)`, `Bash(jjconflicts:*)`, `Bash(jjcheckpoint:*)`
+
+---
+
+## File Structure
+
+```
+plugins/agent-helpers-jj/
+  .claude-plugin/plugin.json                 # manifest
+  README.md
+  LICENSE
+  scripts/
+    jj-agent-helpers.sh                       # the six functions + _jjq (sourced into ~/.zshrc)
+    agent-helpers-install.sh                  # install/remove mechanism (testable, non-interactive)
+  templates/
+    jj-agent-helpers-claudemd.md              # the fenced CLAUDE.md catalog block
+  commands/
+    agent-helpers-setup.md                    # consent + invoke installer + report + restart reminder
+    agent-helpers-remove.md                   # invoke installer remove + report
+  tests/
+    test-jj-agent-helpers.sh                  # unit: the six functions in a scratch jj repo
+    test-agent-helpers-install.sh             # installer: setup→setup→remove against a fake $HOME
+```
+Plus one modification: add the plugin to `./.claude-plugin/marketplace.json`.
+
+---
+
+### Task 1: Plugin scaffold + marketplace registration
+
+**Files:**
+- Create: `plugins/agent-helpers-jj/.claude-plugin/plugin.json`
+- Create: `plugins/agent-helpers-jj/README.md`
+- Create: `plugins/agent-helpers-jj/LICENSE`
+- Modify: `.claude-plugin/marketplace.json` (append one plugin entry)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a registered plugin `agent-helpers-jj` other tasks add files under.
+
+- [ ] **Step 1: Create the plugin manifest**
+
+Create `plugins/agent-helpers-jj/.claude-plugin/plugin.json` (no hooks — this plugin ships no hooks):
+
+```json
+{
+  "name": "agent-helpers-jj",
+  "description": "Machine-level jj (Jujutsu) query shortcuts for agents — read-only helpers that bake in --ignore-working-copy so concurrent workspaces don't race",
+  "author": {
+    "name": "muloka",
+    "email": "muloka@users.noreply.github.com"
+  }
+}
+```
+
+- [ ] **Step 2: Add the LICENSE**
+
+Copy the existing MIT license verbatim so the new plugin matches its siblings:
+
+```bash
+cp plugins/project-setup-jj/LICENSE plugins/agent-helpers-jj/LICENSE
+```
+
+- [ ] **Step 3: Create the README**
+
+Create `plugins/agent-helpers-jj/README.md`:
+
+```markdown
+# agent-helpers-jj
+
+Machine-level jj (Jujutsu) query shortcuts for agents. Six read-only shell
+functions, each wrapping `jj --ignore-working-copy …`, so an agent orienting
+inside a jj repo never writes a working-copy snapshot to the shared operation
+log — the serialization point that concurrent workspaces (e.g. fan-flames)
+would otherwise race on.
+
+| Function | Output | Purpose |
+|---|---|---|
+| `jjctx` | one JSON object | current change (orientation) |
+| `jjstack` | JSONL | local changes ahead of trunk |
+| `jjfiles [rev]` | JSONL | changed files `{path,status}` in `<rev>` (default `@`) |
+| `jjconflicts` | exit code | 0 = clean, 1 = conflicts (printed), >1 = jj error |
+| `jjcheckpoint` | short op id | for a fan-flames ledger `start-op` |
+| `jjclean` | exit code | 0 = working copy has no changes |
+
+## Install
+
+```
+/agent-helpers-setup
+```
+
+This is a **machine-level, one-time** install (not per-project). It:
+1. copies the helper script to `~/.config/jj-agent-helpers/jj-agent-helpers.sh`;
+2. adds a `source` line to `~/.zshrc` (consent-gated);
+3. adds a one-line catalog to `~/.claude/CLAUDE.md` so agents know the helpers exist;
+4. allowlists the six helpers in `~/.claude/settings.json` so they run prompt-free.
+
+**Restart Claude Code afterward** — the helpers become callable only once the next
+session regenerates its shell snapshot.
+
+Uninstall with `/agent-helpers-remove` (reverses all four steps).
+
+Requires zsh and `jj`. Bash shells are not supported in this version.
+```
+
+- [ ] **Step 4: Register in the marketplace manifest**
+
+In `.claude-plugin/marketplace.json`, append this object to the `plugins` array (after the `workspace-jj` entry):
+
+```json
+    {
+      "name": "agent-helpers-jj",
+      "description": "Machine-level jj (Jujutsu) query shortcuts for agents — read-only helpers that bake in --ignore-working-copy so concurrent workspaces don't race",
+      "author": {
+        "name": "muloka",
+        "email": "muloka@users.noreply.github.com"
+      },
+      "source": "./plugins/agent-helpers-jj",
+      "category": "productivity",
+      "homepage": "https://github.com/muloka/claude-plugins/tree/main/plugins/agent-helpers-jj"
+    }
+```
+
+- [ ] **Step 5: Verify the manifests parse and the entry is present**
+
+Run:
+```bash
+jq . plugins/agent-helpers-jj/.claude-plugin/plugin.json >/dev/null && echo "plugin.json OK"
+jq -e '.plugins[] | select(.name=="agent-helpers-jj")' .claude-plugin/marketplace.json >/dev/null && echo "marketplace entry OK"
+```
+Expected: both print `… OK` and exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "feat(agent-helpers-jj): scaffold plugin + marketplace entry
+
+New single-purpose plugin for machine-level jj query helpers. Manifest,
+README, MIT license, and marketplace registration; no components yet."
+jj new
+```
+
+---
+
+### Task 2: Function library + catalog template + unit/drift tests
+
+**Files:**
+- Create: `plugins/agent-helpers-jj/scripts/jj-agent-helpers.sh`
+- Create: `plugins/agent-helpers-jj/templates/jj-agent-helpers-claudemd.md`
+- Create/Test: `plugins/agent-helpers-jj/tests/test-jj-agent-helpers.sh`
+
+**Interfaces:**
+- Consumes: Task 1's plugin directory.
+- Produces: the six functions (`jjctx`, `jjstack`, `jjfiles`, `jjconflicts`, `jjcheckpoint`, `jjclean`) sourced from `scripts/jj-agent-helpers.sh`; the fenced catalog block in `templates/jj-agent-helpers-claudemd.md` (consumed by Task 3's installer).
+
+- [ ] **Step 1: Write the failing unit test harness**
+
+Create `plugins/agent-helpers-jj/tests/test-jj-agent-helpers.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Unit tests for the six jj query helper functions.
+# Creates a scratch jj repo, sources the helpers, exercises each function,
+# and enforces the --ignore-working-copy invariant + catalog drift guard.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HELPERS="$SCRIPT_DIR/../scripts/jj-agent-helpers.sh"
+TEMPLATE="$SCRIPT_DIR/../templates/jj-agent-helpers-claudemd.md"
+
+pass=0
+fail=0
+ok()   { echo "  PASS: $1"; pass=$((pass+1)); }
+bad()  { echo "  FAIL: $1 — $2"; fail=$((fail+1)); }
+
+# --- scratch jj repo ---
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+export JJ_CONFIG="$WORK/jjconfig.toml"
+cat > "$JJ_CONFIG" <<'CFG'
+[user]
+name = "test"
+email = "test@example.com"
+CFG
+cd "$WORK"
+jj git init repo >/dev/null 2>&1
+cd repo
+# seed one described change so trunk()..@ is non-empty. trunk() falls back to
+# the root commit when there is no origin remote — fine here, because we assert
+# jjstack is NON-empty (a local `main` bookmark would not influence trunk();
+# that needs a real main@origin remote, which is more setup than this test needs).
+jj describe -m seed >/dev/null 2>&1
+jj new >/dev/null 2>&1   # @ is now an empty change on top of the seed
+
+# shellcheck disable=SC1090
+. "$HELPERS"
+
+# jjctx: one JSON object carrying a change_id
+out="$(jjctx)"
+if printf '%s' "$out" | jq -e '.change_id' >/dev/null 2>&1; then ok "jjctx emits JSON with change_id"; else bad "jjctx" "no change_id in: $out"; fi
+
+# jjcheckpoint: non-empty short op id
+out="$(jjcheckpoint)"
+if [ -n "$out" ]; then ok "jjcheckpoint prints an op id"; else bad "jjcheckpoint" "empty"; fi
+
+# jjclean: empty @ -> exit 0
+if jjclean; then ok "jjclean exits 0 on empty @"; else bad "jjclean(empty)" "expected 0"; fi
+
+# make @ dirty, then jjclean -> non-zero, jjfiles -> JSONL, jjstack -> includes this change
+echo hello > a.txt
+if jjclean; then bad "jjclean(dirty)" "expected non-zero"; else ok "jjclean non-zero on dirty @"; fi
+
+out="$(jjfiles)"
+if printf '%s' "$out" | head -1 | jq -e '.path and .status' >/dev/null 2>&1; then ok "jjfiles emits {path,status} JSONL"; else bad "jjfiles" "bad line: $out"; fi
+
+out="$(jjstack)"
+if [ -n "$out" ] && printf '%s' "$out" | head -1 | jq -e '.change_id' >/dev/null 2>&1; then ok "jjstack emits JSONL ahead of trunk"; else bad "jjstack" "bad: $out"; fi
+
+# jjconflicts: clean repo -> exit 0
+if jjconflicts; then ok "jjconflicts exits 0 when clean"; else bad "jjconflicts(clean)" "expected 0"; fi
+
+# jjconflicts: broken env (not a jj repo) -> non-zero, NOT a false clean
+( cd "$WORK" && jjconflicts >/dev/null 2>&1 ) && bad "jjconflicts(non-repo)" "returned clean outside a jj repo" || ok "jjconflicts non-zero outside a jj repo"
+
+# --ignore-working-copy invariant: the ONLY direct `jj ` call is _jjq's (which
+# carries the flag). Every helper otherwise routes through _jjq — so no line may
+# invoke bare `jj ` without --ignore-working-copy. (Robust across multi-line bodies.)
+bare="$(grep -nE '(^|[^_A-Za-z])jj ' "$HELPERS" | grep -v -- '--ignore-working-copy' || true)"
+if grep -q -- '--ignore-working-copy' "$HELPERS" && [ -z "$bare" ]; then
+  ok "all direct jj calls carry --ignore-working-copy"
+else
+  bad "invariant" "jj called without the flag: $bare"
+fi
+
+# drift guard: catalog names == public function names (exclude private _jjq)
+defined="$(grep -Eo '^(jj[a-z]+)\(\)' "$HELPERS" | sed 's/()//' | sort -u)"
+catalog="$(grep -Eo '`jj[a-z]+' "$TEMPLATE" | tr -d '`' | sort -u)"
+if [ "$defined" = "$catalog" ]; then ok "catalog matches defined public functions"; else bad "drift" "defined=[$defined] catalog=[$catalog]"; fi
+
+echo ""
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `bash plugins/agent-helpers-jj/tests/test-jj-agent-helpers.sh`
+Expected: FAIL — the harness can't source `scripts/jj-agent-helpers.sh` (doesn't exist yet), erroring at the `. "$HELPERS"` line.
+
+- [ ] **Step 3: Write the function library**
+
+Create `plugins/agent-helpers-jj/scripts/jj-agent-helpers.sh`:
+
+```bash
+# jj query helpers for agents. Sourced from ~/.zshrc by agent-helpers-jj.
+# Bodies are bash+zsh compatible (printf / [ ] / local), so the bash test
+# harness can source them while they install into zsh.
+#
+# _jjq is the single place the --ignore-working-copy flag lives: read-only
+# queries must never snapshot the working copy (that writes a new operation to
+# the shared op-log, the serialization point concurrent jj workspaces race on).
+
+_jjq() { jj --ignore-working-copy "$@"; }
+
+# jjctx — current change as one JSON object (orientation)
+jjctx() { _jjq log -r @ --no-graph -T 'json(self) ++ "\n"'; }
+
+# jjstack — local changes ahead of trunk, JSON lines
+jjstack() { _jjq log -r 'trunk()..@' --no-graph -T 'json(self) ++ "\n"'; }
+
+# jjfiles [rev] — changed files in <rev|@> as JSONL {path,status}
+jjfiles() {
+  _jjq diff -r "${1:-@}" -T '"{ \"path\": " ++ self.path().display().escape_json() ++ ", \"status\": " ++ self.status().escape_json() ++ " }\n"'
+}
+
+# jjclean — exit 0 if the working copy has no changes
+jjclean() { [ "$(_jjq log -r @ --no-graph -T 'if(empty,"1","0")')" = 1 ]; }
+
+# jjconflicts — 0 = clean, 1 = conflicts (printed), >1 = real jj error.
+# On jj 0.43 `jj resolve --list` exits 0 (and lists) when conflicts exist, and
+# exits 2 ("No conflicts found…") when clean. Distinguishing exit 2 from other
+# errors stops an agent reading "clean" from a broken env (not a repo / jj gone).
+jjconflicts() {
+  local out rc
+  out="$(_jjq resolve --list 2>/dev/null)"; rc=$?
+  if [ "$rc" -eq 0 ]; then
+    [ -z "$out" ] && return 0
+    printf '%s\n' "$out"; return 1
+  fi
+  [ "$rc" -eq 2 ] && return 0
+  printf 'jjconflicts: jj error (rc=%s)\n' "$rc" >&2
+  return "$rc"
+}
+
+# jjcheckpoint — current operation id (for a fan-flames ledger start-op)
+jjcheckpoint() { _jjq op log -n1 --no-graph -T 'id.short()'; }
+```
+
+- [ ] **Step 4: Write the catalog template**
+
+Create `plugins/agent-helpers-jj/templates/jj-agent-helpers-claudemd.md` (this exact fenced block is inserted into `~/.claude/CLAUDE.md` by the installer):
+
+```markdown
+<!-- BEGIN jj-agent-helpers (agent-helpers-jj) -->
+**jj query helpers** (run in jj repos; all use `--ignore-working-copy`, safe under concurrent workspaces): `jjctx` current change (one JSON object) · `jjstack` local changes vs trunk (JSONL) · `jjfiles [rev]` changed files (JSONL) · `jjconflicts` (exit 0 = clean) · `jjcheckpoint` op id · `jjclean` (exit 0 = nothing to commit)
+<!-- END jj-agent-helpers -->
+```
+
+- [ ] **Step 5: Run the unit tests to confirm they pass**
+
+Run: `bash plugins/agent-helpers-jj/tests/test-jj-agent-helpers.sh`
+Expected: every line `PASS`, final line `N passed, 0 failed`, exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "feat(agent-helpers-jj): six read-only jj query helpers + tests
+
+jjctx/jjstack/jjfiles/jjconflicts/jjcheckpoint/jjclean, each routed through
+_jjq (--ignore-working-copy) so read-only orientation never snapshots the
+working copy. Bash+zsh compatible bodies; unit tests assert JSON/exit-code
+contracts, the --ignore-working-copy invariant, and catalog drift."
+jj new
+```
+
+---
+
+### Task 3: Installer script + installer tests (the risk surface)
+
+**Files:**
+- Create: `plugins/agent-helpers-jj/scripts/agent-helpers-install.sh`
+- Create/Test: `plugins/agent-helpers-jj/tests/test-agent-helpers-install.sh`
+
+**Interfaces:**
+- Consumes: `scripts/jj-agent-helpers.sh` (its sibling) and `templates/jj-agent-helpers-claudemd.md` (from Task 2).
+- Produces: `agent-helpers-install.sh install` / `remove` — the non-interactive mechanism Task 4's commands invoke. Reads all targets from `$HOME` so tests can override it.
+
+- [ ] **Step 1: Write the failing installer test**
+
+Create `plugins/agent-helpers-jj/tests/test-agent-helpers-install.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installer idempotency + reversibility against a FAKE $HOME.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL="$SCRIPT_DIR/../scripts/agent-helpers-install.sh"
+
+pass=0; fail=0
+ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL: $1 — $2"; fail=$((fail+1)); }
+
+FAKE="$(mktemp -d)"
+trap 'rm -rf "$FAKE"' EXIT
+
+# seed a realistic home
+mkdir -p "$FAKE/.claude"
+printf '# my zshrc\nexport FOO=1\n' > "$FAKE/.zshrc"
+printf '# My global instructions\n\nPrefer jj over git.\n' > "$FAKE/.claude/CLAUDE.md"
+printf '{\n  "permissions": {\n    "allow": ["Bash(ls:*)"]\n  }\n}\n' > "$FAKE/.claude/settings.json"
+
+ZSHRC_ORIG="$(cat "$FAKE/.zshrc")"
+CLAUDE_ORIG="$(cat "$FAKE/.claude/CLAUDE.md")"
+SETTINGS_ORIG_SEMANTIC="$(jq -S . "$FAKE/.claude/settings.json")"
+
+run() { HOME="$FAKE" bash "$INSTALL" "$1"; }
+
+# --- install ---
+run install
+grep -qxF '# >>> jj-agent-helpers (managed by agent-helpers-jj) >>>' "$FAKE/.zshrc" && ok "zshrc fence present" || bad "install/zshrc" "no fence"
+grep -qF 'source' "$FAKE/.zshrc" && grep -qF '.config/jj-agent-helpers/jj-agent-helpers.sh' "$FAKE/.zshrc" && ok "zshrc source line present" || bad "install/zshrc" "no source line"
+[ -f "$FAKE/.config/jj-agent-helpers/jj-agent-helpers.sh" ] && ok "helper script copied" || bad "install/copy" "missing"
+grep -qxF '<!-- BEGIN jj-agent-helpers (agent-helpers-jj) -->' "$FAKE/.claude/CLAUDE.md" && ok "CLAUDE.md fence present" || bad "install/claude" "no fence"
+[ "$(jq -r '.permissions.allow | index("Bash(jjctx:*)") != null' "$FAKE/.claude/settings.json")" = true ] && ok "settings allowlist added" || bad "install/settings" "jjctx missing"
+[ "$(jq -r '.permissions.allow | index("Bash(ls:*)") != null' "$FAKE/.claude/settings.json")" = true ] && ok "settings preserved existing entry" || bad "install/settings" "clobbered ls"
+
+# --- idempotent second install ---
+run install
+zcount=$(grep -cxF '# >>> jj-agent-helpers (managed by agent-helpers-jj) >>>' "$FAKE/.zshrc")
+[ "$zcount" -eq 1 ] && ok "idempotent: one zshrc fence" || bad "idempotent/zshrc" "count=$zcount"
+ccount=$(grep -cxF '<!-- BEGIN jj-agent-helpers (agent-helpers-jj) -->' "$FAKE/.claude/CLAUDE.md")
+[ "$ccount" -eq 1 ] && ok "idempotent: one CLAUDE.md fence" || bad "idempotent/claude" "count=$ccount"
+jcount=$(jq '[.permissions.allow[] | select(. == "Bash(jjctx:*)")] | length' "$FAKE/.claude/settings.json")
+[ "$jcount" -eq 1 ] && ok "idempotent: no duplicate allowlist value" || bad "idempotent/settings" "count=$jcount"
+
+# --- remove restores originals ---
+run remove
+[ "$(cat "$FAKE/.zshrc")" = "$ZSHRC_ORIG" ] && ok "remove restores ~/.zshrc byte-identical" || bad "remove/zshrc" "differs: $(cat "$FAKE/.zshrc")"
+[ "$(cat "$FAKE/.claude/CLAUDE.md")" = "$CLAUDE_ORIG" ] && ok "remove restores CLAUDE.md byte-identical" || bad "remove/claude" "differs"
+[ "$(jq -S . "$FAKE/.claude/settings.json")" = "$SETTINGS_ORIG_SEMANTIC" ] && ok "remove restores settings.json semantically" || bad "remove/settings" "differs: $(jq -S . "$FAKE/.claude/settings.json")"
+[ ! -f "$FAKE/.config/jj-agent-helpers/jj-agent-helpers.sh" ] && ok "remove deletes helper script" || bad "remove/copy" "still present"
+
+# --- missing-file paths ---
+FAKE2="$(mktemp -d)"; trap 'rm -rf "$FAKE" "$FAKE2"' EXIT
+HOME="$FAKE2" bash "$INSTALL" install
+grep -qxF '# >>> jj-agent-helpers (managed by agent-helpers-jj) >>>' "$FAKE2/.zshrc" && ok "install creates missing ~/.zshrc" || bad "missing/zshrc" "not created"
+[ "$(jq -r '.permissions.allow | index("Bash(jjctx:*)") != null' "$FAKE2/.claude/settings.json")" = true ] && ok "install creates missing settings.json with allow" || bad "missing/settings" "not created"
+
+echo ""
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `bash plugins/agent-helpers-jj/tests/test-agent-helpers-install.sh`
+Expected: FAIL — `agent-helpers-install.sh` doesn't exist, so `run install` errors immediately.
+
+- [ ] **Step 3: Write the installer script**
+
+Create `plugins/agent-helpers-jj/scripts/agent-helpers-install.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Non-interactive install/remove mechanism for agent-helpers-jj.
+# Consent + reporting live in the command markdown; this script is the tested
+# mechanism. All targets come from $HOME so tests can override it.
+#
+# Usage: agent-helpers-install.sh {install|remove}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC="$SCRIPT_DIR/jj-agent-helpers.sh"
+TEMPLATE="$SCRIPT_DIR/../templates/jj-agent-helpers-claudemd.md"
+
+HELPER_DIR="$HOME/.config/jj-agent-helpers"
+HELPER_PATH="$HELPER_DIR/jj-agent-helpers.sh"
+ZSHRC="$HOME/.zshrc"
+CLAUDEMD="$HOME/.claude/CLAUDE.md"
+SETTINGS="$HOME/.claude/settings.json"
+
+Z_BEGIN="# >>> jj-agent-helpers (managed by agent-helpers-jj) >>>"
+Z_END="# <<< jj-agent-helpers <<<"
+C_BEGIN="<!-- BEGIN jj-agent-helpers (agent-helpers-jj) -->"
+C_END="<!-- END jj-agent-helpers -->"
+ALLOW=("Bash(jjctx:*)" "Bash(jjstack:*)" "Bash(jjconflicts:*)" "Bash(jjcheckpoint:*)")
+
+# strip_fence FILE BEGIN END — remove the fenced block and one preceding blank line
+strip_fence() {
+  local file="$1" begin="$2" end="$3" bl el start
+  [ -f "$file" ] || return 0
+  grep -qxF "$begin" "$file" || return 0
+  bl=$(grep -nxF "$begin" "$file" | head -1 | cut -d: -f1)
+  el=$(grep -nxF "$end"   "$file" | head -1 | cut -d: -f1)
+  { [ -n "$bl" ] && [ -n "$el" ] && [ "$el" -ge "$bl" ]; } || return 0
+  start="$bl"
+  if [ "$bl" -gt 1 ] && [ -z "$(sed -n "$((bl-1))p" "$file")" ]; then start=$((bl-1)); fi
+  sed "${start},${el}d" "$file" > "$file.tmp"
+  mv "$file.tmp" "$file"
+}
+
+# append_block FILE BLOCK — ensure trailing newline + one blank separator, then append BLOCK
+append_block() {
+  local file="$1" block="$2"
+  if [ -s "$file" ]; then
+    [ "$(tail -c1 "$file" | wc -l)" -eq 1 ] || printf '\n' >> "$file"
+    printf '\n' >> "$file"
+  else
+    : > "$file"
+  fi
+  printf '%s\n' "$block" >> "$file"
+}
+
+settings_json_array() { printf '%s\n' "${ALLOW[@]}" | jq -R . | jq -s .; }
+
+settings_add() {
+  mkdir -p "$(dirname "$SETTINGS")"
+  [ -f "$SETTINGS" ] || echo '{}' > "$SETTINGS"
+  jq --argjson add "$(settings_json_array)" '
+    .permissions = (.permissions // {})
+    | .permissions.allow = ((.permissions.allow // []) as $cur
+        | $cur + [ $add[] | select(. as $x | ($cur | index($x)) | not) ])
+  ' "$SETTINGS" > "$SETTINGS.tmp"
+  mv "$SETTINGS.tmp" "$SETTINGS"
+}
+
+settings_remove() {
+  [ -f "$SETTINGS" ] || return 0
+  jq --argjson rm "$(settings_json_array)" '
+    (if (.permissions.allow // null) != null then .permissions.allow -= $rm else . end)
+    | (if (.permissions.allow == []) then del(.permissions.allow) else . end)
+    | (if (.permissions == {}) then del(.permissions) else . end)
+  ' "$SETTINGS" > "$SETTINGS.tmp"
+  mv "$SETTINGS.tmp" "$SETTINGS"
+}
+
+cmd_install() {
+  mkdir -p "$HELPER_DIR"
+  cp "$SRC" "$HELPER_PATH"
+  strip_fence "$ZSHRC" "$Z_BEGIN" "$Z_END"
+  append_block "$ZSHRC" "$(printf '%s\nsource %s\n%s' "$Z_BEGIN" "$HELPER_PATH" "$Z_END")"
+  mkdir -p "$(dirname "$CLAUDEMD")"
+  strip_fence "$CLAUDEMD" "$C_BEGIN" "$C_END"
+  append_block "$CLAUDEMD" "$(cat "$TEMPLATE")"
+  settings_add
+}
+
+cmd_remove() {
+  strip_fence "$ZSHRC" "$Z_BEGIN" "$Z_END"
+  strip_fence "$CLAUDEMD" "$C_BEGIN" "$C_END"
+  settings_remove
+  rm -f "$HELPER_PATH"
+  rmdir "$HELPER_DIR" 2>/dev/null || true
+}
+
+case "${1:-}" in
+  install) cmd_install ;;
+  remove)  cmd_remove ;;
+  *) echo "usage: $0 {install|remove}" >&2; exit 2 ;;
+esac
+```
+
+- [ ] **Step 4: Run the installer tests to confirm they pass**
+
+Run: `bash plugins/agent-helpers-jj/tests/test-agent-helpers-install.sh`
+Expected: every line `PASS`, final line `N passed, 0 failed`, exit 0. If the byte-identical `remove` assertions fail, inspect the reported diff — the usual cause is `append_block`'s blank-line handling vs `strip_fence`'s preceding-blank removal not cancelling; they must be exact inverses.
+
+- [ ] **Step 5: Make the scripts executable and commit**
+
+```bash
+chmod +x plugins/agent-helpers-jj/scripts/agent-helpers-install.sh
+jj describe -m "feat(agent-helpers-jj): idempotent, reversible installer + tests
+
+agent-helpers-install.sh install/remove edits ~/.zshrc, ~/.claude/CLAUDE.md,
+and ~/.claude/settings.json behind marker fences (known-value jq dedupe for
+JSON), reading all paths from \$HOME. Tests assert idempotent re-run, byte
+round-trip for the two text files, semantic round-trip for JSON, and
+missing-file creation — against a fake \$HOME."
+jj new
+```
+
+---
+
+### Task 4: Setup + remove commands (thin wrappers) + restart UX
+
+**Files:**
+- Create: `plugins/agent-helpers-jj/commands/agent-helpers-setup.md`
+- Create: `plugins/agent-helpers-jj/commands/agent-helpers-remove.md`
+
+**Interfaces:**
+- Consumes: `scripts/agent-helpers-install.sh` (Task 3) via `${CLAUDE_PLUGIN_ROOT}`.
+- Produces: user-facing `/agent-helpers-setup` and `/agent-helpers-remove` commands.
+
+- [ ] **Step 1: Create the setup command**
+
+Create `plugins/agent-helpers-jj/commands/agent-helpers-setup.md`:
+
+```markdown
+---
+description: Install machine-level jj query helpers (jjctx, jjstack, …) for agents
+allowed-tools: Bash(jj:*), Bash(bash:*), Bash(cat:*), Bash(grep:*), Read
+---
+
+**CRITICAL: This is a jj (Jujutsu) plugin. You MUST NOT use ANY raw git commands — not even for context discovery. Always use jj equivalents. The only exceptions are `jj git` subcommands and `gh` CLI.**
+
+## Your Task
+
+Install the read-only jj query helpers **machine-wide** (not per-project). This writes to three files under the user's home directory, so you MUST get consent first.
+
+### Step 1: Explain and get consent
+
+Tell the user this will:
+- copy the helper script to `~/.config/jj-agent-helpers/jj-agent-helpers.sh`
+- add a `source` line to `~/.zshrc` (fenced, removable)
+- add a one-line catalog block to `~/.claude/CLAUDE.md`
+- add six `Bash(jj…:*)` entries to `permissions.allow` in `~/.claude/settings.json`
+
+Ask for explicit confirmation before proceeding. If the user declines, print the four changes they could make by hand (the `source` line and the fence markers are in `${CLAUDE_PLUGIN_ROOT}/scripts/agent-helpers-install.sh`) and stop without changing anything.
+
+### Step 2: Run the installer
+
+On confirmation:
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/agent-helpers-install.sh" install
+```
+The script is idempotent — re-running it will not create duplicates.
+
+### Step 3: Report and remind
+
+Report what changed (the four targets above). Then, prominently:
+
+> **Restart Claude Code (or start a new session) for the helpers to take effect.** They become callable only after the next session regenerates its shell snapshot; the permission allowlist also applies from the next session.
+
+Warn if any of the names `jjctx`, `jjstack`, `jjfiles`, `jjconflicts`, `jjcheckpoint`, `jjclean`, or `_jjq` were already defined in the user's shell (the source line will shadow them). Remove with `/agent-helpers-remove`.
+```
+
+- [ ] **Step 2: Create the remove command**
+
+Create `plugins/agent-helpers-jj/commands/agent-helpers-remove.md`:
+
+```markdown
+---
+description: Remove the machine-level jj query helpers installed by agent-helpers-jj
+allowed-tools: Bash(jj:*), Bash(bash:*), Read
+---
+
+**CRITICAL: This is a jj (Jujutsu) plugin. You MUST NOT use ANY raw git commands — not even for context discovery. Always use jj equivalents. The only exceptions are `jj git` subcommands and `gh` CLI.**
+
+## Your Task
+
+Reverse the machine-level install performed by `/agent-helpers-setup`.
+
+### Step 1: Run the uninstaller
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/agent-helpers-install.sh" remove
+```
+This is idempotent and safe to run even if nothing is installed. It removes the fenced blocks from `~/.zshrc` and `~/.claude/CLAUDE.md`, filters the six values out of `~/.claude/settings.json`, and deletes `~/.config/jj-agent-helpers/jj-agent-helpers.sh`.
+
+### Step 2: Report and remind
+
+Report the four reversals. Then remind:
+
+> **Restart Claude Code (or start a new session)** so the removed functions and allowlist entries stop applying.
+```
+
+- [ ] **Step 3: Verify frontmatter and plugin-root references**
+
+Run:
+```bash
+head -4 plugins/agent-helpers-jj/commands/agent-helpers-setup.md
+grep -c 'CLAUDE_PLUGIN_ROOT' plugins/agent-helpers-jj/commands/agent-helpers-setup.md plugins/agent-helpers-jj/commands/agent-helpers-remove.md
+```
+Expected: setup frontmatter shows `description:` + `allowed-tools:`; each command references `${CLAUDE_PLUGIN_ROOT}` at least once.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "feat(agent-helpers-jj): /agent-helpers-setup and /agent-helpers-remove
+
+Thin command wrappers over agent-helpers-install.sh: setup gates the
+machine-level write behind explicit consent, invokes the installer, reports
+the four targets, and prominently reminds the user to restart so the shell
+snapshot regenerates. Remove reverses it."
+jj new
+```
+
+---
+
+## Verification (whole plan)
+
+1. `bash plugins/agent-helpers-jj/tests/test-jj-agent-helpers.sh` — all PASS, `0 failed`.
+2. `bash plugins/agent-helpers-jj/tests/test-agent-helpers-install.sh` — all PASS, `0 failed` (idempotency + byte/semantic round-trips + missing-file creation).
+3. `jq -e '.plugins[] | select(.name=="agent-helpers-jj")' .claude-plugin/marketplace.json` — exits 0.
+4. `grep -rl -- '--ignore-working-copy' plugins/agent-helpers-jj/scripts/jj-agent-helpers.sh` — hits (the invariant is present in source).
+5. Manual smoke (optional, real `$HOME`): run `/agent-helpers-setup`, confirm the three fenced/known-value markers appear, restart, then confirm an agent can call `jjctx` prompt-free; run `/agent-helpers-remove` and confirm the markers are gone.
+6. Read the two command files once for coherence — consent gate present in setup, restart reminder present in both.

--- a/docs/specs/2026-07-14-agent-helpers-jj-design.md
+++ b/docs/specs/2026-07-14-agent-helpers-jj-design.md
@@ -1,0 +1,174 @@
+# agent-helpers-jj — jj query helpers for agents (design)
+
+**Date:** 2026-07-14
+**Status:** Implemented (reduced to four helpers during execution — see Revision).
+
+> **Revision (2026-07-14, during implementation):** reduced from six helpers to **four**. TDD proved that `--ignore-working-copy` makes a helper read jj's *last snapshot*, not live disk edits, so the two working-copy helpers (`jjclean`, `jjfiles`) return stale "am I clean / what changed?" answers. They were cut. The four shipped helpers — `jjctx`, `jjstack`, `jjconflicts`, `jjcheckpoint` — query committed / op-log state where the flag is strictly correct. The allowlist is correspondingly four values (`Bash(jjctx:*)`, `Bash(jjstack:*)`, `Bash(jjconflicts:*)`, `Bash(jjcheckpoint:*)`). Sections below that say "six" reflect the original design; the code is authoritative.
+
+## Goal
+
+Give agents (and their subagents) a small set of **read-only jj query shortcuts** that bake in `--ignore-working-copy`, so concurrent-workspace fan-flames runs never race on the working-copy snapshot lock. The flag is the one thing agents reliably get wrong — the natural form (`jj log -r @ -T json`) omits it, and the resulting snapshot race is non-obvious and non-local. A wrapper *guarantees* the flag where prose guidance only suggests it.
+
+This is deliberately scoped to the **correctness core**. Mutation wrappers, workspace helpers, and a `jjhelp` catalog were considered and cut (see Non-Goals): they compete with the agent's existing jj fluency and lose, and add discovery + permission surface for little gain.
+
+## Scope decision (why this shape)
+
+From an agent's perspective, alias layers over a command language the agent already speaks are mostly negative value — indirection to learn and verify against a thing it can already write. The exception is discipline the agent can't easily self-correct: `--ignore-working-copy` on read-only queries in a concurrent context. So the library is exactly the read-only queries where that flag matters, and nothing else.
+
+## Architecture
+
+A **new, single-purpose plugin: `agent-helpers-jj`**, owning everything machine-level.
+
+Rationale: the install is machine-level (writes under `$HOME`), whereas `project-setup-jj` is purely project-scoped — every one of its writes targets `$(jj root)/.claude/…`; its only `~/` references are read-only plugin-cache paths. An audit confirmed nothing in `project-setup-jj` is machine-level, so **nothing moves out of it**. Putting a global installer inside a project-scoped plugin would be the sole exception to that plugin's clean identity, so the helpers get their own home. This also matches the repo's aesthetic of small, single-purpose jj plugins, and lets a user install *just* the helpers.
+
+### Files
+
+```
+plugins/agent-helpers-jj/
+  .claude-plugin/plugin.json                     # manifest (repo convention: under .claude-plugin/)
+  README.md
+  LICENSE
+  scripts/jj-agent-helpers.sh                    # the six functions + _jjq
+  commands/agent-helpers-setup.md                # machine-level install
+  commands/agent-helpers-remove.md               # idempotent uninstall
+  templates/jj-agent-helpers-claudemd.md         # the inline CLAUDE.md catalog snippet
+  tests/
+    test-jj-agent-helpers.sh                     # unit: the six functions in a scratch repo
+    test-agent-helpers-install.sh                # installer: setup→setup→remove against a fake $HOME
+```
+
+Plus an entry in the repo marketplace manifest `./.claude-plugin/marketplace.json` registering the new plugin.
+
+### Runtime dependency: the shell snapshot (must be documented for users)
+
+The agent's Bash tool runs a non-interactive shell that replays a Claude Code **shell snapshot** (`~/.claude/shell-snapshots/snapshot-*.sh`), regenerated at session start. A function added to `~/.zshrc` becomes callable by the agent **only after the next session regenerates the snapshot** — i.e. after a restart. So `agent-helpers-setup` must tell the user, prominently: *the helpers (and their prompt-free allowlist) take effect only after you restart Claude Code / start a new session.* Without a restart, `jjctx` is both "command not found" and un-allowlisted — a baffling double failure if undocumented. (This same mechanism is what makes the permission claim below hold: the matcher sees the literal token `jjctx` replayed from the snapshot, not the expanded `jj …`.)
+
+## Components
+
+### 1. `scripts/jj-agent-helpers.sh` — the function library
+
+Target shell: **zsh** (the source line is added to `~/.zshrc`; bash support is a Non-Goal for v1). A private `_jjq` backs every function so the `--ignore-working-copy` flag exists in exactly one place.
+
+```zsh
+# _jjq: read-only jj — never snapshots the working copy; safe under concurrent workspaces.
+_jjq() { jj --ignore-working-copy "$@"; }
+
+# jjctx — current change as JSON (orientation)
+jjctx()   { _jjq log -r @ --no-graph -T 'json(self) ++ "\n"'; }
+
+# jjstack — local changes ahead of trunk, JSON lines
+jjstack() { _jjq log -r 'trunk()..@' --no-graph -T 'json(self) ++ "\n"'; }
+
+# jjfiles [rev] — changed files in <rev|@> as JSON {path,status}
+jjfiles() { _jjq diff -r "${1:-@}" -T '"{ \"path\": " ++ self.path().display().escape_json() ++ ", \"status\": " ++ self.status().escape_json() ++ " }\n"'; }
+
+# jjclean — exit 0 if the working copy has no changes (a commit/verification gate)
+jjclean() { [[ "$(_jjq log -r @ --no-graph -T 'if(empty,"1","0")')" == 1 ]]; }
+
+# jjconflicts — exit 0 if clean; 1 (+ prints files) if conflicts; >1 on a real error.
+# On jj 0.43, `jj resolve --list` exits 0 (and lists) when conflicts exist, and exits 2
+# with "No conflicts found…" when clean. We distinguish that from other failures (not a
+# jj repo, jj missing) so an agent's pre-commit gate can't read "clean" from a broken env.
+# The plan MUST re-verify the exit codes on the target jj version before relying on them.
+jjconflicts() {
+  local out rc
+  out="$(_jjq resolve --list 2>/dev/null)"; rc=$?
+  if (( rc == 0 )); then
+    [[ -z "$out" ]] && return 0        # no conflicts listed
+    print -r -- "$out"; return 1        # conflicts present
+  fi
+  (( rc == 2 )) && return 0            # "No conflicts found" — clean
+  print -r -- "jjconflicts: jj error (rc=$rc)" >&2; return "$rc"   # real failure — surfaced
+}
+
+# jjcheckpoint — current operation id (for a fan-flames ledger start-op)
+jjcheckpoint() { _jjq op log -n1 --no-graph -T 'id.short()'; }
+```
+
+All six templates are verified working against jj 0.43. Contract per function: JSON on stdout (`jjctx`/`jjstack`/`jjfiles`/`jjcheckpoint`) or a meaningful exit code (`jjclean`, `jjconflicts`).
+
+### 2. `commands/agent-helpers-setup.md` — machine-level install
+
+A one-time, per-machine, **consent-gated, idempotent** install. It writes to three files under `$HOME` plus one script — so it presents **one consent prompt listing all four targets** (`~/.zshrc`, `~/.claude/CLAUDE.md`, `~/.claude/settings.json`, `~/.config/jj-agent-helpers/`) before touching anything. On decline, it prints exactly what the user would need to add by hand and makes no changes. The four steps, each reversible:
+
+1. **Copy the script** → `~/.config/jj-agent-helpers/jj-agent-helpers.sh` (stable path; re-copied on re-run / plugin update). `mkdir -p` the dir.
+2. **Source line in `~/.zshrc`** — add the fenced block idempotently (replace in place if the fence already exists; append otherwise). If `~/.zshrc` doesn't exist, create it.
+3. **CLAUDE.md catalog** → write the fenced snippet from `templates/jj-agent-helpers-claudemd.md` into `~/.claude/CLAUDE.md` (replace the fence in place if present; append otherwise). Create the file (and `~/.claude/`) if absent.
+4. **Permission allowlist** → add the six helper entries to `permissions.allow` in `~/.claude/settings.json` via `jq`, deduped. The filter MUST tolerate a missing file and a missing key — `(.permissions.allow // [])`, then rebuild `.permissions.allow` as the deduped union. Create `settings.json` as `{"permissions":{"allow":[...]}}` if absent. Pattern form: colon-star (`Bash(jjctx:*)`, …) — tighter than the repo's existing glob form (`Bash(jj log*)`, which would also match `jjctxfoo`). **The plan must confirm the no-arg case (`jjctx` with no arguments) actually auto-approves under colon-star; if it surprisingly requires an argument, fall back to the exact form `Bash(jjctx)` for the five no-arg helpers and colon-star only for `jjfiles`.**
+
+Before sourcing, the command checks whether any of the seven names (`_jjq`, `jjctx`, `jjstack`, `jjfiles`, `jjconflicts`, `jjcheckpoint`, `jjclean`) already exist as a function or alias in the user's shell, and warns about any collision (the source would shadow the user's own). It verifies `jj` is available, and ends by reporting a summary of what changed **and reminding the user to restart Claude Code** (see Runtime dependency above).
+
+### 3. `commands/agent-helpers-remove.md` — uninstall
+
+Reverses all four steps idempotently: delete the fenced block from `~/.zshrc` and `~/.claude/CLAUDE.md`, filter the six known values out of `~/.claude/settings.json` via `jq`, and remove `~/.config/jj-agent-helpers/jj-agent-helpers.sh` (optionally the now-empty dir). Safe to run when nothing is installed.
+
+### 4. Marker conventions (identifiable / reversible)
+
+Each home file gets a distinct, greppable marker; the scheme differs because two files allow comments and one doesn't.
+
+**`~/.zshrc`** — sentinel comment fence (conda-style):
+```zsh
+# >>> jj-agent-helpers (managed by agent-helpers-jj) >>>
+source ~/.config/jj-agent-helpers/jj-agent-helpers.sh
+# <<< jj-agent-helpers <<<
+```
+
+**`~/.claude/CLAUDE.md`** — HTML-comment fence (invisible when rendered, still greppable):
+```markdown
+<!-- BEGIN jj-agent-helpers (agent-helpers-jj) -->
+**jj query helpers** (run in jj repos; all use `--ignore-working-copy`, safe under concurrent workspaces):
+`jjctx` current change (one JSON object) · `jjstack` local changes vs trunk (JSONL) · `jjfiles [rev]` changed files (JSONL) · `jjconflicts` (exit 0 = clean) · `jjcheckpoint` op id · `jjclean` (exit 0 = nothing to commit)
+<!-- END jj-agent-helpers -->
+```
+
+**`~/.claude/settings.json`** — JSON has no comments, so no fence. The six entries in `permissions.allow` are **self-identifying by value** — `Bash(jjctx:*)`, `Bash(jjstack:*)`, `Bash(jjfiles:*)`, `Bash(jjconflicts:*)`, `Bash(jjcheckpoint:*)`, `Bash(jjclean:*)`. Setup adds each only if absent (dedupe); remove filters exactly those six out. Both operations use `jq` so the rest of the file is untouched.
+
+**Exact insertion bytes.** The plan must pin the exact fence bytes — each fenced block is preceded by exactly one blank line (unless the file is empty/new) and the block itself has no trailing blank line — so re-run replacement is exact and remove restores the two *text* files byte-clean. The BEGIN/END fence means re-run **blindly replaces** the CLAUDE.md block; this deliberately omits the `hash:<hex>` update-detection marker that `project-setup-jj`'s `CLAUDE.md.template` uses. That's an intentional divergence (the block is small and always safe to overwrite), noted here so a reviewer doesn't read it as an oversight.
+
+What the markers buy: idempotent setup (no accumulating duplicate blocks), surgical remove (deletes exactly what the plugin owns), and human auditability (`grep jj-agent-helpers ~/.zshrc ~/.claude/CLAUDE.md`; the "managed by agent-helpers-jj" tag names the source).
+
+## Why the allowlist is load-bearing (not polish)
+
+The Bash permission matcher evaluates the *typed* command string (`jjctx`), not the expanded `jj --ignore-working-copy log …`. So helper names are opaque to any existing `Bash(jj …)` allowlist. `project-setup-jj` already allowlists `Bash(jj log*)` etc., so raw `jj log` runs **prompt-free today** — but an un-allowlisted `jjctx` would *prompt*, and the agent would fall back to raw jj, losing the `--ignore-working-copy` enforcement that is the feature's entire reason to exist. Step 4 (allowlisting the six read-only helpers) is therefore required for the feature to work, not a convenience. The helpers are read-only and side-effect-free, so auto-approving them is safe.
+
+## Discoverability
+
+No `jjhelp`. With six functions used regularly by a fan-flames orchestrator, the earlier trade analysis favors **inlining the catalog** in `~/.claude/CLAUDE.md` over a `jjhelp` indirection (jjhelp wins for large, occasionally-used catalogs; inline wins for a small, frequently-used set). The inline catalog is the CLAUDE.md fenced block above.
+
+## Testing
+
+Two bash harnesses, in the style of `project-setup-jj/tests/test-statusline-jj.sh`.
+
+**`tests/test-jj-agent-helpers.sh` — unit tests for the functions.** Creates a scratch jj repo, sources `jj-agent-helpers.sh`, and asserts:
+
+- `jjctx` emits a JSON object containing the current `change_id`.
+- `jjstack` emits JSON lines for changes ahead of trunk. **The harness must create a `main`/trunk bookmark at `@` first** (as `test-statusline-jj.sh` sets up `main@origin`) — in a fresh repo `trunk()` resolves to the root commit, so `trunk()..@` is never empty and the "empty when `@` is trunk" assertion is only meaningful with a real trunk bookmark in place.
+- `jjfiles` emits `{path,status}` JSON lines for a modified file.
+- `jjclean` exits 0 on an empty `@`, non-zero when `@` has a diff.
+- `jjconflicts` exits 0 (clean) on a conflict-free repo; the plan should also cover the broken-env path (non-jj dir → non-zero, not a false "clean").
+- `jjcheckpoint` prints a short op id.
+- **Race-safety invariant:** every read-only function body contains `--ignore-working-copy` (grep the script — guards against a future edit dropping the flag).
+- **Drift guard:** the function names referenced in `templates/jj-agent-helpers-claudemd.md` exactly match the *public* functions defined in `jj-agent-helpers.sh` — **excluding `_jjq`**, which is a private helper intentionally absent from the catalog (a naive name-set comparison would false-fail on it).
+
+**`tests/test-agent-helpers-install.sh` — installer idempotency + reversibility (the real risk surface).** Runs the setup and remove logic against a **fake `$HOME`** (a temp dir with a seeded `~/.zshrc`, `~/.claude/CLAUDE.md`, and `~/.claude/settings.json`), asserting:
+
+- setup produces exactly one fenced block in each text file and the six values in `settings.json`;
+- **setup run twice is a no-op** — no duplicate fences, no duplicate allowlist values;
+- setup then remove leaves `~/.zshrc` and `~/.claude/CLAUDE.md` **byte-identical** to their pre-install content, and `~/.claude/settings.json` **semantically identical** (jq-normalized — see Verification note), with the script removed;
+- missing-file paths: setup against an absent `~/.zshrc` / `CLAUDE.md` / `settings.json` (and a `settings.json` with no `permissions.allow` key) all succeed and produce valid results.
+
+## Non-Goals (YAGNI)
+
+- **Mutation wrappers** (`jjd`, `jjc`, `jjresolve`, `jjfix`, `jjrewind`) — agents are fluent in `jj describe -m`, etc.; the safe non-interactive forms are already enforced by the fan-flames dispatch-prompt guidance merged in PR #64. Near-zero agent value.
+- **Fan-flames workspace helpers** (`jjws_add`, `jjws_forget`, `jjrootkey`) — `fan-flames.md` already inlines the workspace-add/forget commands with the `/tmp/jj-workspaces` convention, and the orchestrator has them in context.
+- **`jjhelp` catalog** — see Discoverability; inline wins at this size.
+- **Per-project function variants** and any auto-`jj root` on shell init — the functions are global by nature (sourced from `~/.zshrc`) and call `jj`, erroring harmlessly outside a jj repo.
+- **bash support** (`~/.bashrc`, POSIX-only bodies) — v1 targets zsh, matching the user's shell and the plugin's install target. Revisit if there's demand.
+- **Folding into `project-setup-jj`** — rejected to preserve that plugin's project-only identity.
+
+## Verification (whole feature)
+
+1. Both harnesses pass — `tests/test-jj-agent-helpers.sh` (functions) and `tests/test-agent-helpers-install.sh` (installer idempotency + reversibility).
+2. `agent-helpers-setup` on a clean machine produces exactly the fenced blocks / known values; re-running is a no-op (no duplicates).
+3. `agent-helpers-remove` restores the two **text** files (`~/.zshrc`, `~/.claude/CLAUDE.md`) **byte-identical** to their pre-install state and removes the script. `~/.claude/settings.json` is restored **semantically identical** (not byte-identical): it round-trips through `jq`, which reserializes the whole document (indentation and key order are jq's, not the original's) — only the six values are logically added/removed, the rest of the settings are preserved.
+4. In a live session **after install + restart** (the restart regenerates the shell snapshot — see Runtime dependency), an agent can call `jjctx` prompt-free (allowlist working) and the call carries `--ignore-working-copy` semantics — no new working-copy snapshot is written to the shared operation log (the actual serialization point across workspaces; each workspace snapshots its own working copy, and the flag skips that op-log write).

--- a/plugins/agent-helpers-jj/.claude-plugin/plugin.json
+++ b/plugins/agent-helpers-jj/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "agent-helpers-jj",
+  "description": "Machine-level jj (Jujutsu) query shortcuts for agents — read-only helpers that bake in --ignore-working-copy so concurrent workspaces don't race",
+  "author": {
+    "name": "muloka",
+    "email": "muloka@users.noreply.github.com"
+  }
+}

--- a/plugins/agent-helpers-jj/LICENSE
+++ b/plugins/agent-helpers-jj/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/agent-helpers-jj/README.md
+++ b/plugins/agent-helpers-jj/README.md
@@ -1,0 +1,39 @@
+# agent-helpers-jj
+
+Machine-level jj (Jujutsu) query shortcuts for agents. Four read-only shell
+functions, each wrapping `jj --ignore-working-copy …`, so an agent orienting
+inside a jj repo never writes a working-copy snapshot to the shared operation
+log — the serialization point that concurrent workspaces (e.g. fan-flames)
+would otherwise race on.
+
+| Function | Output | Purpose |
+|---|---|---|
+| `jjctx` | one JSON object | current change (orientation) |
+| `jjstack` | JSONL | local changes ahead of trunk |
+| `jjconflicts` | exit code | 0 = clean, 1 = conflicts (printed), >1 = jj error |
+| `jjcheckpoint` | short op id | for a fan-flames ledger `start-op` |
+
+These are **structural** queries — they read committed / op-log state, where
+`--ignore-working-copy` is strictly correct. Two working-copy helpers
+(`jjclean`, `jjfiles`) were considered and cut: under `--ignore-working-copy`
+they report the last *snapshot*, not live edits, so they'd give stale answers
+to "am I clean / what changed?". For that, use plain `jj status` / `jj diff`.
+
+## Install
+
+```
+/agent-helpers-setup
+```
+
+This is a **machine-level, one-time** install (not per-project). It:
+1. copies the helper script to `~/.config/jj-agent-helpers/jj-agent-helpers.sh`;
+2. adds a `source` line to `~/.zshrc` (consent-gated);
+3. adds a one-line catalog to `~/.claude/CLAUDE.md` so agents know the helpers exist;
+4. allowlists the six helpers in `~/.claude/settings.json` so they run prompt-free.
+
+**Restart Claude Code afterward** — the helpers become callable only once the next
+session regenerates its shell snapshot.
+
+Uninstall with `/agent-helpers-remove` (reverses all four steps).
+
+Requires zsh and `jj`. Bash shells are not supported in this version.

--- a/plugins/agent-helpers-jj/commands/agent-helpers-remove.md
+++ b/plugins/agent-helpers-jj/commands/agent-helpers-remove.md
@@ -1,0 +1,23 @@
+---
+description: Remove the machine-level jj query helpers installed by agent-helpers-jj
+allowed-tools: Bash(jj:*), Bash(bash:*), Read
+---
+
+**CRITICAL: This is a jj (Jujutsu) plugin. You MUST NOT use ANY raw git commands — not even for context discovery. Always use jj equivalents. The only exceptions are `jj git` subcommands and `gh` CLI.**
+
+## Your Task
+
+Reverse the machine-level install performed by `/agent-helpers-setup`.
+
+### Step 1: Run the uninstaller
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/agent-helpers-install.sh" remove
+```
+This is idempotent and safe to run even if nothing is installed. It removes the fenced blocks from `~/.zshrc` and `~/.claude/CLAUDE.md`, filters the four helper values out of `~/.claude/settings.json`, and deletes `~/.config/jj-agent-helpers/jj-agent-helpers.sh`.
+
+### Step 2: Report and remind
+
+Report the four reversals. Then remind:
+
+> **Restart Claude Code (or start a new session)** so the removed functions and allowlist entries stop applying.

--- a/plugins/agent-helpers-jj/commands/agent-helpers-setup.md
+++ b/plugins/agent-helpers-jj/commands/agent-helpers-setup.md
@@ -1,0 +1,36 @@
+---
+description: Install machine-level jj query helpers (jjctx, jjstack, jjconflicts, jjcheckpoint) for agents
+allowed-tools: Bash(jj:*), Bash(bash:*), Bash(cat:*), Bash(grep:*), Read
+---
+
+**CRITICAL: This is a jj (Jujutsu) plugin. You MUST NOT use ANY raw git commands — not even for context discovery. Always use jj equivalents. The only exceptions are `jj git` subcommands and `gh` CLI.**
+
+## Your Task
+
+Install the read-only jj query helpers **machine-wide** (not per-project). This writes to three files under the user's home directory, so you MUST get consent first.
+
+### Step 1: Explain and get consent
+
+Tell the user this will:
+- copy the helper script to `~/.config/jj-agent-helpers/jj-agent-helpers.sh`
+- add a `source` line to `~/.zshrc` (fenced, removable)
+- add a one-line catalog block to `~/.claude/CLAUDE.md`
+- add four `Bash(jj…:*)` entries to `permissions.allow` in `~/.claude/settings.json`
+
+Ask for explicit confirmation before proceeding. If the user declines, print the four changes they could make by hand (the `source` line and the fence markers are in `${CLAUDE_PLUGIN_ROOT}/scripts/agent-helpers-install.sh`) and stop without changing anything.
+
+### Step 2: Run the installer
+
+On confirmation:
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/agent-helpers-install.sh" install
+```
+The script is idempotent — re-running it will not create duplicates.
+
+### Step 3: Report and remind
+
+Report what changed (the four targets above). Then, prominently:
+
+> **Restart Claude Code (or start a new session) for the helpers to take effect.** They become callable only after the next session regenerates its shell snapshot; the permission allowlist also applies from the next session.
+
+Warn if any of the names `jjctx`, `jjstack`, `jjconflicts`, `jjcheckpoint`, or `_jjq` were already defined in the user's shell (the source line will shadow them). Remove with `/agent-helpers-remove`.

--- a/plugins/agent-helpers-jj/scripts/agent-helpers-install.sh
+++ b/plugins/agent-helpers-jj/scripts/agent-helpers-install.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Non-interactive install/remove mechanism for agent-helpers-jj.
+# Consent + reporting live in the command markdown; this script is the tested
+# mechanism. All targets come from $HOME so tests can override it.
+#
+# Usage: agent-helpers-install.sh {install|remove}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC="$SCRIPT_DIR/jj-agent-helpers.sh"
+TEMPLATE="$SCRIPT_DIR/../templates/jj-agent-helpers-claudemd.md"
+
+HELPER_DIR="$HOME/.config/jj-agent-helpers"
+HELPER_PATH="$HELPER_DIR/jj-agent-helpers.sh"
+ZSHRC="$HOME/.zshrc"
+CLAUDEMD="$HOME/.claude/CLAUDE.md"
+SETTINGS="$HOME/.claude/settings.json"
+
+Z_BEGIN="# >>> jj-agent-helpers (managed by agent-helpers-jj) >>>"
+Z_END="# <<< jj-agent-helpers <<<"
+C_BEGIN="<!-- BEGIN jj-agent-helpers (agent-helpers-jj) -->"
+C_END="<!-- END jj-agent-helpers -->"
+ALLOW=("Bash(jjctx:*)" "Bash(jjstack:*)" "Bash(jjconflicts:*)" "Bash(jjcheckpoint:*)")
+
+# strip_fence FILE BEGIN END — remove the fenced block and one preceding blank line
+strip_fence() {
+  local file="$1" begin="$2" end="$3" bl el start
+  [ -f "$file" ] || return 0
+  grep -qxF "$begin" "$file" || return 0
+  bl=$(grep -nxF "$begin" "$file" | head -1 | cut -d: -f1)
+  el=$(grep -nxF "$end"   "$file" | head -1 | cut -d: -f1)
+  { [ -n "$bl" ] && [ -n "$el" ] && [ "$el" -ge "$bl" ]; } || return 0
+  start="$bl"
+  if [ "$bl" -gt 1 ] && [ -z "$(sed -n "$((bl-1))p" "$file")" ]; then start=$((bl-1)); fi
+  sed "${start},${el}d" "$file" > "$file.tmp"
+  mv "$file.tmp" "$file"
+}
+
+# append_block FILE BLOCK — ensure trailing newline + one blank separator, then append BLOCK
+append_block() {
+  local file="$1" block="$2"
+  if [ -s "$file" ]; then
+    [ "$(tail -c1 "$file" | wc -l)" -eq 1 ] || printf '\n' >> "$file"
+    printf '\n' >> "$file"
+  else
+    : > "$file"
+  fi
+  printf '%s\n' "$block" >> "$file"
+}
+
+settings_json_array() { printf '%s\n' "${ALLOW[@]}" | jq -R . | jq -s .; }
+
+settings_add() {
+  mkdir -p "$(dirname "$SETTINGS")"
+  [ -f "$SETTINGS" ] || echo '{}' > "$SETTINGS"
+  jq --argjson add "$(settings_json_array)" '
+    .permissions = (.permissions // {})
+    | .permissions.allow = ((.permissions.allow // []) as $cur
+        | $cur + [ $add[] | select(. as $x | ($cur | index($x)) | not) ])
+  ' "$SETTINGS" > "$SETTINGS.tmp"
+  mv "$SETTINGS.tmp" "$SETTINGS"
+}
+
+settings_remove() {
+  [ -f "$SETTINGS" ] || return 0
+  jq --argjson rm "$(settings_json_array)" '
+    (if (.permissions.allow // null) != null then .permissions.allow -= $rm else . end)
+    | (if (.permissions.allow == []) then del(.permissions.allow) else . end)
+    | (if (.permissions == {}) then del(.permissions) else . end)
+  ' "$SETTINGS" > "$SETTINGS.tmp"
+  mv "$SETTINGS.tmp" "$SETTINGS"
+}
+
+cmd_install() {
+  mkdir -p "$HELPER_DIR"
+  cp "$SRC" "$HELPER_PATH"
+  strip_fence "$ZSHRC" "$Z_BEGIN" "$Z_END"
+  append_block "$ZSHRC" "$(printf '%s\nsource %s\n%s' "$Z_BEGIN" "$HELPER_PATH" "$Z_END")"
+  mkdir -p "$(dirname "$CLAUDEMD")"
+  strip_fence "$CLAUDEMD" "$C_BEGIN" "$C_END"
+  append_block "$CLAUDEMD" "$(cat "$TEMPLATE")"
+  settings_add
+}
+
+cmd_remove() {
+  strip_fence "$ZSHRC" "$Z_BEGIN" "$Z_END"
+  strip_fence "$CLAUDEMD" "$C_BEGIN" "$C_END"
+  settings_remove
+  rm -f "$HELPER_PATH"
+  rmdir "$HELPER_DIR" 2>/dev/null || true
+}
+
+case "${1:-}" in
+  install) cmd_install ;;
+  remove)  cmd_remove ;;
+  *) echo "usage: $0 {install|remove}" >&2; exit 2 ;;
+esac

--- a/plugins/agent-helpers-jj/scripts/jj-agent-helpers.sh
+++ b/plugins/agent-helpers-jj/scripts/jj-agent-helpers.sh
@@ -1,0 +1,34 @@
+# jj query helpers for agents. Sourced from ~/.zshrc by agent-helpers-jj.
+# Bodies are bash+zsh compatible (printf / [ ] / local), so the bash test
+# harness can source them while they install into zsh.
+#
+# _jjq is the single place the --ignore-working-copy flag lives: read-only
+# queries must never snapshot the working copy (that writes a new operation to
+# the shared op-log, the serialization point concurrent jj workspaces race on).
+
+_jjq() { jj --ignore-working-copy "$@"; }
+
+# jjctx — current change as one JSON object (orientation)
+jjctx() { _jjq log -r @ --no-graph -T 'json(self) ++ "\n"'; }
+
+# jjstack — local changes ahead of trunk, JSON lines
+jjstack() { _jjq log -r 'trunk()..@' --no-graph -T 'json(self) ++ "\n"'; }
+
+# jjconflicts — 0 = clean, 1 = conflicts (printed), >1 = real jj error.
+# On jj 0.43 `jj resolve --list` exits 0 (and lists) when conflicts exist, and
+# exits 2 ("No conflicts found…") when clean. Distinguishing exit 2 from other
+# errors stops an agent reading "clean" from a broken env (not a repo / jj gone).
+jjconflicts() {
+  local out rc
+  out="$(_jjq resolve --list 2>/dev/null)"; rc=$?
+  if [ "$rc" -eq 0 ]; then
+    [ -z "$out" ] && return 0
+    printf '%s\n' "$out"; return 1
+  fi
+  [ "$rc" -eq 2 ] && return 0
+  printf 'jjconflicts: jj error (rc=%s)\n' "$rc" >&2
+  return "$rc"
+}
+
+# jjcheckpoint — current operation id (for a fan-flames ledger start-op)
+jjcheckpoint() { _jjq op log -n1 --no-graph -T 'id.short()'; }

--- a/plugins/agent-helpers-jj/templates/jj-agent-helpers-claudemd.md
+++ b/plugins/agent-helpers-jj/templates/jj-agent-helpers-claudemd.md
@@ -1,0 +1,3 @@
+<!-- BEGIN jj-agent-helpers (agent-helpers-jj) -->
+**jj query helpers** (structural, read-only; all use `--ignore-working-copy`, safe under concurrent workspaces): `jjctx` current change (one JSON object) · `jjstack` local changes vs trunk (JSONL) · `jjconflicts` (exit 0 = clean, 1 = conflicts) · `jjcheckpoint` op id
+<!-- END jj-agent-helpers -->

--- a/plugins/agent-helpers-jj/tests/test-agent-helpers-install.sh
+++ b/plugins/agent-helpers-jj/tests/test-agent-helpers-install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installer idempotency + reversibility against a FAKE $HOME.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL="$SCRIPT_DIR/../scripts/agent-helpers-install.sh"
+
+pass=0; fail=0
+ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL: $1 — $2"; fail=$((fail+1)); }
+
+FAKE="$(mktemp -d)"
+FAKE2="$(mktemp -d)"
+trap 'rm -rf "$FAKE" "$FAKE2"' EXIT
+
+# seed a realistic home
+mkdir -p "$FAKE/.claude"
+printf '# my zshrc\nexport FOO=1\n' > "$FAKE/.zshrc"
+printf '# My global instructions\n\nPrefer jj over git.\n' > "$FAKE/.claude/CLAUDE.md"
+printf '{\n  "permissions": {\n    "allow": ["Bash(ls:*)"]\n  }\n}\n' > "$FAKE/.claude/settings.json"
+
+ZSHRC_ORIG="$(cat "$FAKE/.zshrc")"
+CLAUDE_ORIG="$(cat "$FAKE/.claude/CLAUDE.md")"
+SETTINGS_ORIG_SEMANTIC="$(jq -S . "$FAKE/.claude/settings.json")"
+
+run() { HOME="$FAKE" bash "$INSTALL" "$1"; }
+
+# --- install ---
+run install
+grep -qxF '# >>> jj-agent-helpers (managed by agent-helpers-jj) >>>' "$FAKE/.zshrc" && ok "zshrc fence present" || bad "install/zshrc" "no fence"
+grep -qF 'source' "$FAKE/.zshrc" && grep -qF '.config/jj-agent-helpers/jj-agent-helpers.sh' "$FAKE/.zshrc" && ok "zshrc source line present" || bad "install/zshrc" "no source line"
+[ -f "$FAKE/.config/jj-agent-helpers/jj-agent-helpers.sh" ] && ok "helper script copied" || bad "install/copy" "missing"
+grep -qxF '<!-- BEGIN jj-agent-helpers (agent-helpers-jj) -->' "$FAKE/.claude/CLAUDE.md" && ok "CLAUDE.md fence present" || bad "install/claude" "no fence"
+[ "$(jq -r '.permissions.allow | index("Bash(jjctx:*)") != null' "$FAKE/.claude/settings.json")" = true ] && ok "settings allowlist added" || bad "install/settings" "jjctx missing"
+[ "$(jq -r '.permissions.allow | index("Bash(ls:*)") != null' "$FAKE/.claude/settings.json")" = true ] && ok "settings preserved existing entry" || bad "install/settings" "clobbered ls"
+
+# --- idempotent second install ---
+run install
+zcount=$(grep -cxF '# >>> jj-agent-helpers (managed by agent-helpers-jj) >>>' "$FAKE/.zshrc")
+[ "$zcount" -eq 1 ] && ok "idempotent: one zshrc fence" || bad "idempotent/zshrc" "count=$zcount"
+ccount=$(grep -cxF '<!-- BEGIN jj-agent-helpers (agent-helpers-jj) -->' "$FAKE/.claude/CLAUDE.md")
+[ "$ccount" -eq 1 ] && ok "idempotent: one CLAUDE.md fence" || bad "idempotent/claude" "count=$ccount"
+jcount=$(jq '[.permissions.allow[] | select(. == "Bash(jjctx:*)")] | length' "$FAKE/.claude/settings.json")
+[ "$jcount" -eq 1 ] && ok "idempotent: no duplicate allowlist value" || bad "idempotent/settings" "count=$jcount"
+
+# --- remove restores originals ---
+run remove
+[ "$(cat "$FAKE/.zshrc")" = "$ZSHRC_ORIG" ] && ok "remove restores ~/.zshrc byte-identical" || bad "remove/zshrc" "differs: $(cat "$FAKE/.zshrc")"
+[ "$(cat "$FAKE/.claude/CLAUDE.md")" = "$CLAUDE_ORIG" ] && ok "remove restores CLAUDE.md byte-identical" || bad "remove/claude" "differs"
+[ "$(jq -S . "$FAKE/.claude/settings.json")" = "$SETTINGS_ORIG_SEMANTIC" ] && ok "remove restores settings.json semantically" || bad "remove/settings" "differs: $(jq -S . "$FAKE/.claude/settings.json")"
+[ ! -f "$FAKE/.config/jj-agent-helpers/jj-agent-helpers.sh" ] && ok "remove deletes helper script" || bad "remove/copy" "still present"
+
+# --- missing-file paths ---
+HOME="$FAKE2" bash "$INSTALL" install
+grep -qxF '# >>> jj-agent-helpers (managed by agent-helpers-jj) >>>' "$FAKE2/.zshrc" && ok "install creates missing ~/.zshrc" || bad "missing/zshrc" "not created"
+[ "$(jq -r '.permissions.allow | index("Bash(jjctx:*)") != null' "$FAKE2/.claude/settings.json")" = true ] && ok "install creates missing settings.json with allow" || bad "missing/settings" "not created"
+
+echo ""
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/plugins/agent-helpers-jj/tests/test-jj-agent-helpers.sh
+++ b/plugins/agent-helpers-jj/tests/test-jj-agent-helpers.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Unit tests for the four jj query helper functions.
+# Creates a scratch jj repo, sources the helpers, exercises each function,
+# and enforces the --ignore-working-copy race-safety invariant (behaviorally:
+# the helpers must create no operations, i.e. never snapshot) + catalog drift.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HELPERS="$SCRIPT_DIR/../scripts/jj-agent-helpers.sh"
+TEMPLATE="$SCRIPT_DIR/../templates/jj-agent-helpers-claudemd.md"
+
+pass=0
+fail=0
+ok()   { echo "  PASS: $1"; pass=$((pass+1)); }
+bad()  { echo "  FAIL: $1 — $2"; fail=$((fail+1)); }
+
+# --- scratch jj repo ---
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+export JJ_CONFIG="$WORK/jjconfig.toml"
+cat > "$JJ_CONFIG" <<'CFG'
+[user]
+name = "test"
+email = "test@example.com"
+CFG
+cd "$WORK"
+jj git init repo >/dev/null 2>&1
+cd repo
+# seed one described change so trunk()..@ is non-empty. trunk() falls back to
+# the root commit when there is no origin remote — fine here, because we assert
+# jjstack is NON-empty (a local `main` bookmark would not influence trunk();
+# that needs a real main@origin remote, which is more setup than this test needs).
+jj describe -m seed >/dev/null 2>&1
+jj new >/dev/null 2>&1   # @ is now an empty change on top of the seed
+
+# shellcheck disable=SC1090
+. "$HELPERS"
+
+# jjctx: one JSON object carrying a change_id
+out="$(jjctx)"
+if printf '%s' "$out" | jq -e '.change_id' >/dev/null 2>&1; then ok "jjctx emits JSON with change_id"; else bad "jjctx" "no change_id in: $out"; fi
+
+# jjcheckpoint: non-empty short op id
+out="$(jjcheckpoint)"
+if [ -n "$out" ]; then ok "jjcheckpoint prints an op id"; else bad "jjcheckpoint" "empty"; fi
+
+# jjstack: JSONL for changes ahead of trunk
+out="$(jjstack)"
+if [ -n "$out" ] && printf '%s' "$out" | head -1 | jq -e '.change_id' >/dev/null 2>&1; then ok "jjstack emits JSONL ahead of trunk"; else bad "jjstack" "bad: $out"; fi
+
+# jjconflicts: clean repo -> exit 0
+if jjconflicts; then ok "jjconflicts exits 0 when clean"; else bad "jjconflicts(clean)" "expected 0"; fi
+
+# jjconflicts: broken env (not a jj repo) -> non-zero, NOT a false clean
+( cd "$WORK" && jjconflicts >/dev/null 2>&1 ) && bad "jjconflicts(non-repo)" "returned clean outside a jj repo" || ok "jjconflicts non-zero outside a jj repo"
+
+# race-safety invariant (behavioral): the helpers must NOT snapshot the working
+# copy, so they must create no new operations — even when the working copy is
+# dirty (an unsnapshotted edit that a plain jj command would snapshot into a new op).
+echo dirty > uncommitted.txt
+ops() { jj --ignore-working-copy op log --no-graph -T 'id.short() ++ "\n"' | grep -c .; }
+before="$(ops)"
+jjctx >/dev/null 2>&1 || true
+jjstack >/dev/null 2>&1 || true
+jjconflicts >/dev/null 2>&1 || true
+jjcheckpoint >/dev/null 2>&1 || true
+after="$(ops)"
+if [ "$before" = "$after" ]; then ok "helpers create no operations (no working-copy snapshot)"; else bad "invariant" "op count $before -> $after (a helper snapshotted)"; fi
+
+# defense in depth: the flag is literally present in the script
+if grep -q -- '--ignore-working-copy' "$HELPERS"; then ok "script carries --ignore-working-copy"; else bad "flag" "missing from script"; fi
+
+# drift guard: catalog names == public function names (exclude private _jjq)
+defined="$(grep -Eo '^(jj[a-z]+)\(\)' "$HELPERS" | sed 's/()//' | sort -u)"
+catalog="$(grep -Eo '`jj[a-z]+' "$TEMPLATE" | tr -d '`' | sort -u)"
+if [ "$defined" = "$catalog" ]; then ok "catalog matches defined public functions"; else bad "drift" "defined=[$defined] catalog=[$catalog]"; fi
+
+echo ""
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

A new single-purpose plugin, `agent-helpers-jj`, that installs **four read-only jj query shortcuts** into the user's shell so agents can orient inside a jj repo without ever writing a working-copy snapshot to the shared operation log — the serialization point that concurrent workspaces (e.g. fan-flames) would otherwise race on.

**The four helpers** (each wraps `jj --ignore-working-copy …`):
- `jjctx` — current change as one JSON object
- `jjstack` — local changes ahead of trunk (JSONL)
- `jjconflicts` — exit 0 = clean, 1 = conflicts (printed), >1 = real jj error
- `jjcheckpoint` — short op id (for a fan-flames ledger `start-op`)

**Why these four, not more.** This started as a six-helper design; a fresh-context spec review plus TDD narrowed it to the correctness core:
- Mutation wrappers and a `jjhelp` catalog were cut in design — they compete with an agent's existing jj fluency and lose.
- `jjclean`/`jjfiles` were cut during implementation: TDD proved that under `--ignore-working-copy` a helper reads jj's *last snapshot*, not live disk edits, so the two working-copy helpers would report stale "am I clean / what changed?" answers. The four shipped helpers query committed / op-log state, where the flag is strictly correct.

**Machine-level install** (`/agent-helpers-setup`, consent-gated & idempotent), reversed by `/agent-helpers-remove`:
1. copies the helper script to `~/.config/jj-agent-helpers/jj-agent-helpers.sh`
2. adds a fenced `source` line to `~/.zshrc`
3. adds a one-line catalog to `~/.claude/CLAUDE.md` (so agents know the helpers exist)
4. allowlists the four helpers in `~/.claude/settings.json` (so they run prompt-free — load-bearing: the permission matcher sees the opaque `jjctx`, not the expanded `jj …`)

Each home file is edited behind an identifiable marker (conda-style fence in `~/.zshrc`, HTML-comment fence in `CLAUDE.md`, known-value `jq` dedupe in `settings.json`) for surgical, reversible removal. Setup prominently reminds the user to **restart** — the helpers become callable only once the next session regenerates its shell snapshot.

Includes the design spec (`docs/specs/`) and implementation plan (`docs/plans/`).

## Test plan
- [x] Unit tests (`test-jj-agent-helpers.sh`) 8/8 — JSON/exit-code contracts, catalog drift guard, and a **behavioral race-safety invariant**: the helpers create zero operations even on a dirty working copy (proving they never snapshot)
- [x] Installer tests (`test-agent-helpers-install.sh`) 15/15 — against a fake `$HOME`: idempotent re-run (no duplicate fences/values), byte-identical round-trip for the two text files, semantic round-trip for `settings.json`, and missing-file creation
- [x] No regressions — `project-setup-jj` and `workspace-jj` suites still pass
- [ ] Reviewer: confirm the `Bash(jjctx:*)` colon-star allowlist form auto-approves a no-arg `jjctx` (documented as needing confirmation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)