### PR TITLE
fan-flames: fix nine defects found by actually running it, and lint the rule class that hid #1

### DIFF
--- a/docs/plans/2026-07-14-fan-flames-correctness-fixes-plan.md
+++ b/docs/plans/2026-07-14-fan-flames-correctness-fixes-plan.md
@@ -1,0 +1,839 @@
+# Fan-Flames Correctness Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **Do NOT use workspace-jj:fan-flames for this plan** — Tasks 2, 3, and 4 all modify `plugins/workspace-jj/skills/fan-flames.md`, so the overlap graph collapses to one task per wave. Fan-flames' own Parallelism Threshold rule (<40% parallel) directs you to sequential execution here. Inline execution is correct.
+
+**Goal:** Fix eight defects in `workspace-jj:fan-flames` found by running it end-to-end (findings #2–#9 of the 2026-07-14 test run), and add a lint that prevents finding #1's class from recurring.
+
+**Architecture:** Five files across four stacked changes. Two changes carry code (a script + its tests, and a new lint); two are prose corrections to the skill. Each change is independently revertable. The lint lands last so it lands green.
+
+**Tech Stack:** Bash, awk, Markdown. jj for VCS.
+
+**Spec:** `docs/specs/2026-07-14-fan-flames-correctness-fixes-design.md` — read it for the *why* behind each fix. This plan is the *how*.
+
+## Global Constraints
+
+- **No raw git commands anywhere** — jj equivalents only. The only exceptions are `jj git` subcommands and the `gh` CLI.
+- **Non-interactive jj forms only** — always pass `-m` to describe/commit/squash. Never run bare `jj describe`, `jj resolve`, `jj diffedit`, or `jj split` without paths.
+- **Commit convention:** conventional commits, `jj describe -m "…"` then `jj new`.
+- **Prose edits are surgical.** Replace exactly the quoted text. Do not restructure surrounding sections, rewrite adjacent prose, or "improve" text the task did not name.
+- **This repo has no Rust and no `cargo`.** Do not add a `cargo` example anywhere.
+- **Attribution:** Cluster E's lint/eval distinction draws on `netresearch/jujutsu-workflow-skill` (MIT AND CC-BY-SA-4.0). Write all text in this repo's own words — do not copy their prose verbatim.
+- **Test count baseline:** `plugins/workspace-jj/tests/test-fan-flames-scripts.sh` currently reports `15 passed, 0 failed`. It must never report fewer passing than that.
+
+---
+
+### Task 1: Self-contained task briefs
+
+**Files:**
+- Modify: `plugins/workspace-jj/scripts/fan-flames-task-brief`
+- Modify: `plugins/workspace-jj/tests/test-fan-flames-scripts.sh` (fixture ~line 39; new cases after line 92)
+- Modify: `plugins/workspace-jj/skills/fan-flames.md` (Prepare Artifacts, ~line 293)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: briefs that contain the plan preamble followed by `---` followed by the task text. No later task depends on this.
+
+**Why:** `fan-flames-task-brief` extracts only the task section, so Global Constraints and shared definitions never reach the implementer — while the dispatch template tells the agent the brief "is your requirements." In the test run every brief said *"all four drift criteria in 'What drift means' above"* with no "above". The repo's own `docs/plans/2026-07-13-jj-agent-safety-plan.md` has a Task 1 that dangles identically.
+
+> **Revision (2026-07-14, during implementation):** the steps below produce a **doubled horizontal rule** on every real plan in this repo. Each one closes its preamble with `---` before the first task — it is the writing-plans convention — so prepending our own separator yields two. The fixture could not catch it: its preamble does not end in a rule, which is how the plan came to be written from the fixture rather than from the plans it actually runs against.
+>
+> The shipped script therefore drops a trailing `---` from the preamble before adding its own, and two cases were added covering a preamble that ends in a rule. Test count is **22**, not the 20 these steps predict. The code is authoritative; the steps below are left as executed.
+
+- [ ] **Step 1: Add a fenced decoy to the test fixture's preamble**
+
+The existing fixture has a preamble ("Intro text that belongs to no task.") but its only fenced decoy sits inside Task 2, which tests the *task* extractor. The *preamble* extractor needs its own decoy, or fence-awareness goes untested.
+
+In `plugins/workspace-jj/tests/test-fan-flames-scripts.sh`, replace:
+
+```bash
+cat > "$repo/plan.md" <<'EOF'
+# Example Plan
+
+## Overview
+
+Intro text that belongs to no task.
+
+### Task 1: First thing
+```
+
+with:
+
+```bash
+cat > "$repo/plan.md" <<'EOF'
+# Example Plan
+
+## Overview
+
+Intro text that belongs to no task.
+
+```markdown
+### Task 8: preamble decoy inside a code fence
+this fenced heading must not terminate the preamble
+```
+
+Global rule: the preamble continues past the fence.
+
+### Task 1: First thing
+```
+
+Leave the rest of the fixture (Tasks 1–3 and the Task 9 decoy inside Task 2) exactly as it is.
+
+- [ ] **Step 2: Write the failing tests**
+
+In the same file, immediately after this existing line:
+
+```bash
+check_fails "brief excludes Task 3" 1 grep -q 'Third thing' "$brief"
+```
+
+insert:
+
+```bash
+# --- preamble is prepended (findings #2) ---
+check "brief contains the plan preamble" \
+  grep -q 'Intro text that belongs to no task' "$brief"
+check "brief separates preamble from task" grep -qx -- '---' "$brief"
+check "fenced Task heading does not terminate the preamble" \
+  grep -q 'Global rule: the preamble continues past the fence' "$brief"
+
+# A plan whose first line is already a task heading has no preamble, and
+# must not get a stray leading separator.
+cat > "$repo/plan-nopreamble.md" <<'EOF'
+### Task 1: Only thing
+
+**Files:** `z.ts`
+EOF
+"$SCRIPTS/fan-flames-task-brief" plan-nopreamble.md 1 "$tmp/nopre.md" >/dev/null
+check "no-preamble plan still yields the task" grep -q 'Only thing' "$tmp/nopre.md"
+check_fails "no-preamble plan yields no separator" 1 grep -qx -- '---' "$tmp/nopre.md"
+```
+
+- [ ] **Step 3: Run the tests and verify they fail**
+
+Run: `bash plugins/workspace-jj/tests/test-fan-flames-scripts.sh`
+
+Expected: FAIL. Specifically `brief contains the plan preamble`, `brief separates preamble from task`, and `fenced Task heading does not terminate the preamble` all report `FAIL`, because the script does not yet emit a preamble. The final line reports a non-zero failure count and the script exits non-zero.
+
+(`no-preamble plan yields no separator` will *pass* already — it is a regression guard, not a new behavior. That is expected.)
+
+- [ ] **Step 4: Implement the preamble pass**
+
+In `plugins/workspace-jj/scripts/fan-flames-task-brief`, replace everything from the `# Extract one task's...` header comment through the end of the file with:
+
+```bash
+# Extract one task's full text from an implementation plan into a file the
+# implementer reads in one call, so the task text never has to be pasted
+# through the orchestrator's context.
+#
+# A task starts at a markdown heading matching "Task N" (any heading level)
+# and ends at the next task heading. Headings inside code fences are ignored.
+#
+# The plan's preamble — everything before the first task heading — holds the
+# Global Constraints and shared definitions that task text references but does
+# not repeat. It is prepended to every brief, because the skill tells
+# implementers the brief IS their requirements, and without the preamble that
+# claim is false.
+#
+# Usage: fan-flames-task-brief PLAN_FILE TASK_NUMBER [OUTFILE]
+# Default OUTFILE: <artifacts-dir>/task-<N>-brief.md
+set -euo pipefail
+
+if [ $# -lt 2 ] || [ $# -gt 3 ]; then
+  echo "usage: fan-flames-task-brief PLAN_FILE TASK_NUMBER [OUTFILE]" >&2
+  exit 2
+fi
+
+plan=$1
+n=$2
+[ -f "$plan" ] || { echo "no such plan file: $plan" >&2; exit 2; }
+
+if [ $# -eq 3 ]; then
+  out=$3
+else
+  dir=$("$(cd "$(dirname "$0")" && pwd)/fan-flames-artifacts")
+  out="$dir/task-${n}-brief.md"
+fi
+
+task=$(awk -v n="$n" '
+  /^```/ { infence = !infence }
+  !infence && /^#+[ \t]+Task[ \t]+[0-9]+/ {
+    intask = ($0 ~ ("^#+[ \t]+Task[ \t]+" n "([^0-9]|$)"))
+  }
+  intask { print }
+' "$plan")
+
+if [ -z "$task" ]; then
+  echo "task ${n} not found in ${plan} (no heading matching 'Task ${n}')" >&2
+  exit 3
+fi
+
+# Everything before the first task heading. Same fence awareness as the task
+# pass above — otherwise the two halves of this script would disagree about
+# where the first task begins.
+preamble=$(awk '
+  /^```/ { infence = !infence }
+  !infence && /^#+[ \t]+Task[ \t]+[0-9]+/ { exit }
+  { print }
+' "$plan")
+
+{
+  if [ -n "$(printf '%s' "$preamble" | tr -d '[:space:]')" ]; then
+    printf '%s\n\n---\n\n' "$preamble"
+  fi
+  printf '%s\n' "$task"
+} > "$out"
+
+echo "wrote ${out}: $(wc -l < "$out" | tr -d ' ') lines"
+```
+
+Note the not-found check now tests `$task` rather than the output file's size, because the file would be non-empty from the preamble alone. Exit code 3 is unchanged.
+
+- [ ] **Step 5: Run the tests and verify they pass**
+
+Run: `bash plugins/workspace-jj/tests/test-fan-flames-scripts.sh`
+
+Expected: PASS. The final line reports `22 passed, 0 failed` (15 existing + 7 new) and the script exits 0. If any pre-existing case now fails, the preamble pass broke the task pass — fix before continuing.
+
+- [ ] **Step 6: Update the skill's Prepare Artifacts note**
+
+In `plugins/workspace-jj/skills/fan-flames.md`, replace:
+
+```markdown
+   - **Plan document input:** `../scripts/fan-flames-task-brief <plan-file> <N>`
+     for each task — the script extracts the task's full text without it
+     passing through your context again
+```
+
+with:
+
+```markdown
+   - **Plan document input:** `../scripts/fan-flames-task-brief <plan-file> <N>`
+     for each task — the script extracts the task's full text without it
+     passing through your context again, and prepends the plan's preamble
+     (Global Constraints, shared definitions) so the brief stands alone
+```
+
+- [ ] **Step 7: Verify**
+
+```bash
+bash plugins/workspace-jj/tests/test-fan-flames-scripts.sh | tail -1
+grep -c "prepends the plan's preamble" plugins/workspace-jj/skills/fan-flames.md
+```
+
+Expected: `22 passed, 0 failed`; the grep returns `1`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+jj describe -m "fix(fan-flames): self-contained task briefs
+
+fan-flames-task-brief extracted only the task section, so a plan's Global
+Constraints and shared definitions never reached the implementer — while
+the dispatch template told the agent the brief IS its requirements. Every
+brief in the 2026-07-14 test run referenced 'the four drift criteria above'
+with no above; docs/plans/2026-07-13-jj-agent-safety-plan.md dangles the
+same way.
+
+The script now prepends the plan preamble, fence-aware to match the task
+pass, so the brief is complete on its own.
+
+Found by: fan-flames test run 2026-07-14 (finding #2)"
+jj new
+```
+
+---
+
+### Task 2: De-Rust the test gate and handle waves with no test surface
+
+**Files:**
+- Modify: `plugins/workspace-jj/skills/fan-flames.md` (phase diagram ~line 34; REVIEW Step 1 ~lines 564–578; Fix Loop item 2 ~lines 639–643)
+- Modify: `plugins/workspace-jj/skills/fan-flames-wave-reviewer.md` (Your Job ~line 61)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the ledger event `wave <W>: no-test-surface`, added to the event-lines list by Task 3. Task 3 depends on this event's exact spelling.
+
+**Why:** `cargo test` is asserted in three places in a repo with no Rust — every reviewer in the test run was told a suite passed that doesn't exist. Worse, Fix Loop item 2 *hard-requires* covering tests before re-review, so a docs-only fix loop can never advance. The run hit that wall and had to deviate.
+
+- [ ] **Step 1: De-Rust the phase diagram**
+
+In `plugins/workspace-jj/skills/fan-flames.md`, replace:
+
+```
+  ║  REVIEW ── cargo test (spec gate)            ║
+```
+
+with:
+
+```
+  ║  REVIEW ── test suite (spec gate)            ║
+```
+
+`test suite` and `cargo test` are both 10 characters, so the box border stays aligned. Do not adjust surrounding whitespace.
+
+- [ ] **Step 2: De-Rust the test gate and add the no-test-surface branch**
+
+In the same file, replace:
+
+````markdown
+```bash
+# For each task in the wave:
+(cd /tmp/jj-workspaces/<repo>/<task-name> && cargo test)  # or the project's equivalent test command
+```
+
+If tests fail, dispatch fix subagents to the relevant workspace(s) and re-run. Escalate to user after 2 failed attempts.
+````
+
+with:
+
+````markdown
+```bash
+# For each task in the wave:
+(cd /tmp/jj-workspaces/<repo>/<task-name> && <the project's test command>)
+```
+
+If tests fail, dispatch fix subagents to the relevant workspace(s) and re-run. Escalate to user after 2 failed attempts.
+
+**If the wave has no test surface** — its changes are documentation, prose, or
+config that no test in the project reads — say so and move on. Record
+`wave <W>: no-test-surface` in the ledger, tell the reviewers no automated
+check has validated this wave, and rely on review. Do not invent a test, and
+do not run an unrelated suite and report its pass as this wave's gate: a
+suite that cannot fail on these changes has verified nothing, and reporting
+it as a pass is worse than reporting no gate at all.
+````
+
+- [ ] **Step 3: Give Fix Loop item 2 the matching escape**
+
+In the same file, replace:
+
+```markdown
+2. Fix subagent uses the same implementer protocol (DONE / BLOCKED /
+   NEEDS_CONTEXT) and appends its fix report to the task's existing
+   `<artifacts>/task-N-report.md`. The report must contain the covering
+   tests, the command run, and the output — confirm all three are present
+   before re-dispatching the reviewer
+```
+
+with:
+
+```markdown
+2. Fix subagent uses the same implementer protocol (DONE / BLOCKED /
+   NEEDS_CONTEXT) and appends its fix report to the task's existing
+   `<artifacts>/task-N-report.md`. The report must contain the covering
+   tests, the command run, and the output — confirm all three are present
+   before re-dispatching the reviewer. If no test covers the change (a
+   docs or config fix), the report must say that explicitly and state what
+   was verified instead; a fix subagent must never fabricate a test command
+   to satisfy this gate
+```
+
+- [ ] **Step 4: De-Rust the reviewer template**
+
+In `plugins/workspace-jj/skills/fan-flames-wave-reviewer.md`, replace:
+
+```
+    cargo test already passes — don't re-verify test values.
+    Focus on what tests CAN'T catch.
+```
+
+with:
+
+```
+    The wave's test gate has already run — don't re-verify test values.
+    If the orchestrator told you this wave has no test surface, then no
+    automated check has validated this work at all; review accordingly.
+    Focus on what tests CAN'T catch.
+```
+
+- [ ] **Step 5: Verify**
+
+```bash
+grep -rn "cargo" plugins/workspace-jj/skills/
+grep -c "no-test-surface" plugins/workspace-jj/skills/fan-flames.md
+grep -c "never fabricate a test command" plugins/workspace-jj/skills/fan-flames.md
+awk 'NR>=21 && NR<=45 && /║/' plugins/workspace-jj/skills/fan-flames.md | awk '{print length($0)}' | sort -u | wc -l
+```
+
+Expected, in order: the first grep returns **only** `- Formatting: run the project's formatter/linter (e.g., cargo fmt, prettier, ruff) …` (an honest multi-language example that stays — no other `cargo` hits, and none in `fan-flames-wave-reviewer.md`); then `1`; then `1`.
+
+> **Revision (2026-07-15, during implementation):** the fourth check as originally written — `awk '{print length($0)}' | sort -u | wc -l`, expecting `1` — is wrong twice over and was dropped. `awk` counts **bytes**, and the box-drawing characters are multi-byte UTF-8, so it returns `4` on a perfectly aligned diagram. Counting characters (`perl -CSD`) returns `2`, because line 41 (`(only review-approved tasks)`) carries one extra space — a pre-existing misalignment present on `main`, untouched here per the surgical-edits constraint. The line this task edits is 50 characters before and after (`cargo test` and `test suite` are both 10), so alignment is unchanged. Verify by that fact, not by a length histogram.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "fix(fan-flames): de-Rust the test gate, handle waves with no test surface
+
+Three places asserted cargo test in a repo with no Rust, and the reviewer
+template told every reviewer a suite had passed that does not exist. Worse,
+Fix Loop item 2 hard-required covering tests before re-review, so a
+docs-only fix loop could never advance — the 2026-07-14 test run hit that
+wall and had to deviate to proceed.
+
+REVIEW Step 1 now names the no-test-surface case and forbids reporting a
+vacuous pass; Fix Loop item 2 takes the matching escape.
+
+Found by: fan-flames test run 2026-07-14 (findings #5, #6, #7)"
+jj new
+```
+
+---
+
+### Task 3: Correct the integrity model and the fix-delta commands
+
+**Files:**
+- Modify: `plugins/workspace-jj/skills/fan-flames.md` (ledger example ~line 129; event lines ~lines 139–142; ledger init ~line 304; dispatch template ~line 417; integrity check ~lines 499–503; COLLECT ~after line 532; Fix Loop items 1 and 3 ~lines 632–648; FAN IN conflict check ~line 789)
+
+**Interfaces:**
+- Consumes: the `wave <W>: no-test-surface` event spelling from Task 2.
+- Produces: the ledger event `task N: fixing from=<commit-id>`.
+
+**Why:** Four separate defects, all observed. The Wave 1 integrity baseline assumes an empty `@` that nothing requires — in the test run it produced a false `WORKSPACE_LEAK` on the plan document. The check never re-runs after the fix loop, which is exactly where a fix subagent leaked into `@` (it self-caught; the skill would not have). `evolog --limit 2` counts evolution steps, not "the fix" — `jj describe` consumed a window slot in three of four fixes. And `jj resolve --list` exits 2 when there are no conflicts.
+
+- [ ] **Step 1: Fix the Wave 1 integrity baseline**
+
+In `plugins/workspace-jj/skills/fan-flames.md`, replace:
+
+```markdown
+The expected baseline is wave-aware: in Wave 1, `@` should show no changes;
+from Wave 2 on, `@` legitimately contains all prior waves' merged content, so
+compare against the stat recorded after the previous FAN IN (record
+`jj diff -r @ --stat` after every FAN IN to refresh the baseline). If `@`
+differs from its baseline, at least one agent failed to `cd` to its workspace.
+```
+
+with:
+
+```markdown
+Compare against the **recorded baseline**, never against zero. `@` is not
+required to be empty — it routinely holds the plan document, or work in
+progress the run builds on. PLAN records `jj diff -r @ --stat` as the run's
+baseline; every FAN IN re-records it, so from Wave 2 on the baseline includes
+all prior waves' merged content. If `@` differs from the current baseline, at
+least one agent failed to `cd` to its workspace.
+```
+
+- [ ] **Step 2: Record the baseline at PLAN**
+
+In the same file, replace:
+
+```markdown
+3. Initialize the ledger — write the header and wave plan to
+   `<artifacts>/progress.md`:
+```
+
+with:
+
+```markdown
+3. Record the integrity baseline: run `jj diff -r @ --stat` and keep the
+   result. It is what every Workspace Integrity Check compares against — `@`
+   may legitimately be non-empty at PLAN, and comparing against zero would
+   report the run's own starting content as a leak.
+4. Initialize the ledger — write the header and wave plan to
+   `<artifacts>/progress.md`:
+```
+
+- [ ] **Step 3: Re-run the integrity check after each fix-loop round**
+
+In the same file, replace:
+
+```markdown
+4. Repeat until no critical/important findings remain
+5. Escalate to user after 2 failed fix attempts — present the findings and ask how to proceed
+```
+
+with:
+
+```markdown
+4. Re-run the Workspace Integrity Check (Phase 3) against the recorded
+   baseline. Fix subagents reach their workspace by `cd`, exactly as
+   implementers do, and are exactly as able to miss it — a check that runs
+   only after COLLECT does not cover an agent dispatched after COLLECT
+5. Repeat until no critical/important findings remain
+6. Escalate to user after 2 failed fix attempts — present the findings and ask how to proceed
+```
+
+- [ ] **Step 4: Record the pre-fix commit ID at dispatch**
+
+In the same file, replace:
+
+```markdown
+   to work in the existing workspace directory path, and name the test files
+   covering the change — a small fix doesn't need the whole suite
+```
+
+with:
+
+```markdown
+   to work in the existing workspace directory path, and name the test files
+   covering the change — a small fix doesn't need the whole suite. Before
+   dispatching, record the change's current commit ID —
+   `jj log -r <change-id> --no-graph -T 'commit_id.short()'` — to the ledger
+   as `task N: fixing from=<commit-id>`. This is the only moment the fix's
+   starting point is unambiguous; step 3 needs it
+```
+
+- [ ] **Step 5: Point re-reviews at the exact fix delta**
+
+In the same file, replace:
+
+```markdown
+3. Re-dispatch reviewer scoped to the fix delta: fix subagents amend in
+   place, so `jj evolog -r <change-id> -p --limit 2` shows exactly what the
+   fix changed. Name that command in the re-review prompt as the reviewer's
+   primary view (with the original findings for context) — re-reviews judge
+   the amendment, not the whole task again
+```
+
+with:
+
+```markdown
+3. Re-dispatch reviewer scoped to the fix delta. Fix subagents amend in
+   place, so the delta is exactly `jj diff --from <the commit-id recorded in
+   step 1> --to <change-id>`. Name that command in the re-review prompt as
+   the reviewer's primary view (with the original findings for context) —
+   re-reviews judge the amendment, not the whole task again. Do not derive
+   the delta from `jj evolog --limit N`: that counts evolution steps, not
+   "the fix", and a `jj describe` or a second snapshot silently shifts the
+   window — a truncated delta is indistinguishable from a small one
+```
+
+- [ ] **Step 6: Fix the FAN IN conflict check**
+
+In the same file, replace:
+
+````markdown
+2. **Check for conflicts:**
+
+```bash
+jj resolve --list
+```
+````
+
+with:
+
+````markdown
+2. **Check for conflicts:**
+
+```bash
+jj log -r 'conflicts()' --no-graph -T 'change_id.short() ++ "\n"'
+```
+
+Empty output means clean. Use this rather than `jj resolve --list` as the
+check: `resolve --list` exits 2 when there are *no* conflicts, so any scripted
+use reads the clean case as a failure. `jj resolve --list` is still the right
+way to show a human which files conflict, once you know some do.
+````
+
+- [ ] **Step 7: Make the recovery convention real**
+
+In the same file, replace:
+
+```markdown
+    Before reporting back, capture your change ID and workspace name:
+    jj log -r @ --no-graph -T 'change_id'
+    basename "$PWD"
+```
+
+with:
+
+```markdown
+    Before reporting back, describe your change so it can be recovered if
+    you die before reporting, then capture your change ID and workspace name:
+    jj describe -m "Task N: <short description>"
+    jj log -r @ --no-graph -T 'change_id'
+    basename "$PWD"
+```
+
+- [ ] **Step 8: Note that empty changes are legitimate**
+
+In the same file, immediately after this line:
+
+```markdown
+If multiple matches, use the most recent. If no matches, the subagent likely never created any changes — treat as BLOCKED.
+```
+
+insert:
+
+```markdown
+### Empty Changes Are a Valid Outcome
+
+A task can correctly produce no change — an audit that finds nothing, a
+check that confirms the code is already right. An empty change is a result,
+not a failure: review it like any other (the claim "there was nothing to do"
+is exactly as verifiable as a diff, just against the source rather than
+against a patch), and fan it in normally. `jj squash` abandons an empty
+source silently, which is the correct no-op. Distinguish this from a subagent
+that produced nothing because it failed — the report and the ledger say which.
+```
+
+- [ ] **Step 9: Add both new events to the ledger schema**
+
+In the same file, replace:
+
+```markdown
+Event lines: `dispatched workspace=…`, `done change=… files=…`,
+`done-with-concerns change=… files=…`, `blocked reason=…`, `needs-context`,
+`workspace-leak`, `review-passed`, `review-failed findings=<n>c,<n>i`,
+`squashed`, `wave <W>: fanned-in`, `run: complete`.
+```
+
+with:
+
+```markdown
+Event lines: `dispatched workspace=…`, `done change=… files=…`,
+`done-with-concerns change=… files=…`, `blocked reason=…`, `needs-context`,
+`workspace-leak`, `review-passed`, `review-failed findings=<n>c,<n>i`,
+`fixing from=<commit-id>`, `squashed`, `wave <W>: no-test-surface`,
+`wave <W>: fanned-in`, `run: complete`.
+```
+
+- [ ] **Step 10: Verify**
+
+```bash
+grep -c "recorded baseline" plugins/workspace-jj/skills/fan-flames.md
+grep -c "fixing from=" plugins/workspace-jj/skills/fan-flames.md
+grep -c "no-test-surface" plugins/workspace-jj/skills/fan-flames.md
+grep -n "jj evolog" plugins/workspace-jj/skills/fan-flames.md
+grep -n "jj resolve --list" plugins/workspace-jj/skills/fan-flames.md
+grep -c "Empty Changes Are a Valid Outcome" plugins/workspace-jj/skills/fan-flames.md
+```
+
+Expected, in order: `recorded baseline` ≥ 2; `fixing from=` returns 2 (Fix Loop step 1 + the event list); `no-test-surface` returns 2 (Task 2's REVIEW branch + the event list — if this returns 1, Task 2's event spelling and this list have drifted); `jj evolog` returns 1 (only the Fix Loop's "do not derive the delta from" warning); `Empty Changes` returns 1.
+
+> **Revision (2026-07-15, during implementation):** two of these were wrong, both caught by dry-running the edits against a scratch copy before applying them.
+>
+> **`recorded baseline` originally expected ≥ 2 and returns 1.** Step 3's replacement text wrapped the phrase across a line break (`against the recorded` / `baseline.`), and `grep` is line-based, so it never matched. The text was correct; the check could not see it. Step 3 above is reflowed to keep the phrase on one line. It returns 3 as shipped — Step 2's text references it too.
+>
+> **`jj resolve --list` originally expected "only where human-facing" and returns 6.** That expectation is unusable: four sites are agent-facing *verify-after-resolve* usages (`edit the markers, then verify with jj resolve --list`), which are correct — they read output rather than branching on exit code, and #64 established that wording deliberately. Step 6's own explanation adds two more while explaining why not to use it as the check. Replace that grep with the check that means something:
+>
+> ```bash
+> awk '/^2\. \*\*Check for conflicts/,/^Empty output means clean/' plugins/workspace-jj/skills/fan-flames.md | grep -c '^jj resolve --list$'
+> ```
+>
+> Expected: `0` — the conflict check itself no longer uses it. That is the whole finding; the other sites are not in scope.
+
+- [ ] **Step 11: Commit**
+
+```bash
+jj describe -m "fix(fan-flames): correct the integrity model and fix-delta commands
+
+Four defects, all observed in the 2026-07-14 test run:
+
+- Wave 1's integrity baseline assumed an empty @, which no prerequisite
+  requires. The run's plan document tripped it: a false WORKSPACE_LEAK.
+  PLAN now records the baseline and every check compares against it, which
+  also collapses the Wave 1 and Wave 2+ rules into one.
+- The check never re-ran after the fix loop — precisely where a fix
+  subagent leaked into @ during the run. It self-caught; the skill would
+  not have. It now re-runs each round.
+- evolog --limit 2 counts evolution steps, not the fix. jj describe ate a
+  window slot in three of four fixes; one more jj call would have truncated
+  the delta invisibly. The orchestrator now records the pre-fix commit ID at
+  dispatch and re-reviews diff --from/--to it.
+- jj resolve --list exits 2 when clean, inverting any scripted check.
+
+Also: the dispatch template now sets the change description that COLLECT's
+recovery path already assumed, and empty changes are documented as a valid
+outcome.
+
+Found by: fan-flames test run 2026-07-14 (findings #3, #4, #8, #9)"
+jj new
+```
+
+---
+
+### Task 4: Lint model-selection directives in skill files
+
+**Files:**
+- Create: `plugins/workspace-jj/tests/test-model-selection-lint.sh`
+- Modify: `plugins/workspace-jj/skills/fan-flames-wave-reviewer.md` (model directive, ~line 16)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing.
+
+**Why:** Finding #1 — a `model:` directive offering `opus/session`, the exact inheritance PR #65 removed — sat in the template the skill dispatches every reviewer from, and survived three PRs. Nothing caught it because nothing executes prose: source, cache, and installed copy all agreed at `dbcf4e3`, so no staleness check could fire. A lint is deterministic and needs no model call. An eval (netresearch's format) tests model *behavior* and would pass whenever the model happened to choose `opus` anyway — the wrong instrument for a silent, bill-only failure.
+
+> **Revision (2026-07-15, during implementation):** rule 1 as written below was **line-based** (`grep -rnE '^[[:space:]]*model:.*[Ss]ession'`) and could not fire. The directive it must catch spans three lines, with `session` on the third — so Step 2's "verify it FAILS" was impossible, Step 3's tightening was unmotivated, and rule 1 would have shipped having never fired on anything.
+>
+> The error entered at the spec, which quoted the three-line directive as a one-line code span with an ellipsis and then reasoned about the quotation: *"which mentions `session` on a `model:` line"*. The spec's **rule** ("no `model:` **directive** mentions session") was right; its justification prose was not, and this plan implemented the prose. The Known-gaps entry then rationalized the mismatch instead of noticing it.
+>
+> The shipped lint reads the whole directive (`model:` line through the next `key:` or blank line). Every step below then holds as written: the lint fails on the current text, tightening fixes it, and Step 5 confirms both rules fire on the exact `opus/session` string. The spec has been corrected.
+
+- [ ] **Step 1: Write the lint**
+
+Create `plugins/workspace-jj/tests/test-model-selection-lint.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Lints model-selection directives across every plugin's markdown.
+#
+# Why this exists: fan-flames' Model Selection table is restated in the
+# dispatch templates that actually get used. PR #65 fixed the table and
+# missed fan-flames-wave-reviewer.md, which went on offering
+# "opus/session" — session-model inheritance — for three more PRs. Nothing
+# caught it: every layer (source, cache, installed copy) agreed, because
+# they agreed on the unfixed text. Prose is not executed, so it is not
+# checked. This checks the one rule class where being wrong is silent and
+# only shows up on the bill.
+#
+# Usage: test-model-selection-lint.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+PLUGINS="$ROOT/plugins"
+PASS=0
+FAIL=0
+
+ok()  { echo "PASS: $1"; PASS=$((PASS+1)); }
+bad() { echo "FAIL: $1"; FAIL=$((FAIL+1)); shift; printf '%s\n' "$@" | sed 's/^/    /'; }
+
+# --- Rule 1: no model: directive may offer session-model inheritance ---
+# An omitted or inherited model silently uses the session's model, which is
+# usually the most capable and most expensive. Every dispatch names its tier.
+hits=$(grep -rnE '^[[:space:]]*model:.*[Ss]ession' "$PLUGINS" --include='*.md' || true)
+if [ -z "$hits" ]; then
+  ok "no model: directive mentions session"
+else
+  bad "a model: directive offers session-model inheritance" "$hits"
+fi
+
+# --- Rule 2: the exact #1 shape, anywhere in a file ---
+hits=$(grep -rnE '(opus|sonnet|haiku)/session' "$PLUGINS" --include='*.md' || true)
+if [ -z "$hits" ]; then
+  ok "no file offers <tier>/session"
+else
+  bad "found <tier>/session — the PR #65 regression" "$hits"
+fi
+
+# --- Rule 3: every dispatch block names a model ---
+# 'Agent tool:' marks a dispatch example. Each must carry a model: line
+# within the block, or the example teaches omission by demonstration.
+while IFS=: read -r file line _; do
+  [ -n "$file" ] || continue
+  block=$(sed -n "${line},$((line + 8))p" "$file")
+  if printf '%s' "$block" | grep -qE '^[[:space:]]*model:'; then
+    ok "dispatch block at $(basename "$file"):$line names a model"
+  else
+    bad "dispatch block at $(basename "$file"):$line has no model: line" "$block"
+  fi
+done < <(grep -rn 'Agent tool:' "$PLUGINS" --include='*.md' || true)
+
+echo
+echo "$PASS passed, $FAIL failed"
+test "$FAIL" -eq 0
+```
+
+- [ ] **Step 2: Run the lint and verify it FAILS**
+
+Run: `bash plugins/workspace-jj/tests/test-model-selection-lint.sh`
+
+Expected: FAIL, exit non-zero, with `FAIL: a model: directive offers session-model inheritance` naming `fan-flames-wave-reviewer.md:16`.
+
+This failure is the point. The current directive reads:
+
+```
+  model: <per the skill's Model Selection — sonnet floor; opus for risky or final
+         waves. Always specify explicitly — an omitted model silently inherits
+         the session's model>
+```
+
+That text is *correct guidance* but it states the rule on the directive line, where rule 1 cannot distinguish a warning about session inheritance from an offer of it. **A lint that has never failed is a lint nobody has verified** — observe this failure before making it pass.
+
+- [ ] **Step 3: Tighten the directive so the lint passes**
+
+In `plugins/workspace-jj/skills/fan-flames-wave-reviewer.md`, replace:
+
+```
+  model: <per the skill's Model Selection — sonnet floor; opus for risky or final
+         waves. Always specify explicitly — an omitted model silently inherits
+         the session's model>
+```
+
+with:
+
+```
+  model: <per the skill's Model Selection — sonnet floor; opus for risky or
+         final waves. Always explicit; never omitted>
+```
+
+The directive does not need to explain *why*: the skill's Model Selection section already states that an omitted `model` inherits the session's model. The directive's job is to be unambiguous about what to write.
+
+- [ ] **Step 4: Run the lint and verify it passes**
+
+Run: `bash plugins/workspace-jj/tests/test-model-selection-lint.sh`
+
+Expected: PASS, exit 0, `4 passed, 0 failed` — rules 1 and 2 plus one case per `Agent tool:` block (`fan-flames.md:348` and `fan-flames-wave-reviewer.md:14`, both of which already carry a `model:` line).
+
+- [ ] **Step 5: Prove the lint catches the original bug**
+
+Verify the lint fails on the exact text that shipped, rather than trusting that it would:
+
+```bash
+cp plugins/workspace-jj/skills/fan-flames-wave-reviewer.md /tmp/wr-backup.md
+sed -i '' 's|model: <per the skill.s Model Selection — sonnet floor; opus for risky or|model: <per the skill'"'"'s Model Selection — sonnet floor; opus/session for risky or|' plugins/workspace-jj/skills/fan-flames-wave-reviewer.md
+bash plugins/workspace-jj/tests/test-model-selection-lint.sh; echo "exit: $?"
+cp /tmp/wr-backup.md plugins/workspace-jj/skills/fan-flames-wave-reviewer.md
+rm /tmp/wr-backup.md
+bash plugins/workspace-jj/tests/test-model-selection-lint.sh | tail -1
+```
+
+Expected: the middle run FAILS on both rule 1 and rule 2 with a non-zero exit; after restoring, the final line reads `4 passed, 0 failed`. Confirm `jj diff --stat` shows `fan-flames-wave-reviewer.md` back to just the Step 3 edit before committing.
+
+- [ ] **Step 6: Verify**
+
+```bash
+bash plugins/workspace-jj/tests/test-model-selection-lint.sh | tail -1
+bash plugins/workspace-jj/tests/test-fan-flames-scripts.sh | tail -1
+test -x plugins/workspace-jj/tests/test-model-selection-lint.sh && echo "executable" || chmod +x plugins/workspace-jj/tests/test-model-selection-lint.sh
+```
+
+Expected: `4 passed, 0 failed`; `22 passed, 0 failed`; the lint is executable (match the mode of the sibling test scripts).
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj describe -m "test(workspace-jj): lint model-selection directives in skill files
+
+PR #65 removed session-model inheritance from fan-flames.md's Model
+Selection table and missed fan-flames-wave-reviewer.md — the template the
+skill dispatches every reviewer from — which went on offering opus/session
+for three more PRs. No staleness check could catch it: source, cache, and
+installed copy all agreed at dbcf4e3, on the unfixed text. Nothing executes
+prose, so nothing checked it.
+
+Three deterministic rules over plugins/**/*.md: no model: directive mentions
+session, no file offers <tier>/session, every 'Agent tool:' block names a
+model. Verified by observing it fail on the text that actually shipped.
+
+An eval would test model behavior and pass whenever the model happened to
+pick opus anyway — the wrong instrument for a failure that is silent and
+only visible on the bill. The behavioral eval suite stays parked; the
+lint/eval split is recorded in the design doc.
+
+Scope is deliberately one rule class. Other skill rules are equally
+unexecuted and each needs its own false-positive analysis.
+
+Found by: fan-flames test run 2026-07-14 (finding #1's class)"
+jj new
+```
+
+---
+
+## Verification (whole plan)
+
+1. `bash plugins/workspace-jj/tests/test-fan-flames-scripts.sh` → `22 passed, 0 failed`
+2. `bash plugins/workspace-jj/tests/test-model-selection-lint.sh` → `4 passed, 0 failed`
+3. `grep -rn "cargo" plugins/workspace-jj/skills/` → exactly one hit, the `(e.g., cargo fmt, prettier, ruff)` formatter example
+4. `grep -rnE '(opus|sonnet|haiku)/session' plugins/` → no hits
+5. `grep -c "no-test-surface" plugins/workspace-jj/skills/fan-flames.md` → 2 (the REVIEW branch and the event list agree)
+6. `grep -c "fixing from=" plugins/workspace-jj/skills/fan-flames.md` → 2 (Fix Loop and the event list agree)
+7. `jj log -r 'trunk()..@' --no-graph -T 'description.first_line() ++ "\n"'` → the four changes, in order
+8. Read the edited regions of `fan-flames.md` once for coherence. Growth from all four tasks should stay under ~50 lines.
+
+## Known gaps (accepted, per the spec)
+
+- **Tasks 2 and 3 have no automated test.** Their verification is greps and reading. This is the design's weakest point and is deliberate: the lint closes one rule class (model directives), not the skill's prose in general.
+- **The lint's rule 1 ends a directive at the next `key:` or blank line.** A continuation line that happens to start with `word:` would end the span early. No directive in the repo does, and rule 2 catches the specific `<tier>/session` shape anywhere in a file regardless. (An earlier version of this plan shipped rule 1 as a line-based grep and accepted a much larger gap — that it could not see continuation lines at all. See Task 4's Revision.)
+- **No end-to-end re-run validates these changes.** Deferred by decision — the next genuine fan-flames use is the test. A prose regression surfaces there, not before.

--- a/docs/plans/2026-07-14-plugin-readme-audit-plan.md
+++ b/docs/plans/2026-07-14-plugin-readme-audit-plan.md
@@ -1,0 +1,169 @@
+# Plugin README Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use workspace-jj:fan-flames (per CLAUDE.md override of superpowers:subagent-driven-development). Each task touches exactly one README; all five are independent and run in a single wave.
+
+**Goal:** Audit each plugin's README against that plugin's actual commands, agents, scripts, skills, and templates, and fix any drift. READMEs have accumulated drift as plugins gained and lost components across recent PRs.
+
+**Architecture:** Markdown only. One task per plugin directory. Plugin directories are disjoint, so no task can conflict with another.
+
+**Tech Stack:** Markdown. jj for VCS.
+
+## Global Constraints
+
+- **No raw git commands anywhere** — jj equivalents only. The only exceptions are `jj git` subcommands and the `gh` CLI.
+- **Non-interactive jj forms only** — always pass `-m` to describe/commit/squash. Never run bare `jj describe`, `jj resolve`, `jj diffedit`, or `jj split` without paths.
+- **Audit, don't redesign.** Fix drift between the README and what is on disk. Do not add new features, invent components, restructure the document, or rewrite prose that is already accurate.
+- **Scope discipline.** Each task modifies exactly one file: its own plugin's README. Never edit another plugin's files, the source components themselves, or shared docs.
+- **Evidence over assumption.** Every claim you keep or write must be checked against a file you actually read. If the README documents behavior, open the command/script and confirm the behavior matches.
+
+## What "drift" means
+
+For each plugin, the README should satisfy all four:
+
+1. **No missing components** — every command, agent, skill, script, and template that exists on disk and is user-facing is documented.
+2. **No phantom components** — nothing documented that no longer exists on disk.
+3. **Accurate behavior** — descriptions, flags, arguments, and examples match what the files actually do.
+4. **Accurate names and paths** — command names, file paths, and script names are spelled as they exist.
+
+---
+
+### Task 1: agent-helpers-jj README audit
+
+**Files:**
+- Modify: `plugins/agent-helpers-jj/README.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Inventory what exists**
+
+Read every file under `plugins/agent-helpers-jj/` except the README itself: the plugin manifest, both commands, both scripts, the template, and both test files. The scripts define the actual helper functions (`jjctx`, `jjstack`, `jjconflicts`, `jjcheckpoint`) — their real behavior, flags, and output shape are the ground truth.
+
+- [ ] **Step 2: Audit the README against that inventory**
+
+Check the README against all four drift criteria in "What drift means" above. Pay particular attention to the helper functions' documented output and flags: this plugin was changed twice recently (PRs #66 and #67), and the README may describe an earlier shape. `--ignore-working-copy` handling in particular is worth verifying against the script.
+
+- [ ] **Step 3: Fix the drift**
+
+Edit `plugins/agent-helpers-jj/README.md` only. Keep the existing structure and voice.
+
+- [ ] **Step 4: Verify**
+
+Re-read your edited README start to finish and confirm every factual claim traces to a file you read in Step 1.
+
+---
+
+### Task 2: commit-commands-jj README audit
+
+**Files:**
+- Modify: `plugins/commit-commands-jj/README.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Inventory what exists**
+
+Read every file under `plugins/commit-commands-jj/` except the README itself. There are 16 command files and one script. For each command, note its name, its `description` frontmatter, and what it actually instructs.
+
+- [ ] **Step 2: Audit the README against that inventory**
+
+Check the README against all four drift criteria in "What drift means" above. This is the largest README in the repo (~549 lines) and the plugin most recently gained commands — `/absorb` was added in PR #64, and `commit-push-pr` and `finish` gained `jj git push --change` notes. Confirm every one of the 16 commands is documented and that none are documented that don't exist.
+
+- [ ] **Step 3: Fix the drift**
+
+Edit `plugins/commit-commands-jj/README.md` only. Keep the existing structure and voice. If the README organizes commands into sections or tables, place any additions where they belong rather than appending.
+
+- [ ] **Step 4: Verify**
+
+Confirm the set of commands named in the README exactly equals the set of files in `plugins/commit-commands-jj/commands/`, with no extras and no omissions.
+
+---
+
+### Task 3: peer-review-jj README audit
+
+**Files:**
+- Modify: `plugins/peer-review-jj/README.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Inventory what exists**
+
+Read every file under `plugins/peer-review-jj/` except the README itself: the manifest, the `change-reviewer` agent, the `peer-review` command, both scripts, and both skills (`receiving-change-review`, `requesting-change-review`).
+
+- [ ] **Step 2: Audit the README against that inventory**
+
+Check the README against all four drift criteria in "What drift means" above. The README is short (~47 lines) relative to the number of components, so missing components are the likeliest drift — confirm both skills, the agent, and both scripts are represented if they are user-facing.
+
+- [ ] **Step 3: Fix the drift**
+
+Edit `plugins/peer-review-jj/README.md` only. Keep the existing structure and voice.
+
+- [ ] **Step 4: Verify**
+
+Re-read your edited README start to finish and confirm every factual claim traces to a file you read in Step 1.
+
+---
+
+### Task 4: project-setup-jj README audit
+
+**Files:**
+- Modify: `plugins/project-setup-jj/README.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Inventory what exists**
+
+Read every file under `plugins/project-setup-jj/` except the README itself: the manifest, all three commands, all six scripts, and the test file. The `project-setup` command file describes the hooks it installs — that is ground truth for what the README should say setup does.
+
+- [ ] **Step 2: Audit the README against that inventory**
+
+Check the README against all four drift criteria in "What drift means" above. PR #64 added a `PreCompact` snapshot hook to the `project-setup` command; verify the README's account of which hooks get installed matches the command file.
+
+- [ ] **Step 3: Fix the drift**
+
+Edit `plugins/project-setup-jj/README.md` only. Keep the existing structure and voice.
+
+- [ ] **Step 4: Verify**
+
+Confirm the hooks and scripts the README says setup installs match what `plugins/project-setup-jj/commands/project-setup.md` actually installs.
+
+---
+
+### Task 5: workspace-jj README audit
+
+**Files:**
+- Modify: `plugins/workspace-jj/README.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Inventory what exists**
+
+Read every file under `plugins/workspace-jj/` except the README itself: the manifest, both commands (`fan-flames`, `workspace-list`), all four scripts (`fan-flames-artifacts`, `fan-flames-task-brief`, `jj-workspace-create.sh`, `jj-workspace-remove.sh`), both skills (`fan-flames.md`, `fan-flames-wave-reviewer.md`), and the test file.
+
+- [ ] **Step 2: Audit the README against that inventory**
+
+Check the README against all four drift criteria in "What drift means" above. The `fan-flames` skill was substantially changed in PRs #64 and #65 (ledger `start-op` and run rollback, evolog-scoped fix re-reviews, divergent-change guidance, model selection). If the README summarizes the skill's phases, flags, or behavior, verify that summary against `skills/fan-flames.md` as it exists now.
+
+- [ ] **Step 3: Fix the drift**
+
+Edit `plugins/workspace-jj/README.md` only. Do not edit the skill — the README describes it, not the reverse.
+
+- [ ] **Step 4: Verify**
+
+Confirm the README's account of fan-flames' flags and phases matches `plugins/workspace-jj/skills/fan-flames.md`.
+
+---
+
+## Verification (whole plan)
+
+1. Exactly five files changed, one README per plugin.
+2. No source component (command, script, skill, agent, template) was modified.
+3. For each plugin: the set of components named in the README equals the set on disk.

--- a/docs/specs/2026-07-14-fan-flames-correctness-fixes-design.md
+++ b/docs/specs/2026-07-14-fan-flames-correctness-fixes-design.md
@@ -1,0 +1,233 @@
+# fan-flames correctness fixes (design)
+
+**Date:** 2026-07-14
+**Status:** Approved, not yet implemented.
+
+> **Provenance:** every fix below was found by *running* fan-flames end-to-end against the #64/#65 changes (a five-task plugin README audit, one wave, five parallel workspaces). None came from reading the skill. The run's ledger and artifacts are the evidence; the findings are numbered as reported there. Finding #1 shipped separately during the same session and is out of scope here.
+
+## Goal
+
+Correct eight defects in `workspace-jj:fan-flames` that only surface when the skill is executed: dangling brief context, an integrity check that misfires on Wave 1 and never re-runs after fixes, a test gate that assumes Rust and cannot express "no test can validate this wave", and two commands whose documented form is subtly wrong.
+
+The unifying property: **every one of these is invisible to review and visible on the first run.** #1 — the bug that opened this thread — survived three PRs of human review of the diff, then took minutes to find by dispatching one agent. This design does not fix that gap (see Non-Goals), but it is the reason the gap is worth naming.
+
+## Root causes, not findings
+
+The eight findings collapse into four causes. Fixing causes rather than symptoms is what makes this three changes instead of eight.
+
+| Cluster | Findings | Root cause |
+|---|---|---|
+| **A. Rust assumption** | #5, #6, #7 | The skill assumes a test suite exists and that it is `cargo test` |
+| **B. Integrity model** | #3, #4 | The check is one-shot, and its Wave 1 baseline assumes an empty `@` |
+| **C. Brief not self-contained** | #2 | `fan-flames-task-brief` extracts only the task section |
+| **D. Wrong commands** | #8, #9 | `evolog --limit 2` and `resolve --list` are both subtly wrong |
+| **E. Nothing executes prose** | #1's *class* | No mechanism asserts that skill text states the rules correctly |
+
+Cluster E is not one of the numbered findings. It is why #1 existed, and it is the only cluster that prevents a recurrence rather than fixing an instance.
+
+## Architecture
+
+Five files. Clusters C and E carry code; the rest is prose in the skill.
+
+| File | Nature | Clusters |
+|---|---|---|
+| `plugins/workspace-jj/scripts/fan-flames-task-brief` | code | C |
+| `plugins/workspace-jj/tests/test-fan-flames-scripts.sh` | code | C |
+| `plugins/workspace-jj/tests/test-model-selection-lint.sh` | **new**, code | E |
+| `plugins/workspace-jj/skills/fan-flames.md` | prose | A, B, C, D |
+| `plugins/workspace-jj/skills/fan-flames-wave-reviewer.md` | prose | A, E |
+
+---
+
+## Cluster C — self-contained briefs
+
+**The defect.** `fan-flames-task-brief` extracts from `### Task N` to the next task heading. Plan-level sections — Global Constraints, shared definitions, Tech Stack — are silently dropped. The dispatch template then tells the agent the brief "is your requirements, with the exact values to use verbatim." It isn't. In the test run, every brief contained the phrase *"all four drift criteria in 'What drift means' above"* with no "above" present.
+
+This is not an artifact of the test plan. `docs/plans/2026-07-13-jj-agent-safety-plan.md` — the plan that produced #64 — has Task 1 declaring *"Produces: the canonical conflict-resolution wording (see Global Constraints)"*. That brief dangles identically.
+
+**The skill also contradicts itself on the remedy.** The dispatch template offers a slot for "decisions the brief cannot know," while the dispatch rules forbid pasting "task text, plan excerpts, or prior-wave summaries" into the prompt. Global Constraints are a plan excerpt. Filling the slot breaks the rule; obeying the rule leaves the agent underspecified. There is no compliant path.
+
+**The fix.** The script prepends the plan's preamble — everything before the first task heading — to each brief, separated by `---`. The brief becomes what the skill already claims it is.
+
+```
+## <plan preamble: Goal, Global Constraints, shared definitions>
+
+---
+
+### Task 3: peer-review-jj README audit
+...
+```
+
+**Rejected: point agents at the plan file path.** This cannot work and the run proved it. Wave 1 workspaces are pinned to `@-`, and the plan document typically lives in `@` — so the file is absent from the workspace. This was discovered live, when the orchestrator's ad-hoc `plan-context.md` had to go in `/tmp` for exactly this reason.
+
+**Rejected: orchestrator writes a shared `plan-context.md`.** Workable (it is what the run did as a stopgap), but it adds an artifact type and requires every dispatch to remember a second path. One file the agent reads is better than two it must be told about.
+
+**Edges the tests must pin:**
+
+1. Plan **with** a preamble → brief carries preamble, separator, task.
+2. Plan **without** a preamble → brief is the task alone, no leading separator.
+3. Task not found → still exits 3 (regression).
+4. Preamble extraction is fence-aware, matching the existing task extractor: a `### Task 1` inside a code fence must not terminate the preamble.
+
+Edge 4 is not hypothetical. `docs/plans/2026-07-12-fan-flames-context-economics-plan.md` contains **three `### Task N` headings inside code fences**. A non-fence-aware preamble extractor terminates at the first one and silently truncates the preamble. The existing task extractor is already fence-aware; the preamble pass must match it, or the two halves of the same script will disagree about where the first task begins.
+
+**Ad-hoc input is unaffected** — the orchestrator writes those briefs itself and can include whatever it needs.
+
+---
+
+## Cluster A — de-Rust, and name the vacuous gate
+
+**The defect, part one (cosmetic).** `cargo test` appears in three places that assume Rust: the phase diagram (`fan-flames.md:34`, a flat assertion), the test gate (`:575`, hedged with "or the project's equivalent"), and the reviewer template (`fan-flames-wave-reviewer.md:61`, unhedged — *"cargo test already passes — don't re-verify test values"*). This repo contains no Rust. Every reviewer dispatched during the test run was told a suite passed that does not exist.
+
+`fan-flames.md:393` reads `(e.g., cargo fmt, prettier, ruff)`. That is an honest multi-language example and **stays**.
+
+**The defect, part two (blocking).** REVIEW Step 1 calls the test suite "the primary spec compliance gate." Fix Loop step 2 goes further: *"The report must contain the covering tests, the command run, and the output — confirm all three are present before re-dispatching the reviewer."*
+
+For a wave that changes only documentation, no test can reach the changes. Taken literally, that gate can never be satisfied and **the fix loop can never advance**. The test run hit this wall and had to deviate to proceed.
+
+**The fix.** REVIEW Step 1 gains an explicit branch: if the wave's changes have no test surface, record `wave W: no-test-surface` and rely on review — do not fabricate a test, and do not report a vacuous pass as a pass. Fix Loop step 2 gains the matching escape: if no test covers the change, the report must say so explicitly and state what was verified instead.
+
+**Why not a general "Verification Gate" rewrite.** Considered and cut. Reframing Step 1 as "whatever verification the project affords" is more conceptually correct and more future-proof, but it churns text that works today for waves that do have tests. The narrow fix addresses the actual block. Revisit if a third case appears.
+
+---
+
+## Cluster B — fix the integrity model
+
+**The defect, part one.** The Workspace Integrity Check says: *"in Wave 1, `@` should show no changes… If `@` differs from its baseline, at least one agent failed to `cd`."* Nothing in the Prerequisites requires `@` to be empty — prerequisite 3 asks only for "a description and be a sensible parent."
+
+In the test run, `@` held the plan document (169 insertions), written before PLAN. By the letter of the skill this was a `WORKSPACE_LEAK` and should have been escalated to the user. It was a false positive. Any run started from a non-empty `@` — plan doc in the working copy, or building on WIP — trips this.
+
+The Wave 2+ rule is **already correct**: "compare against the stat recorded after the previous FAN IN." Wave 1 is the odd one out.
+
+**The fix.** PLAN records `jj diff -r @ --stat` as the run's baseline. Wave 1 compares against that recorded baseline rather than against zero. This makes Wave 1 and Wave 2+ the same rule, stated once.
+
+**The defect, part two.** The integrity check runs after COLLECT and never again. Fix subagents `cd` into workspaces exactly as implementers do, and are exactly as exposed.
+
+**This is not hypothetical.** In the test run, task 5's fix subagent edited the orchestrator's workspace instead of its own — *"my first edit attempt accidentally landed on the default workspace… because Bash cwd resets between calls."* It self-caught and reverted. Had it not, the leak would have reached FAN IN unchecked, because the skill never looks again.
+
+**The fix.** The integrity check re-runs after each fix-loop round, against the same recorded baseline. A control that fires once cannot cover an agent dispatched later.
+
+---
+
+## Cluster D — correct the commands
+
+### #8 — the fix delta
+
+**The defect.** Fix Loop step 3 prescribes `jj evolog -r <change-id> -p --limit 2` as showing "exactly what the fix changed." `--limit 2` counts *evolution steps*, not "the fix." A `jj describe` is an evolution step: in the test run, describes consumed a window slot in three of four fixes. The windows happened to remain complete because each fix was a single snapshot.
+
+One extra `jj` invocation between edits — an agent running `jj diff` to check itself mid-fix — yields `[describe][snapshot-2]` and **silently truncates the delta**. A partial fix delta looks exactly like a complete small one; the reviewer cannot detect the truncation.
+
+To be precise: **this did not bite in the test run.** All four windows were verified complete. It is latent, not observed.
+
+**The fix.** Stop discovering the boundary retroactively; record it prospectively. Before dispatching a fix subagent, the orchestrator captures the change's current commit ID to the ledger:
+
+```
+task 4: fixing from=1f67fa9cefa8
+```
+
+The re-review then uses the exact delta:
+
+```
+jj diff --from 1f67fa9cefa8 --to <change-id>
+```
+
+**Verified during the run:** hidden commits remain diffable by commit ID even after the change is squashed and abandoned — `jj diff --from e3c35569 --to cd9441a9` returned task 1's fix precisely. The mechanism is sound.
+
+The same session demonstrated why retroactive discovery fails: an attempt to guess task 4's pre-fix boundary from its five evolog entries picked the wrong pair and returned `0 files changed`. The orchestrator knows the boundary unambiguously at exactly one moment — immediately before it dispatches the fix. Record it there.
+
+### #9 — the conflict check
+
+**The defect.** FAN IN step 2 presents `jj resolve --list` as a bash conflict check. On a clean revision it prints `Error: No conflicts found at this revision` and **exits 2**. Any scripted use (`set -euo pipefail`, or `if jj resolve --list; then`) reads the clean case as a failure — inverted.
+
+**The fix.** Use `jj log -r 'conflicts()'` — exit 0, empty output when clean. This matches the repo's own `jjconflicts` helper (exit 0 = clean, 1 = conflicts). `jj resolve --list` remains useful for a human reading which files conflict; it is not a check.
+
+---
+
+---
+
+## Cluster E — a lint for the rule class
+
+**The defect.** #1 was a `model:` directive offering `opus/session` — the exact session-model inheritance PR #65 set out to remove — sitting in the template the skill dispatches every reviewer from. It survived three PRs of review. Nothing caught it because **nothing executes prose**: source, cache, and installed copy all agreed at `dbcf4e3`, so no staleness check could fire, and no test reads a skill file.
+
+**Why an eval is the wrong instrument here.** The eval-suite idea (adapted from `netresearch/jujutsu-workflow-skill`, whose `evals/evals.json` runs prompt-plus-assertion cases like `describe-noninteractive` and `pager-hang-avoidance`) tests *model behavior* given a prompt. #1 is a defect in *file text*. An orchestrator reading `opus/session` may well still pick `opus` — the eval passes green while the bug persists. Since #1's failure mode is silent and only visible on the bill, a probabilistic instrument is the wrong shape for it.
+
+A lint is deterministic, needs no model call, and cannot flake. Note that netresearch runs both: `evals/` alongside `.markdownlint-cli2.jsonc` and `tests/smoke_test.sh`. The two instruments cover two different gaps:
+
+| Gap | Instrument | Catches #1? |
+|---|---|---|
+| Skill text asserts something wrong | **Lint** | Yes — deterministically |
+| Skill text leads the model to act wrong | **Eval** | Unreliably — passes if the model guesses right |
+
+**The fix.** A new `plugins/workspace-jj/tests/test-model-selection-lint.sh` scanning `plugins/**/*.md`, asserting two rules:
+
+1. **No `model:` directive mentions `session`.** The regression guard for #1 — it fails on the exact text that shipped.
+2. **Every agent-dispatch block carries a `model:` line.** The omission guard, which is #65's actual concern: an omitted `model` is what silently inherits.
+
+**Deliberately not a rule: "must name an explicit tier."** `fan-flames.md:350` reads `model: <per Model Selection — always specify explicitly>`, which names no tier and is entirely correct — it points at the table. A tier rule would flag good text, and a lint that cries wolf gets deleted.
+
+**Rule 1 forces a rewording of #1's own fix.** The shipped text is a directive spanning three lines:
+
+```
+  model: <per the skill's Model Selection — sonnet floor; opus for risky or final
+         waves. Always specify explicitly — an omitted model silently inherits
+         the session's model>
+```
+
+`session` sits on the **third** line, not the `model:` line — so rule 1 must read the whole directive (`model:` line through the next `key:` or blank line), not a single line. A line-based check cannot see this, and would ship green while the rule it claims to enforce goes unenforced.
+
+The template does not need to explain *why* an omitted model is expensive — the skill's Model Selection section already does, and stating the policy inside the directive is what made the rule unstatable. It tightens to `<… Always explicit; never omitted>`. The lint improving the fix that prompted it is the point.
+
+**Location.** `workspace-jj/tests/` despite scanning repo-wide, because workspace-jj owns the Model Selection rule and the repo has no top-level test convention (verified: every test lives under `plugins/*/tests/`, and there is no root runner). If a second repo-wide lint ever appears, that convention deserves revisiting — one lint does not justify inventing it.
+
+---
+
+## Minors folded in
+
+**Recovery depends on an unestablished convention.** COLLECT's "Recovery: Missing Change IDs" recovers a crashed agent's work via `jj log -r 'description("Task N: …")'`. Nothing in the dispatch template tells implementers to describe their change. The safety net presumes a convention the skill never sets. The dispatch template gains `jj describe -m "Task N: <short description>"`.
+
+**Empty changes are legitimate.** A task can correctly produce no change — task 3 audited `peer-review-jj`, found no drift, and returned an empty change. The reviewer independently verified that negative claim and it held. The skill has no branch for this. `jj squash` handles it gracefully (it abandons the empty source, silently), so this is documentation only: COLLECT notes that an empty change may be a valid outcome, not a failure.
+
+## Ledger schema additions
+
+Two new event lines. Both must be added to the event-lines list in Durable Progress — that list is the ledger's schema, and a resume that encounters an undocumented event is a resume that guesses.
+
+| Event | Written at |
+|---|---|
+| `wave W: no-test-surface` | REVIEW Step 1, when no test can reach the wave's changes |
+| `task N: fixing from=<commit-id>` | Fix Loop step 1, before dispatching the fix subagent |
+
+## Delivery
+
+A stack of four changes:
+
+1. **`fix(fan-flames): self-contained task briefs`** — script + tests + skill note.
+2. **`fix(fan-flames): de-Rust the test gate, handle waves with no test surface`** — spans both prose files.
+3. **`fix(fan-flames): correct the integrity model and fix-delta commands`** — Clusters B + D, plus the minors and ledger events.
+4. **`test(workspace-jj): lint model-selection directives in skill files`** — Cluster E, plus the rule-1 rewording of #1's text.
+
+Each is independently revertable. Stacking is free in jj.
+
+**Change 4 goes last on purpose.** It codifies the rule the earlier changes must satisfy, so it lands green rather than red. No intermediate change fails a lint that does not exist yet at its point in the stack; the lint passes at HEAD.
+
+## Testing
+
+**Clusters C and E are genuinely tested.** `test-fan-flames-scripts.sh` grows from 15 cases to 22, covering the brief edges. `test-model-selection-lint.sh` is itself a test (4 cases: two rules plus one per `Agent tool:` block), and must be verified by observation — a lint that has never failed is a lint nobody has verified. It is run against the pre-fix `opus/session` text and watched to fail before being trusted.
+
+**Clusters A, B, and D have no automated test.** Verification is sentinel greps plus reading the edited regions. This is stated plainly because it remains the design's weakest point. Greps confirm text is present; they cannot confirm it is right. Cluster E closes exactly one rule class — the model directives — and nothing more. The rest of the skill's prose is still unexecuted.
+
+**The only real test is another run.** Deliberately deferred: rather than burn a synthetic run now, the next genuine fan-flames use validates these changes. Accepted risk — a prose regression here surfaces on that run, not before it.
+
+## Non-Goals
+
+- **A general Verification Gate rewrite** (see Cluster A) — revisit if a third case appears.
+- **An eval suite for skill prose.** Still parked, where the `2026-07-13` plan put it ("Eval suite (`claude plugin eval` cases) — right long-term practice, separate initiative"). Cluster E takes the deterministic half of that idea at a fraction of the cost; the behavioral half remains a real initiative and a real gap. Adopting netresearch's `evals.json` format is the obvious starting point when it happens.
+- **Generalizing the lint beyond model directives.** Many other skill rules are equally unexecuted (the non-interactive-forms rule, the artifact path handoffs). Each would need its own assertion and its own false-positive analysis. One rule class, proven, first.
+- **Re-auditing #64's other changes.** Swept during the test run and clean: #64's interactive-forms verification grep still passes, and the `opus/session` miss was confirmed bounded to one file. The other `model`/`session` hits across the plugins are pinned frontmatter (`change-reviewer.md:17`, `receiving-change-review.md:118`) and a coincidental `SessionState` example.
+
+## Why the staleness model missed #1
+
+Worth recording, because it generalizes. The three-layer model (source → cache → installed copy) checks whether the layers *agree*. For #1 they agreed perfectly, all at `dbcf4e3`, including the installed copy — they agreed on the **unfixed text**. A currency check cannot find a fix that was never written.
+
+The generalization: when a PR fixes a rule stated in one file, check every file that *restates* the rule. `fan-flames.md` holds the Model Selection table; `fan-flames-wave-reviewer.md` restated it and drifted. Skills that dispatch from templates have two copies of every rule, and only one of them gets reviewed.
+
+Cluster E is that generalization made mechanical, for one rule class. A human remembering to check restatements is a practice; a lint asserting no restatement offers session inheritance is a guarantee. The practice is still worth holding — the lint covers model directives and nothing else — but it is worth noticing that the rule most worth remembering is the one now enforced without anyone remembering it.

--- a/plugins/agent-helpers-jj/README.md
+++ b/plugins/agent-helpers-jj/README.md
@@ -29,11 +29,13 @@ This is a **machine-level, one-time** install (not per-project). It:
 1. copies the helper script to `~/.config/jj-agent-helpers/jj-agent-helpers.sh`;
 2. adds a `source` line to `~/.zshrc` (consent-gated);
 3. adds a one-line catalog to `~/.claude/CLAUDE.md` so agents know the helpers exist;
-4. allowlists the six helpers in `~/.claude/settings.json` so they run prompt-free.
+4. allowlists the four helpers in `~/.claude/settings.json` so they run prompt-free.
 
 **Restart Claude Code afterward** — the helpers become callable only once the next
 session regenerates its shell snapshot.
 
 Uninstall with `/agent-helpers-remove` (reverses all four steps).
 
-Requires zsh and `jj`. Bash shells are not supported in this version.
+Requires zsh, `jj`, and [`jq`](https://jqlang.github.io/jq/) (used by the
+installer to edit `~/.claude/settings.json`). Bash shells are not supported in
+this version.

--- a/plugins/commit-commands-jj/README.md
+++ b/plugins/commit-commands-jj/README.md
@@ -8,6 +8,8 @@ The Commit Commands Plugin for jj automates common Jujutsu operations, reducing 
 
 **Key difference from Git**: In jj, the working copy IS already a commit. There is no staging area. All changes are automatically tracked. The `/commit` command finalizes the current change with a description and starts a new empty change on top.
 
+The plugin itself (independent of any specific command above) also registers a `PreToolUse` hook on all `Bash` calls that blocks raw `git` commands, backed by `scripts/block-raw-git.sh`. This is active as soon as the plugin is enabled.
+
 ## Setup
 
 ### Colocated repos (`.jj/` + `.git/`)
@@ -92,12 +94,51 @@ Complete workflow command that commits, pushes, and creates a pull request in on
 **Features:**
 - Uses jj revsets (`trunk()`) for idiomatic trunk detection
 - Creates bookmarks automatically when needed
+- For a quick anonymous push, skips bookmark creation and pushes directly with `jj git push --change @-` (generates a `push-<change-id>` bookmark)
 - Works with colocated repos out of the box
 - For non-colocated repos, provides guidance on `GIT_DIR` setup
 
 **Requirements:**
 - GitHub CLI (`gh`) must be installed and authenticated
 - Repository must have a remote configured
+
+### `/finish`
+
+Finishes development work by presenting a menu of completion options and executing the chosen workflow. Replaces `superpowers:finishing-a-development-branch` for jj repos.
+
+**What it does:**
+1. Verifies the target change (current or parent, if `@` is empty) has content against trunk
+2. Presents four options: push and create a PR, squash into trunk (local merge), keep as-is, or discard
+3. Executes the chosen workflow:
+   - **Push and create PR:** warns about non-target ancestor changes that would be swept into the PR, creates a bookmark if needed (or uses `jj git push --change <target>` for a quick anonymous push), pushes with `jj git push --bookmark`, and opens the PR with `gh pr create`
+   - **Squash into trunk:** fetches, rebases the change onto trunk, and folds it in with `jj squash --into trunk()`
+   - **Keep as-is:** reports the change ID and stops — no cleanup
+   - **Discard:** requires typed confirmation, then runs `jj abandon`
+4. For push, squash, and discard, cleans up the jj workspace if running in a non-default one (`jj workspace forget`)
+
+**Usage:**
+```bash
+/finish
+```
+
+**Example workflow:**
+```bash
+# Work is done and tested:
+/finish
+
+# Claude will:
+# - Confirm there's work to finish (against trunk)
+# - Ask which of the 4 options you want
+# - Execute it (push+PR, squash, keep, or discard)
+# - Clean up the workspace if applicable
+```
+
+**Features:**
+- Never force-pushes — uses `jj git push` only
+- Requires typed confirmation before discarding work (recoverable via `/undo`)
+- Detects and warns about ancestor changes not part of the target work before pushing
+- After a PR merges, abandons the now-landed local ancestor changes as part of cleanup
+- Does not run tests or reviews — finishing work is its own concern
 
 ### `/describe`
 
@@ -256,6 +297,38 @@ Squashes the current change into its parent, combining their content and descrip
 - Reports "nothing to squash" if the current change is empty
 - Supports `--into <rev>` for squashing into a non-parent change
 - Automatically cleans up combined descriptions
+
+### `/absorb`
+
+Distributes the working copy's edits into the mutable ancestor changes that last touched those lines.
+
+**What it does:**
+1. Reports "nothing to absorb" if the current change has no diff
+2. Runs `jj absorb` (optionally scoped to specific paths, or `--into <revset>` to restrict target changes)
+3. Reports which changes absorbed what, from the command's output
+4. Flags any edits left in the working copy afterward — lines with no single clear ancestor are left behind by design; suggests `/squash` for those
+
+**Usage:**
+```bash
+/absorb
+```
+
+**Example workflow:**
+```bash
+# Fixed a bug that touches three earlier changes in a stack:
+/absorb
+
+# Claude will:
+# - Distribute your edits into the changes that last touched those lines
+# - Report which change absorbed what
+# - Flag any leftover edits that need a manual /squash
+```
+
+**Features:**
+- jj's built-in equivalent of `git absorb` — no plugin needed
+- Fixes the "I amended three stacked changes in one sitting" problem
+- Scope with `--into <revset>` or specific paths
+- Leftover edits (no clear single ancestor) are reported, not silently dropped
 
 ### `/undo`
 
@@ -459,6 +532,11 @@ claude plugins add ./plugins/commit-commands-jj
 - Ensure all your changes are complete and tested
 - Review the PR description and edit if needed
 
+### Using `/finish`
+- Use when work is complete and tested — it presents the completion options rather than assuming one
+- Get typed confirmation before discarding; `/undo` can still recover it immediately after
+- Prefer this over `/commit-push-pr` when you also want the squash-into-trunk, keep, or discard paths
+
 ### Using `/new`
 - Run after `/commit` to start fresh work
 - Use `/new <rev>` to branch from a specific change
@@ -478,6 +556,11 @@ claude plugins add ./plugins/commit-commands-jj
 - Use to fold small fixups into the parent change
 - Check the combined description after squashing
 - For squashing into non-parent changes, specify `--into <rev>`
+
+### Using `/absorb`
+- Use for stacked changes — fold a fix into whichever ancestor last touched those lines
+- Restrict scope with `--into <revset>` or specific paths when you don't want it touching the whole stack
+- Check for leftover edits afterward — not every line has a single clear ancestor
 
 ### Using `/undo`
 - Safe to run — the undo itself can be undone

--- a/plugins/project-setup-jj/README.md
+++ b/plugins/project-setup-jj/README.md
@@ -7,9 +7,12 @@ Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a s
 When starting a new Claude Code project that uses jj, there's no automated way to set up jj workflow enforcement. This plugin adds a `/project-setup` command that configures everything in one step:
 
 - **SessionStart hook** — shows current jj change, status, and workflow reminder when a session starts
-- **PreToolUse guard hook** — prompts you to run `jj new` before editing into a non-empty change
+- **PreToolUse guard hook** — advises Claude to run `jj new` before editing into a non-empty change (informational — does not block)
+- **PreCompact hook** — snapshots the working copy before context compaction so `jj undo` / `jj op restore` can always reach the pre-compaction state
 - **CLAUDE.md template** — slim jj VCS policy directive
 - **Permissions** — pre-allows jj commands and gh CLI, denies raw git
+
+The plugin itself (independent of running `/project-setup`) also registers a `PreToolUse` hook on all `Bash` calls that blocks raw `git` commands and git internals access, backed by `scripts/block-raw-git.sh`. This is active as soon as the plugin is enabled.
 
 ## Installation
 
@@ -30,10 +33,10 @@ This creates/updates the following in your project:
 | File | Purpose |
 |------|---------|
 | `.claude/scripts/jj-session-start.sh` | SessionStart hook showing jj context |
-| `.claude/scripts/require-jj-new.sh` | PreToolUse hook — prompts `jj new` before editing non-empty changes |
+| `.claude/scripts/require-jj-new.sh` | PreToolUse hook — advises Claude to run `jj new` before editing into a non-empty change (informational — does not block) |
 | `.claude/scripts/jj-workspace-create.sh` | WorktreeCreate hook — creates jj workspace for worktree isolation |
 | `.claude/scripts/jj-workspace-remove.sh` | WorktreeRemove hook — cleans up jj workspace |
-| `.claude/settings.local.json` | Hook registration + jj permissions |
+| `.claude/settings.local.json` | Hook registration (SessionStart, PreToolUse, PreCompact, WorktreeCreate, WorktreeRemove) + jj permissions |
 | `CLAUDE.md` | jj VCS policy directive (created or updated) |
 
 **Restart Claude Code** after running `/project-setup` for the SessionStart hook to take effect.
@@ -51,12 +54,31 @@ Current change:
 Working copy status:
 <modified/added files>
 
+Repository config (JSON):
+<repository config>
+
 == jj Workflow Reminder ==
 - Use `jj new` to start a fresh change before making edits
 - Use `jj describe -m "..."` to set intent on the current change
 - Use `jj diff` to review working copy changes
 - Never use raw git commands — use jj equivalents
 ```
+
+## Statusline
+
+Two more commands manage a jj-aware statusline, independent of `/project-setup`:
+
+```
+/statusline-jj-setup
+```
+
+Copies `.claude/scripts/statusline-jj.sh` into the project and sets it as the `statusLine` command in `.claude/settings.local.json`. The statusline is a powerline-style bar showing the model, bookmark, change ID, change description, trunk-sync status, context-window percentage, and Anthropic service status.
+
+```
+/statusline-jj-remove
+```
+
+Removes `.claude/scripts/statusline-jj.sh` and deletes the `statusLine` key from `.claude/settings.local.json`.
 
 ## Idempotent
 

--- a/plugins/workspace-jj/README.md
+++ b/plugins/workspace-jj/README.md
@@ -4,7 +4,7 @@ Wave-based parallel orchestration with spec review gates for jj (Jujutsu) reposi
 
 ## Overview
 
-Provides the **fan-flames** skill — a parallel task orchestrator that dispatches subagents to isolated jj workspaces, reviews their work per-task, then reunifies results into a single change. The jj-native replacement for superpowers' `subagent-driven-development`. Workspace hooks are installed by `/project-setup` from the [project-setup-jj](../project-setup-jj) plugin.
+Provides the **fan-flames** skill — a parallel task orchestrator that dispatches subagents to isolated jj workspaces, gates each wave with a test + peer review pass, then reunifies results into a single change. The jj-native replacement for superpowers' `subagent-driven-development`. Workspace hooks are installed by `/project-setup` from the [project-setup-jj](../project-setup-jj) plugin.
 
 ## How It Works
 
@@ -27,8 +27,8 @@ Workspace hooks are installed automatically by `/project-setup` from the [projec
 
 | Command | Description |
 |---------|-------------|
-| `/fan-flames [plan-file]` | Execute a plan using wave-based parallel orchestration with spec review gates |
-| `/workspace-list` | List all active jj workspaces (JSON output) |
+| `/fan-flames [plan-file] [--skip-review] [--merge-order auto\|task-1,task-2,...]` | Execute a plan using wave-based parallel orchestration with spec review gates |
+| `/workspace-list` | List all jj workspaces with JSON output |
 
 ## Usage
 
@@ -39,7 +39,7 @@ claude --worktree feature-auth
 # Auto-generated name
 claude --worktree
 
-# List active workspaces
+# List all workspaces
 /workspace-list
 ```
 
@@ -81,10 +81,10 @@ Workspaces are cleaned up automatically when you exit a session and choose to re
 
 ## Fan-Flames Skill
 
-Parallel workspace orchestration — fan out tasks to isolated jj workspaces, fan in results.
+Wave-based parallel workspace orchestration — fan out tasks to isolated jj workspaces, gate each wave on a test + peer review pass, then fan in the review-approved results.
 
 ```
-🪭 Fan out → N workspaces → N subagents → 🔥 Fan in → single change → /peer-review
+PLAN → per wave: 🪭 Fan out → Collect → Review (test + peer review) → 🔥 Fan in → next wave or report
 ```
 
 **Usage:** Triggered automatically when `subagent-driven-development` runs in a jj repo, or directly:
@@ -98,7 +98,7 @@ Parallel workspace orchestration — fan out tasks to isolated jj workspaces, fa
 - **Auto-chained:** Content already merged — skip squash, optionally `jj parallelize` for clean history
 - **Independent branches:** Squash each into `@`, smallest diff first (by files touched)
 
-Override merge order with `--merge-order task-3,task-1,task-2`.
+Override merge order with `--merge-order task-3,task-1,task-2`. Skip the REVIEW phase (cleanup straight to FAN IN, no test + peer review) with `--skip-review`.
 
 **Failure handling:** Partial success is preserved. Failed workspaces stay alive for inspection via `/workspace-list`.
 

--- a/plugins/workspace-jj/scripts/fan-flames-task-brief
+++ b/plugins/workspace-jj/scripts/fan-flames-task-brief
@@ -6,6 +6,12 @@
 # A task starts at a markdown heading matching "Task N" (any heading level)
 # and ends at the next task heading. Headings inside code fences are ignored.
 #
+# The plan's preamble — everything before the first task heading — holds the
+# Global Constraints and shared definitions that task text references but does
+# not repeat. It is prepended to every brief, because the skill tells
+# implementers the brief IS their requirements, and without the preamble that
+# claim is false.
+#
 # Usage: fan-flames-task-brief PLAN_FILE TASK_NUMBER [OUTFILE]
 # Default OUTFILE: <artifacts-dir>/task-<N>-brief.md
 set -euo pipefail
@@ -26,17 +32,40 @@ else
   out="$dir/task-${n}-brief.md"
 fi
 
-awk -v n="$n" '
+task=$(awk -v n="$n" '
   /^```/ { infence = !infence }
   !infence && /^#+[ \t]+Task[ \t]+[0-9]+/ {
     intask = ($0 ~ ("^#+[ \t]+Task[ \t]+" n "([^0-9]|$)"))
   }
   intask { print }
-' "$plan" > "$out"
+' "$plan")
 
-if [ ! -s "$out" ]; then
+if [ -z "$task" ]; then
   echo "task ${n} not found in ${plan} (no heading matching 'Task ${n}')" >&2
   exit 3
 fi
+
+# Everything before the first task heading. Same fence awareness as the task
+# pass above — otherwise the two halves of this script would disagree about
+# where the first task begins.
+preamble=$(awk '
+  /^```/ { infence = !infence }
+  !infence && /^#+[ \t]+Task[ \t]+[0-9]+/ { exit }
+  { print }
+' "$plan")
+
+# Plans conventionally close their preamble with a horizontal rule before the
+# first task, and we add a separator of our own — drop theirs so the brief does
+# not carry a doubled rule.
+preamble=${preamble%$'\n'---}
+[ "$preamble" = "---" ] && preamble=""
+while [ "$preamble" != "${preamble%$'\n'}" ]; do preamble=${preamble%$'\n'}; done
+
+{
+  if [ -n "$(printf '%s' "$preamble" | tr -d '[:space:]')" ]; then
+    printf '%s\n\n---\n\n' "$preamble"
+  fi
+  printf '%s\n' "$task"
+} > "$out"
 
 echo "wrote ${out}: $(wc -l < "$out" | tr -d ' ') lines"

--- a/plugins/workspace-jj/skills/fan-flames-wave-reviewer.md
+++ b/plugins/workspace-jj/skills/fan-flames-wave-reviewer.md
@@ -13,7 +13,9 @@ Use this template when dispatching peer review agents during the REVIEW phase.
 ```
 Agent tool:
   subagent_type: "peer-review-jj:change-reviewer"
-  model: <per the skill's Model Selection — sonnet floor; opus/session for risky or final waves>
+  model: <per the skill's Model Selection — sonnet floor; opus for risky or final
+         waves. Always specify explicitly — an omitted model silently inherits
+         the session's model>
   description: "Wave N review: <files summary>"
   prompt: |
     You are reviewing code from a parallel execution wave. You have the original

--- a/plugins/workspace-jj/skills/fan-flames-wave-reviewer.md
+++ b/plugins/workspace-jj/skills/fan-flames-wave-reviewer.md
@@ -13,9 +13,8 @@ Use this template when dispatching peer review agents during the REVIEW phase.
 ```
 Agent tool:
   subagent_type: "peer-review-jj:change-reviewer"
-  model: <per the skill's Model Selection — sonnet floor; opus for risky or final
-         waves. Always specify explicitly — an omitted model silently inherits
-         the session's model>
+  model: <per the skill's Model Selection — sonnet floor; opus for risky or
+         final waves. Always explicit; never omitted>
   description: "Wave N review: <files summary>"
   prompt: |
     You are reviewing code from a parallel execution wave. You have the original

--- a/plugins/workspace-jj/skills/fan-flames-wave-reviewer.md
+++ b/plugins/workspace-jj/skills/fan-flames-wave-reviewer.md
@@ -58,7 +58,9 @@ Agent tool:
 
     ## Your Job
 
-    cargo test already passes — don't re-verify test values.
+    The wave's test gate has already run — don't re-verify test values.
+    If the orchestrator told you this wave has no test surface, then no
+    automated check has validated this work at all; review accordingly.
     Focus on what tests CAN'T catch.
 
     1. **Spec compliance:** does the code match the spec? Missing/extra/wrong?

--- a/plugins/workspace-jj/skills/fan-flames.md
+++ b/plugins/workspace-jj/skills/fan-flames.md
@@ -293,7 +293,8 @@ Once waves are confirmed:
 2. Write one brief per task:
    - **Plan document input:** `../scripts/fan-flames-task-brief <plan-file> <N>`
      for each task — the script extracts the task's full text without it
-     passing through your context again
+     passing through your context again, and prepends the plan's preamble
+     (Global Constraints, shared definitions) so the brief stands alone
    - **Ad-hoc input:** Write `<artifacts>/task-N-brief.md` yourself containing
      the full task description
 3. Initialize the ledger — write the header and wave plan to

--- a/plugins/workspace-jj/skills/fan-flames.md
+++ b/plugins/workspace-jj/skills/fan-flames.md
@@ -31,7 +31,7 @@ PLAN ─── validate independence, compute waves, confirm with user
   ║     │       classify status                  ║
   ║     │       workspaces kept alive            ║
   ║     ▼                                        ║
-  ║  REVIEW ── cargo test (spec gate)            ║
+  ║  REVIEW ── test suite (spec gate)            ║
   ║     │      spec-informed peer review         ║
   ║     │      (batched, ~1 agent per 300 lines) ║
   ║     │      fix loop on critical findings     ║
@@ -573,10 +573,18 @@ materialize files on disk):
 
 ```bash
 # For each task in the wave:
-(cd /tmp/jj-workspaces/<repo>/<task-name> && cargo test)  # or the project's equivalent test command
+(cd /tmp/jj-workspaces/<repo>/<task-name> && <the project's test command>)
 ```
 
 If tests fail, dispatch fix subagents to the relevant workspace(s) and re-run. Escalate to user after 2 failed attempts.
+
+**If the wave has no test surface** — its changes are documentation, prose, or
+config that no test in the project reads — say so and move on. Record
+`wave <W>: no-test-surface` in the ledger, tell the reviewers no automated
+check has validated this wave, and rely on review. Do not invent a test, and
+do not run an unrelated suite and report its pass as this wave's gate: a suite
+that cannot fail on these changes has verified nothing, and reporting it as a
+pass is worse than reporting no gate at all.
 
 ### Step 2: Spec-Informed Peer Review
 
@@ -640,7 +648,10 @@ When reviewers find critical or important issues:
    NEEDS_CONTEXT) and appends its fix report to the task's existing
    `<artifacts>/task-N-report.md`. The report must contain the covering
    tests, the command run, and the output — confirm all three are present
-   before re-dispatching the reviewer
+   before re-dispatching the reviewer. If no test covers the change (a docs
+   or config fix), the report must say that explicitly and state what was
+   verified instead; a fix subagent must never fabricate a test command to
+   satisfy this gate
 3. Re-dispatch reviewer scoped to the fix delta: fix subagents amend in
    place, so `jj evolog -r <change-id> -p --limit 2` shows exactly what the
    fix changed. Name that command in the re-review prompt as the reviewer's

--- a/plugins/workspace-jj/skills/fan-flames.md
+++ b/plugins/workspace-jj/skills/fan-flames.md
@@ -38,7 +38,7 @@ PLAN ─── validate independence, compute waves, confirm with user
   ║     │      cleanup workspaces on pass        ║
   ║     ▼                                        ║
   ║  FAN IN ── squash into @, smallest first     ║
-  ║            (only review-approved tasks)       ║
+  ║            (only review-approved tasks)      ║
   ╚══════════════════════════════════════════════╝
   │
   Report plan coverage

--- a/plugins/workspace-jj/skills/fan-flames.md
+++ b/plugins/workspace-jj/skills/fan-flames.md
@@ -139,7 +139,8 @@ run: complete
 Event lines: `dispatched workspace=…`, `done change=… files=…`,
 `done-with-concerns change=… files=…`, `blocked reason=…`, `needs-context`,
 `workspace-leak`, `review-passed`, `review-failed findings=<n>c,<n>i`,
-`squashed`, `wave <W>: fanned-in`, `run: complete`.
+`fixing from=<commit-id>`, `squashed`, `wave <W>: no-test-surface`,
+`wave <W>: fanned-in`, `run: complete`.
 
 Write ledger lines in the same message as the phase's other bookkeeping —
 never as a separate turn.
@@ -297,7 +298,12 @@ Once waves are confirmed:
      (Global Constraints, shared definitions) so the brief stands alone
    - **Ad-hoc input:** Write `<artifacts>/task-N-brief.md` yourself containing
      the full task description
-3. Initialize the ledger — write the header and wave plan to
+3. Record the integrity baseline: run `jj diff -r @ --stat` and keep the
+   result. It is the recorded baseline every Workspace Integrity Check
+   compares against — `@` may legitimately be non-empty at PLAN, and
+   comparing against zero would report the run's own starting content as a
+   leak.
+4. Initialize the ledger — write the header and wave plan to
    `<artifacts>/progress.md`:
 
    ```
@@ -415,7 +421,9 @@ Agent tool:
     - Self-review findings (if any)
     - Any issues or concerns
 
-    Before reporting back, capture your change ID and workspace name:
+    Before reporting back, describe your change so it can be recovered if
+    you die before reporting, then capture your change ID and workspace name:
+    jj describe -m "Task N: <short description>"
     jj log -r @ --no-graph -T 'change_id'
     basename "$PWD"
 
@@ -497,11 +505,12 @@ change=<id> files=<paths>` (or `done-with-concerns …`, `blocked reason=…`,
 jj diff -r @ --stat
 ```
 
-The expected baseline is wave-aware: in Wave 1, `@` should show no changes;
-from Wave 2 on, `@` legitimately contains all prior waves' merged content, so
-compare against the stat recorded after the previous FAN IN (record
-`jj diff -r @ --stat` after every FAN IN to refresh the baseline). If `@`
-differs from its baseline, at least one agent failed to `cd` to its workspace.
+Compare against the **recorded baseline**, never against zero. `@` is not
+required to be empty — it routinely holds the plan document, or work in
+progress the run builds on. PLAN records `jj diff -r @ --stat` as the run's
+baseline; every FAN IN re-records it, so from Wave 2 on the baseline includes
+all prior waves' merged content. If `@` differs from the current baseline, at
+least one agent failed to `cd` to its workspace.
 
 **Step 2:** For each agent that reported DONE or DONE_WITH_CONCERNS, verify its change landed in the correct workspace:
 
@@ -531,6 +540,16 @@ jj log -r 'description("Task N: <short description>")' --no-graph -T 'change_id'
 ```
 
 If multiple matches, use the most recent. If no matches, the subagent likely never created any changes — treat as BLOCKED.
+
+### Empty Changes Are a Valid Outcome
+
+A task can correctly produce no change — an audit that finds nothing, a
+check that confirms the code is already right. An empty change is a result,
+not a failure: review it like any other (the claim "there was nothing to do"
+is exactly as verifiable as a diff, just against the source rather than
+against a patch), and fan it in normally. `jj squash` abandons an empty
+source silently, which is the correct no-op. Distinguish this from a subagent
+that produced nothing because it failed — the report and the ledger say which.
 
 ### Divergent Changes (`change_id??`)
 
@@ -643,7 +662,11 @@ When reviewers find critical or important issues:
    (the workspace already exists — `isolation` would create a new one), on
    the same model as the task's implementer (see Model Selection). Tell it
    to work in the existing workspace directory path, and name the test files
-   covering the change — a small fix doesn't need the whole suite
+   covering the change — a small fix doesn't need the whole suite. Before
+   dispatching, record the change's current commit ID —
+   `jj log -r <change-id> --no-graph -T 'commit_id.short()'` — to the ledger
+   as `task N: fixing from=<commit-id>`. This is the only moment the fix's
+   starting point is unambiguous; step 3 needs it
 2. Fix subagent uses the same implementer protocol (DONE / BLOCKED /
    NEEDS_CONTEXT) and appends its fix report to the task's existing
    `<artifacts>/task-N-report.md`. The report must contain the covering
@@ -652,13 +675,20 @@ When reviewers find critical or important issues:
    or config fix), the report must say that explicitly and state what was
    verified instead; a fix subagent must never fabricate a test command to
    satisfy this gate
-3. Re-dispatch reviewer scoped to the fix delta: fix subagents amend in
-   place, so `jj evolog -r <change-id> -p --limit 2` shows exactly what the
-   fix changed. Name that command in the re-review prompt as the reviewer's
-   primary view (with the original findings for context) — re-reviews judge
-   the amendment, not the whole task again
-4. Repeat until no critical/important findings remain
-5. Escalate to user after 2 failed fix attempts — present the findings and ask how to proceed
+3. Re-dispatch reviewer scoped to the fix delta. Fix subagents amend in
+   place, so the delta is exactly `jj diff --from <the commit-id recorded in
+   step 1> --to <change-id>`. Name that command in the re-review prompt as
+   the reviewer's primary view (with the original findings for context) —
+   re-reviews judge the amendment, not the whole task again. Do not derive
+   the delta from `jj evolog --limit N`: that counts evolution steps, not
+   "the fix", and a `jj describe` or a second snapshot silently shifts the
+   window — a truncated delta is indistinguishable from a small one
+4. Re-run the Workspace Integrity Check (Phase 3) against the recorded baseline.
+   Fix subagents reach their workspace by `cd`, exactly as implementers do, and
+   are exactly as able to miss it — a check that runs only after COLLECT does
+   not cover an agent dispatched after COLLECT
+5. Repeat until no critical/important findings remain
+6. Escalate to user after 2 failed fix attempts — present the findings and ask how to proceed
 
 Fix-induced file overlap changes for later waves are ignored. jj handles any resulting conflicts during fan-in.
 
@@ -797,8 +827,13 @@ JJ_EDITOR=true jj squash --from <change-id> --into @
 2. **Check for conflicts:**
 
 ```bash
-jj resolve --list
+jj log -r 'conflicts()' --no-graph -T 'change_id.short() ++ "\n"'
 ```
+
+Empty output means clean. Use this rather than `jj resolve --list` as the
+check: `resolve --list` exits 2 when there are *no* conflicts, so any scripted
+use reads the clean case as a failure. `jj resolve --list` is still the right
+way to show a human which files conflict, once you know some do.
 
 If conflicts exist:
 - Report them clearly with file paths

--- a/plugins/workspace-jj/tests/test-fan-flames-scripts.sh
+++ b/plugins/workspace-jj/tests/test-fan-flames-scripts.sh
@@ -32,8 +32,9 @@ repo="$tmp/fan-flames-test-$$"
 trap 'rm -rf "$tmp" "/tmp/jj-workspaces/$(basename "$repo")"' EXIT
 
 # Fixture: a jj repo (uniquely named so its /tmp artifacts dir cannot collide
-# with a real repo's) and a plan file with three tasks and a decoy heading
-# inside a code fence.
+# with a real repo's) and a plan file with three tasks and two decoy headings
+# inside code fences — one in the preamble (which the preamble pass must not
+# stop at) and one inside Task 2 (which the task pass must not split on).
 mkdir -p "$repo"
 (cd "$repo" && jj git init >/dev/null 2>&1)
 cat > "$repo/plan.md" <<'EOF'
@@ -42,6 +43,13 @@ cat > "$repo/plan.md" <<'EOF'
 ## Overview
 
 Intro text that belongs to no task.
+
+```markdown
+### Task 8: preamble decoy inside a code fence
+this fenced heading must not terminate the preamble
+```
+
+Global rule: the preamble continues past the fence.
 
 ### Task 1: First thing
 
@@ -90,6 +98,49 @@ check "brief contains post-fence body" grep -q 'line two (after the fence)' "$br
 check "brief keeps the fenced decoy verbatim" grep -q 'Task 9: decoy' "$brief"
 check_fails "brief excludes Task 1" 1 grep -q 'First thing' "$brief"
 check_fails "brief excludes Task 3" 1 grep -q 'Third thing' "$brief"
+
+# --- preamble is prepended (finding #2) ---
+# A plan's Global Constraints live in the preamble, and task text references
+# them without repeating them. A brief without the preamble is incomplete,
+# which contradicts what the dispatch prompt tells the implementer.
+check "brief contains the plan preamble" \
+  grep -q 'Intro text that belongs to no task' "$brief"
+check "brief separates preamble from task" grep -qx -- '---' "$brief"
+check "fenced Task heading does not terminate the preamble" \
+  grep -q 'Global rule: the preamble continues past the fence' "$brief"
+
+# A plan whose first line is already a task heading has no preamble, and
+# must not get a stray leading separator.
+cat > "$repo/plan-nopreamble.md" <<'EOF'
+### Task 1: Only thing
+
+**Files:** `z.ts`
+EOF
+"$SCRIPTS/fan-flames-task-brief" plan-nopreamble.md 1 "$tmp/nopre.md" >/dev/null
+check "no-preamble plan still yields the task" grep -q 'Only thing' "$tmp/nopre.md"
+check_fails "no-preamble plan yields no separator" 1 grep -qx -- '---' "$tmp/nopre.md"
+
+# Every plan in this repo closes its preamble with a horizontal rule before
+# the first task — it is the writing-plans convention. Our own separator must
+# not double it.
+cat > "$repo/plan-rule.md" <<'EOF'
+# Ruled Plan
+
+## Global Constraints
+
+- Everything must obey this.
+
+---
+
+### Task 1: Ruled thing
+
+**Files:** `r.ts`
+EOF
+"$SCRIPTS/fan-flames-task-brief" plan-rule.md 1 "$tmp/ruled.md" >/dev/null
+check "preamble ending in a rule yields exactly one separator" \
+  test "$(grep -cx -- '---' "$tmp/ruled.md")" = "1"
+check "trailing-rule plan keeps its constraints" \
+  grep -q 'Everything must obey this' "$tmp/ruled.md"
 
 "$SCRIPTS/fan-flames-task-brief" plan.md 3 "$tmp/custom-out.md" >/dev/null
 check "explicit OUTFILE honored" grep -q 'Third thing' "$tmp/custom-out.md"

--- a/plugins/workspace-jj/tests/test-model-selection-lint.sh
+++ b/plugins/workspace-jj/tests/test-model-selection-lint.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Lints model-selection directives across every plugin's markdown.
+#
+# Why this exists: fan-flames' Model Selection table is restated in the
+# dispatch templates that actually get used. PR #65 fixed the table and missed
+# fan-flames-wave-reviewer.md, which went on offering "opus/session" —
+# session-model inheritance — for three more PRs. Nothing caught it: source,
+# cache, and installed copy all agreed, because they agreed on the unfixed
+# text. Prose is not executed, so it is not checked. This checks the one rule
+# class where being wrong is silent and only shows up on the bill.
+#
+# Scope is deliberately narrow. Other skill rules are equally unexecuted; each
+# would need its own assertion and its own false-positive analysis.
+#
+# Usage: test-model-selection-lint.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+PLUGINS="$ROOT/plugins"
+PASS=0
+FAIL=0
+
+ok()  { echo "PASS: $1"; PASS=$((PASS+1)); }
+bad() { echo "FAIL: $1"; FAIL=$((FAIL+1)); shift; printf '%s\n' "$@" | sed 's/^/    /'; }
+
+# --- Rule 1: no model: directive may offer session-model inheritance ---
+#
+# An omitted or inherited model silently uses the session's model, usually the
+# most capable and most expensive. Every dispatch names its tier.
+#
+# This reads the whole DIRECTIVE, not just the model: line. A directive wraps
+# across continuation lines, and a line-based check cannot see a `session` that
+# landed on line 3 of one — which is exactly how the text that prompted this
+# lint was written. The directive ends at the next `key:` or a blank line.
+hits=$(find "$PLUGINS" -name '*.md' -print0 | while IFS= read -r -d '' f; do
+  awk -v f="$f" '
+    /^[[:space:]]*model:/ { span=$0; start=NR; inspan=1; next }
+    inspan {
+      if ($0 ~ /^[[:space:]]*$/ || $0 ~ /^[[:space:]]*[A-Za-z_][A-Za-z0-9_-]*:/) {
+        inspan=0
+        if (span ~ /[Ss]ession/) print f ":" start ": " span
+        next
+      }
+      span = span " " $0
+    }
+    END { if (inspan && span ~ /[Ss]ession/) print f ":" start ": " span }
+  ' "$f"
+done)
+if [ -z "$hits" ]; then
+  ok "no model: directive mentions session"
+else
+  bad "a model: directive mentions session-model inheritance" "$hits"
+fi
+
+# --- Rule 2: the exact #1 shape, anywhere in a file ---
+hits=$(grep -rnE '(opus|sonnet|haiku)/session' "$PLUGINS" --include='*.md' || true)
+if [ -z "$hits" ]; then
+  ok "no file offers <tier>/session"
+else
+  bad "found <tier>/session — the PR #65 regression" "$hits"
+fi
+
+# --- Rule 3: every dispatch block names a model ---
+#
+# 'Agent tool:' marks a dispatch example. Each must carry a model: line within
+# the block, or the example teaches omission by demonstration.
+while IFS=: read -r file line _; do
+  [ -n "$file" ] || continue
+  block=$(sed -n "${line},$((line + 8))p" "$file")
+  if printf '%s' "$block" | grep -qE '^[[:space:]]*model:'; then
+    ok "dispatch block at $(basename "$file"):$line names a model"
+  else
+    bad "dispatch block at $(basename "$file"):$line has no model: line" "$block"
+  fi
+done < <(grep -rn 'Agent tool:' "$PLUGINS" --include='*.md' || true)
+
+echo
+echo "$PASS passed, $FAIL failed"
+test "$FAIL" -eq 0


### PR DESCRIPTION
## Summary

Fan-flames was substantially hardened in #64/#65 but had never been **run** with those changes. This PR is the result of running it: a five-task plugin README audit, one wave, five parallel workspaces. The audit was the pretext; exercising the skill was the point.

The run surfaced **nine defects**. Every one is invisible to review and visible on the first execution — including one that means **#65's fix was incomplete**.

## The headline: #65 missed the file it dispatches from

```
fan-flames.md                last touched by  2c16a66  (#65) ← the fix
fan-flames-wave-reviewer.md  last touched by  61c9db6  (#59) ← three PRs earlier
```

#65 — *"pin Opus as the model ceiling, remove session-model inheritance"* — rewrote the Model Selection table in `fan-flames.md` and never touched `fan-flames-wave-reviewer.md`, the template the skill uses to compose **every** reviewer dispatch. Its model line still read:

```
model: <per the skill's Model Selection — sonnet floor; opus/session for risky or final waves>
```

`opus/session` is exactly the inheritance #65 set out to remove. The three-layer staleness model (source → cache → installed copy) couldn't catch it: all three agreed at `dbcf4e3` — they agreed on the *unfixed text*. A currency check cannot find a fix that was never written.

## Changes, in stack order

Squash-merge will collapse these into one commit; the detail is preserved here.

### `kkruzwvu` — docs(plugins): audit plugin READMEs against their actual components
The run's output. Four READMEs had drifted: `agent-helpers-jj` claimed six helpers where the installer allowlists four, and omitted `jq` (a jq-less install aborts *after* editing `~/.zshrc` and `~/.claude/CLAUDE.md`, before the allowlist lands); `commit-commands-jj` didn't document `/absorb`, `/finish`, or the always-on `block-raw-git.sh` deny hook; `project-setup-jj` said `require-jj-new.sh` "prompts you" when its own header says it "does NOT block or prompt"; `workspace-jj`'s phase diagram still showed review happening *after* fan-in via an external `/peer-review`, stale since #64/#65 moved REVIEW per-wave. `peer-review-jj` was audited and found accurate — no changes, and the reviewer independently verified that negative claim rather than accepting it.

### `npywtksy` — fix(fan-flames): remove session-model inheritance from the reviewer template
The one-line fix for the above. `opus/session` → `opus`.

### `ltxxlkmk` — docs: design and implementation plan
`docs/specs/` + `docs/plans/`. Nine findings collapse to four root causes plus a fifth (nothing executes prose) that explains why #1 existed. Carries four Revision notes recording what execution found that authorship missed.

### `yrkyuzsx` — fix(fan-flames): self-contained task briefs (finding #2)
`fan-flames-task-brief` extracted only the task section, so a plan's Global Constraints never reached the implementer — while the dispatch template told the agent the brief **is** its requirements. Every brief in the run referenced "the four drift criteria above" with no *above*. `docs/plans/2026-07-13-jj-agent-safety-plan.md` dangles identically. The script now prepends the plan preamble, fence-aware to match the task pass. Tests: 15 → 22.

### `qwvyxvvl` — fix(fan-flames): de-Rust the test gate, handle waves with no test surface (#5, #6, #7)
`cargo test` was asserted in three places in a repo with no Rust — every reviewer in the run was told a suite passed that doesn't exist. Worse, Fix Loop item 2 *hard-required* covering tests before re-review, so a docs-only fix loop could never advance; the run hit that wall. REVIEW Step 1 now names the no-test-surface case and forbids reporting a vacuous pass.

### `sxnqmmsm` — fix(fan-flames): correct the integrity model and fix-delta commands (#3, #4, #8, #9)
- **Wave 1's integrity baseline assumed an empty `@`**, which no prerequisite requires. The run's plan document tripped it — a false `WORKSPACE_LEAK`. PLAN now records the baseline; Wave 1 and Wave 2+ become one rule.
- **The check never re-ran after the fix loop** — precisely where a fix subagent *did* leak into `@` during the run. It self-caught; the skill wouldn't have.
- **`evolog --limit 2` counts evolution steps, not "the fix."** A `jj describe` ate a window slot in three of four fixes. The orchestrator now records the pre-fix commit ID at dispatch and re-reviews `jj diff --from/--to`.
- **`jj resolve --list` exits 2 when there are no conflicts**, inverting any scripted check. FAN IN uses `jj log -r 'conflicts()'`.

### `xrvrxwuz` — fix(fan-flames): align the phase diagram's closing box border
The FAN IN continuation line carried one extra space, making it 51 characters against the diagram's 50. Pre-existing on `main`; left alone during the plan work because the surgical-edits constraint forbids improving text a task didn't name. Worth noting *why* nobody caught it: the obvious check is wrong. `awk length()` counts **bytes**, and the box-drawing characters are multi-byte UTF-8, so a byte histogram reports four distinct lengths on a diagram that's perfectly aligned. Character counting shows the two real values. Every line is now 50.

### `xwmxmoqm` — test(workspace-jj): lint model-selection directives (#1's class)
Three deterministic rules over `plugins/**/*.md`. Rule 1 reads the whole **directive**, not the `model:` line — the text that prompted this lint spans three lines with `session` on the third, and a line-based check ships green while the rule goes unenforced. An eval would test model *behaviour* and pass whenever the model happened to pick `opus` anyway — the wrong instrument for a failure that's silent and only visible on the bill. The behavioural eval suite stays parked.

## Verified, not asserted

- The lint was run against the exact `opus/session` text that shipped and **observed failing** on both rules before being trusted.
- `jj op restore <start-op>` was exercised end-to-end: restored to the precise pre-PLAN commit, artifacts survived outside the repo, `jj undo` recovered byte-identical state.
- The new conflict check exits **0** on a clean revision where the old one exits **2**.
- Task 1 verified against the real `2026-07-13` plan, not just its fixture.

## Test plan

- [x] `plugins/workspace-jj/tests/test-fan-flames-scripts.sh` → 22 passed
- [x] `plugins/workspace-jj/tests/test-model-selection-lint.sh` → 4 passed
- [x] `plugins/agent-helpers-jj/tests/test-jj-agent-helpers.sh` → 8 passed
- [x] `plugins/agent-helpers-jj/tests/test-agent-helpers-install.sh` → 15 passed
- [x] `plugins/project-setup-jj/tests/test-statusline-jj.sh` → 8/8
- [x] No `<tier>/session` anywhere; one `cargo` (the honest `cargo fmt, prettier, ruff` example)

## Known gaps

- **The prose changes have no automated test.** The lint closes exactly one rule class. Verification for `qwvyxvvl` and `sxnqmmsm` is greps and reading — the same category as the bug that started this.
- **No end-to-end re-run validates these changes.** Deferred by decision; the next genuine fan-flames use is the test.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
