### PR TITLE
fix(permission-gateway): allowlist the safe jj op subcommands

### DIFF
--- a/plugins/permission-gateway/scripts/permission-gate.sh
+++ b/plugins/permission-gateway/scripts/permission-gate.sh
@@ -503,12 +503,21 @@ if echo "$command_normalized" | grep -qE '^(go\s+(test|build|vet|fmt)|rustfmt)\b
 fi
 
 # Safe VCS (jj read-only)
-if echo "$command_normalized" | grep -qE '^jj\s+(log|status|diff|show|file|config\s+list|root|workspace\s+list|op\s+log)\b'; then
+if echo "$command_normalized" | grep -qE '^jj\s+(log|status|diff|show|file|config\s+list|root|workspace\s+list|op\s+(log|show|diff))\b'; then
   approve
 fi
 
 # Safe jj write operations (local only, no push)
-if echo "$command_normalized" | grep -qE '^jj\s+(new|describe|commit|edit|squash|abandon|undo|rebase|resolve|bookmark)\b'; then
+#
+# `op revert` and `op restore` belong here for the same reason the rest do:
+# they are local-only, and they are themselves recorded in the operation log,
+# so they are as recoverable as any other jj write. Both are run by shipped
+# workflows — /undo runs `jj op revert`, fan-flames' abort path runs
+# `jj op restore` — so gating them prompts the user on their own tooling.
+#
+# `op abandon` is deliberately absent: it discards operation history, which is
+# the one jj write no later operation can recover. It falls through to Tier 2.
+if echo "$command_normalized" | grep -qE '^jj\s+(new|describe|commit|edit|squash|abandon|undo|rebase|resolve|bookmark|op\s+(revert|restore))\b'; then
   approve
 fi
 

--- a/plugins/permission-gateway/tests/test-permission-gate.sh
+++ b/plugins/permission-gateway/tests/test-permission-gate.sh
@@ -263,6 +263,22 @@ assert_decision "jj git push" "jj git push" "ask"
 assert_decision "jj new" "jj new" "silent"
 assert_decision "jj describe" "jj describe -m 'test'" "silent"
 
+# jj operation log — read-only inspection. /op-show runs `jj op show`.
+assert_decision "jj op log" "jj op log" "silent"
+assert_decision "jj op show" "jj op show abc123" "silent"
+assert_decision "jj op diff" "jj op diff" "silent"
+
+# jj operation rewrites — local-only and themselves recorded in the op log, so
+# they are recoverable exactly like the other allowlisted jj writes. Both are
+# run by shipped workflows: /undo runs `jj op revert` (commands/undo.md), and
+# fan-flames' abort path runs `jj op restore` (skills/fan-flames.md).
+assert_decision "jj op revert" "jj op revert abc123" "silent"
+assert_decision "jj op restore" "jj op restore abc123" "silent"
+
+# jj op abandon discards operation history — the one op that no later op can
+# recover. It must NOT be silently approved. This pins the boundary.
+assert_decision "jj op abandon" "jj op abandon" "ask"
+
 echo ""
 echo "=== Rule precedence ==="
 


### PR DESCRIPTION
## Summary

The `jj op` family was under-represented in both Tier 1 allowlists, so **three shipped workflows prompted the user on their own tooling**:

| command | before | used by |
|---|---|---|
| `jj op show` | **ask** | `/op-show` — its `allowed-tools` is `Bash(jj op show:*)` |
| `jj op revert` | **ask** | `/undo` — `commands/undo.md` runs it |
| `jj op restore` | **ask** | fan-flames' abort path — `skills/fan-flames.md:155` |
| `jj undo` | approve | **nothing** — `/undo` explicitly says not to use it |

The allowlist named the command nothing runs and omitted the three that everything runs. `jj op restore` is the sharpest: it's the documented recovery path for a bad fan-flames run, so it escalated at exactly the moment someone is trying to undo damage.

## What changed

- `op show` / `op diff` join the **read-only** list — both are strictly informational (`jj op show --help`: "Show changes to the repository in an operation").
- `op revert` / `op restore` join the **safe-write** list. They're local-only and are themselves recorded in the operation log, so they're as recoverable as `squash` or `abandon`, which were already there.
- **`op abandon` deliberately stays gated** — it discards operation history, the one jj write no later operation can recover. A test pins that boundary so a future widening can't take it silently.

`jj undo` is left in place. `commands/undo.md` claims it's "deprecated and will be removed", but `jj undo --help` on jj 0.43.0 shows no deprecation notice and documents a complementary `jj redo` — so that claim is unverified and not something this PR should act on. Filed as a follow-up thought, not fixed here.

## Verified, not assumed

Every row above was probed against the real gate with `jq`-constructed payloads, before and after:

```
before:  jj op revert abc123  → "permissionDecision": "ask"
after:   jj op revert abc123  → (no output) = silent approve
```

Boundary checks after the change — all still gate correctly:

```
jj op abandon                                  → ask
jj git push                                    → ask
rm -rf /                                       → deny
jj bookmark delete x && jj git push --deleted  → ask
```

## Test plan

- [x] `plugins/permission-gateway/tests/test-permission-gate.sh` → **133 passed, 0 failed** (was 127)
- [x] 6 new cases: `op log`, `op show`, `op diff`, `op revert`, `op restore` approve; `op abandon` asks
- [x] The 4 new approve cases were watched **failing** before the fix, then passing after

## Found by

The 2026-07-15 fan-flames re-run validating #68/#69. A wave reviewer caught it while verifying task 3's `/undo` README fix — by probing the gate rather than reading its regex.

Related: #70 (fail-open asymmetry, filed separately — a design question, not a patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)