### PR TITLE
fix(agent-helpers-jj): inline --ignore-working-copy (shell snapshot drops _jjq)

### DIFF
--- a/docs/specs/2026-07-14-agent-helpers-jj-design.md
+++ b/docs/specs/2026-07-14-agent-helpers-jj-design.md
@@ -41,13 +41,15 @@ Plus an entry in the repo marketplace manifest `./.claude-plugin/marketplace.jso
 
 ### Runtime dependency: the shell snapshot (must be documented for users)
 
-The agent's Bash tool runs a non-interactive shell that replays a Claude Code **shell snapshot** (`~/.claude/shell-snapshots/snapshot-*.sh`), regenerated at session start. A function added to `~/.zshrc` becomes callable by the agent **only after the next session regenerates the snapshot** — i.e. after a restart. So `agent-helpers-setup` must tell the user, prominently: *the helpers (and their prompt-free allowlist) take effect only after you restart Claude Code / start a new session.* Without a restart, `jjctx` is both "command not found" and un-allowlisted — a baffling double failure if undocumented. (This same mechanism is what makes the permission claim below hold: the matcher sees the literal token `jjctx` replayed from the snapshot, not the expanded `jj …`.)
+The agent's Bash tool runs a non-interactive shell that replays a Claude Code **shell snapshot** (`~/.claude/shell-snapshots/snapshot-*.sh`), regenerated at session start. A function added to `~/.zshrc` becomes callable by the agent **only after the next session regenerates the snapshot** — i.e. after a restart. (Re-sourcing `~/.zshrc` fixes an interactive terminal but NOT the agent, which reads the frozen snapshot.)
+
+> **Snapshot filters single-underscore functions (discovered in live testing, 2026-07-14).** The snapshot capture drops functions whose names begin with a single underscore (the zsh completion-function convention, `_command`) — a double underscore survives. So an internal helper like `_jjq` is *absent* from the snapshot even though its public callers are present, and every helper fails at runtime with `command not found: _jjq`. **Consequence for this design:** the helpers must not share a single-underscore private helper. Each function inlines `jj --ignore-working-copy` instead. Unit tests can't catch this (they `source` the file directly, where `_jjq` exists) — only an end-to-end run through the real snapshot does. So `agent-helpers-setup` must tell the user, prominently: *the helpers (and their prompt-free allowlist) take effect only after you restart Claude Code / start a new session.* Without a restart, `jjctx` is both "command not found" and un-allowlisted — a baffling double failure if undocumented. (This same mechanism is what makes the permission claim below hold: the matcher sees the literal token `jjctx` replayed from the snapshot, not the expanded `jj …`.)
 
 ## Components
 
 ### 1. `scripts/jj-agent-helpers.sh` — the function library
 
-Target shell: **zsh** (the source line is added to `~/.zshrc`; bash support is a Non-Goal for v1). A private `_jjq` backs every function so the `--ignore-working-copy` flag exists in exactly one place.
+Target shell: **zsh** (the source line is added to `~/.zshrc`; bash support is a Non-Goal for v1). **Each function inlines `jj --ignore-working-copy`** — the original design used a shared private `_jjq` helper, but live testing showed the shell snapshot drops single-underscore functions (see Runtime dependency above), so inlining is required. The code block below shows the original `_jjq` form; the shipped code inlines the flag into each of the four functions.
 
 ```zsh
 # _jjq: read-only jj — never snapshots the working copy; safe under concurrent workspaces.

--- a/plugins/agent-helpers-jj/scripts/jj-agent-helpers.sh
+++ b/plugins/agent-helpers-jj/scripts/jj-agent-helpers.sh
@@ -1,18 +1,22 @@
 # jj query helpers for agents. Sourced from ~/.zshrc by agent-helpers-jj.
-# Bodies are bash+zsh compatible (printf / [ ] / local), so the bash test
-# harness can source them while they install into zsh.
+# Bodies are bash+zsh compatible (printf / [ ] / local).
 #
