### PR TITLE
fix(finish): post-merge cleanup verifies before abandoning, and lands @ on the merged trunk

### DIFF
--- a/plugins/commit-commands-jj/commands/finish.md
+++ b/plugins/commit-commands-jj/commands/finish.md
@@ -103,10 +103,51 @@ What would you like to do?
 
 5. Output the PR URL.
 
-6. **Post-merge cleanup.** After a successful `gh pr merge`, before syncing, abandon all local changes that were ancestors of the PR branch (between trunk and the bookmark), since they're now in trunk via the squash-merge:
-   ```bash
-   jj abandon 'ancestors(TARGET) & ~ancestors(trunk())'
-   ```
+6. **Post-merge cleanup.** After a successful `gh pr merge`.
+
+   Do not pass `--delete-branch` to `gh pr merge`. It tries to delete a local
+   *git* branch and fails with `could not determine current branch`, because a
+   jj working copy is not on one. The merge itself still succeeds — only the
+   branch cleanup fails, and step (e) below handles that.
+
+   a. **Fetch**, so `trunk()` names the merged trunk rather than the state you
+      pushed from:
+      ```bash
+      jj git fetch
+      ```
+
+   b. **Verify trunk actually has the work — before abandoning anything.** A
+      squash-merge rebuilds your changes as a new commit; nothing guarantees it
+      matches what you pushed, and the next step is destructive:
+      ```bash
+      jj diff --from 'trunk()' --to <target> --stat
+      ```
+      Empty output means trunk's content equals the target's, so the local
+      changes are redundant copies. **If it is not empty, stop and report** —
+      something did not land, and abandoning would destroy the only copy.
+
+   c. **Abandon** the local changes now duplicated in trunk:
+      ```bash
+      jj abandon 'ancestors(<target>) & ~ancestors(trunk())'
+      ```
+
+   d. **Move the working copy onto the merged trunk:**
+      ```bash
+      jj new trunk()
+      ```
+      This is not optional. Abandoning re-parents `@` onto whatever the bottom
+      of the stack sat on — the *pre-merge* trunk — so `@` silently lands on a
+      stale base and every file you just merged reads as reverted on disk. The
+      work is safe in trunk; the working copy is simply looking at the wrong
+      revision, which is far more alarming than it sounds.
+
+   e. **Delete the bookmark.** Abandoning the target usually takes the local
+      bookmark with it (it pointed at an abandoned change), so this is often
+      just the remote half:
+      ```bash
+      jj bookmark delete <name>   # only if it survived (c)
+      jj git push --deleted
+      ```
 
 7. Then: Workspace cleanup (Step 4).
 


### PR DESCRIPTION
## Summary

`/finish`'s post-merge step told you to abandon every local change between trunk and the target after a squash-merge, and stopped there. Following it literally while merging #68 — an eight-change stack — hit four problems in a row.

Every claim below was **observed during that merge**, not reasoned about.

## What was wrong

**`trunk()` was stale.** Nothing fetched first, so `trunk()` still meant the state you pushed from. Option 2 of the same skill fetches before it acts — this path just didn't.

**Eight changes were abandoned on an assumption.** A squash-merge rebuilds your work as a *new* commit; nothing checks that it matches what you pushed. The step went straight to `jj abandon` with no verification — a destructive operation with no confirmation that the thing it destroys is safely duplicated.

**`@` landed on the pre-merge trunk.** This is the alarming one. Abandoning re-parents `@` onto whatever the *bottom* of the stack sat on — which is the trunk from before the merge. The working copy silently reverts to a stale base, and every file you just merged reads as reverted on disk. The work is fine; the working copy is looking at the wrong revision, which does not feel fine.

**The bookmark was left behind**, local and remote.

## What it does now

```
a. jj git fetch                                    → trunk() means the merged trunk
b. jj diff --from 'trunk()' --to <target> --stat   → VERIFY, and stop if non-empty
c. jj abandon 'ancestors(<target>) & ~ancestors(trunk())'
d. jj new trunk()                                  → not optional
e. jj git push --deleted                           → bookmark, remote half
```

Step (b) is the important addition: empty output means trunk's content equals the target's, so the local changes are redundant. **If it is not empty, stop** — something didn't land, and abandoning would destroy the only copy.

Also records that `gh pr merge --delete-branch` fails in a jj repo with `could not determine current branch` — it tries to delete a local *git* branch, and a jj working copy isn't on one. The merge still succeeds; only the branch cleanup fails.

## Checked for restatements

Per the lesson from #68 (a rule fixed in one file, missed in the file that restates it): grepped for any other file describing the post-merge cleanup. There are none. Both READMEs mention `/finish` only at surface level, so nothing there went stale.

## Known gap — not fixed here

Steps 6–7 describe work that happens **after `/finish` has returned**. Option 1 ends at "Output the PR URL"; the merge happens later, often in a different session. So the post-merge steps are orphaned from the command's execution — nobody is running `/finish` at the moment they're needed, which is plausibly why they were never exercised. Whether this belongs in `/finish` at all, or in a separate `/land`, is a design question rather than a text fix.

## Test plan

- [x] `plugins/workspace-jj/tests/test-model-selection-lint.sh` → 4 passed (scans all `plugins/**/*.md`)
- [x] No raw-git instructions introduced — only `jj git` and `gh pr` references
- [x] No interactive jj forms introduced
- [x] Each documented command was run for real during the #68 merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)