-# _jjq is the single place the --ignore-working-copy flag lives: read-only
-# queries must never snapshot the working copy (that writes a new operation to
-# the shared op-log, the serialization point concurrent jj workspaces race on).
-
-_jjq() { jj --ignore-working-copy "$@"; }
+# Each function inlines `jj --ignore-working-copy` rather than sharing a private
+# `_jjq` helper: Claude Code's shell-snapshot capture (the mechanism that makes
+# ~/.zshrc functions callable by the agent's Bash tool) DROPS single-underscore-
+# prefixed functions — the zsh completion-function convention. A shared `_jjq`
+# would be absent at call time and every helper would fail with "command not
+# found: _jjq". Inlining keeps each helper self-contained and snapshot-safe.
+#
+# --ignore-working-copy: read-only queries must never snapshot the working copy
+# (a snapshot writes a new operation to the shared op-log, the serialization
+# point concurrent jj workspaces race on).
 
 # jjctx — current change as one JSON object (orientation)
-jjctx() { _jjq log -r @ --no-graph -T 'json(self) ++ "\n"'; }
+jjctx() { jj --ignore-working-copy log -r @ --no-graph -T 'json(self) ++ "\n"'; }
 
 # jjstack — local changes ahead of trunk, JSON lines
-jjstack() { _jjq log -r 'trunk()..@' --no-graph -T 'json(self) ++ "\n"'; }
+jjstack() { jj --ignore-working-copy log -r 'trunk()..@' --no-graph -T 'json(self) ++ "\n"'; }
 
 # jjconflicts — 0 = clean, 1 = conflicts (printed), >1 = real jj error.
 # On jj 0.43 `jj resolve --list` exits 0 (and lists) when conflicts exist, and
@@ -20,7 +24,7 @@ jjstack() { _jjq log -r 'trunk()..@' --no-graph -T 'json(self) ++ "\n"'; }
 # errors stops an agent reading "clean" from a broken env (not a repo / jj gone).
 jjconflicts() {
   local out rc
-  out="$(_jjq resolve --list 2>/dev/null)"; rc=$?
+  out="$(jj --ignore-working-copy resolve --list 2>/dev/null)"; rc=$?
   if [ "$rc" -eq 0 ]; then
     [ -z "$out" ] && return 0
     printf '%s\n' "$out"; return 1
@@ -31,4 +35,4 @@ jjconflicts() {
 }
 
 # jjcheckpoint — current operation id (for a fan-flames ledger start-op)
-jjcheckpoint() { _jjq op log -n1 --no-graph -T 'id.short()'; }
+jjcheckpoint() { jj --ignore-working-copy op log -n1 --no-graph -T 'id.short()'; }


### PR DESCRIPTION
## Summary

Follow-up fix to #66, surfaced by a **live end-to-end run** on a real machine (install → restart → call the helpers).

**Bug:** every helper failed with `command not found: _jjq`. The four public functions (`jjctx`/`jjstack`/`jjconflicts`/`jjcheckpoint`) made it into Claude Code's shell snapshot, but the private `_jjq` helper they all call did **not** — the snapshot capture drops **single-underscore-prefixed functions** (the zsh completion-function convention; a *double*-underscore function like `__starship_get_time` survived, single-underscore `_jjq` did not).

**Fix:** inline `jj --ignore-working-copy` into each of the four functions. No shared helper to be filtered; each function is self-contained and snapshot-safe.

**Why the tests didn't catch it:** the unit tests `source` the script directly, where `_jjq` is defined and works. Only a run through the real shell snapshot exposes the filter. The spec's Runtime-dependency section now documents the finding so it isn't rediscovered the hard way.

## Silver linings from the same run
- The `Bash(jjctx:*)` allowlist form is **confirmed working** — the functions executed *prompt-free* (they only errored internally on `_jjq`), closing the last open item from #66.
- The restart/shell-snapshot dependency itself was confirmed in the wild (functions uncallable until the session regenerated the snapshot).

## Test plan
- [x] Unit tests 8/8 on the inlined script
- [x] Installer tests 15/15 (unaffected — allowlist still four values)
- [x] Fresh-zsh smoke: all four helpers emit correct output / exit codes with no `_jjq`
- [ ] Post-merge: update the plugin and re-run `/agent-helpers-setup`; confirm `jjctx` runs after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)