### PR TITLE
docs(plugins): audit permission-gateway and commit-commands-jj READMEs

### DIFF
--- a/docs/plans/2026-07-15-post-merge-readme-audit-plan.md
+++ b/docs/plans/2026-07-15-post-merge-readme-audit-plan.md
@@ -1,0 +1,133 @@
+# Post-#68/#69 README Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use workspace-jj:fan-flames (per CLAUDE.md override of superpowers:subagent-driven-development). Each task touches exactly one README; all three are independent and run in a single wave.
+
+**Goal:** Audit three plugin READMEs against what their plugins actually ship. Two of them describe behaviour that changed in #68 and #69; the third has never been audited at all.
+
+**Architecture:** Markdown only. One task per plugin directory. Plugin directories are disjoint, so no task can conflict with another.
+
+**Tech Stack:** Markdown. jj for VCS.
+
+## Global Constraints
+
+- **No raw git commands anywhere** — jj equivalents only. The only exceptions are `jj git` subcommands and the `gh` CLI.
+- **Non-interactive jj forms only** — always pass `-m` to describe/commit/squash. Never run bare `jj describe`, `jj resolve`, `jj diffedit`, or `jj split` without paths.
+- **Audit, don't redesign.** Fix drift between the README and what is on disk. Do not add features, invent components, restructure the document, or rewrite prose that is already accurate.
+- **Scope discipline.** Each task modifies exactly one file: its own plugin's README. Never edit another plugin's files, the source components themselves, or shared docs.
+- **Evidence over assumption.** Every claim you keep or write must be checked against a file you actually read. If the README documents behaviour, open the command/script/skill and confirm the behaviour matches. A claim that merely *sounds* right is exactly the failure this audit exists to catch.
+- **An empty change is a valid result.** If a README is already accurate, change nothing and report that. "No drift found" is a real finding, not a failure — but it must be *verified*, not assumed.
+
+## What "drift" means
+
+For each plugin, the README should satisfy all four:
+
+1. **No missing components** — every command, agent, skill, script, and template that exists on disk and is user-facing is documented.
+2. **No phantom components** — nothing documented that no longer exists on disk.
+3. **Accurate behaviour** — descriptions, flags, arguments, and examples match what the files actually do.
+4. **Accurate names and paths** — command names, file paths, and script names are spelled as they exist.
+
+## Format note
+
+Task headings look like this, and a fenced example must not confuse the extractor:
+
+```markdown
+### Task 9: this heading is inside a code fence and is not a real task
+```
+
+---
+
+### Task 1: permission-gateway README audit
+
+**Files:**
+- Modify: `plugins/permission-gateway/README.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Inventory what exists**
+
+Read every file under `plugins/permission-gateway/` except the README itself: the plugin manifest, every command, every script, every skill or agent, and the test file. This plugin has **never been audited** — it was deliberately excluded from the 2026-07-14 run — so treat every README claim as unverified.
+
+- [ ] **Step 2: Audit the README against that inventory**
+
+Check the README against all four drift criteria in "What drift means" above. Because nothing here has been checked before, work in both directions deliberately: every component on disk should appear in the README, and every component named in the README should exist on disk.
+
+- [ ] **Step 3: Fix the drift**
+
+Edit `plugins/permission-gateway/README.md` only. Keep the existing structure and voice.
+
+- [ ] **Step 4: Verify**
+
+Confirm the set of components named in the README equals the set on disk, and that every behavioural claim traces to a file you read in Step 1.
+
+---
+
+### Task 2: workspace-jj README vs the post-#68 skill
+
+**Files:**
+- Modify: `plugins/workspace-jj/README.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Inventory what exists**
+
+Read `plugins/workspace-jj/skills/fan-flames.md` in full, plus both commands, all four scripts, `skills/fan-flames-wave-reviewer.md`, and both test files (`tests/test-fan-flames-scripts.sh` and the new `tests/test-model-selection-lint.sh`).
+
+- [ ] **Step 2: Audit the README against that inventory**
+
+Check the README against all four drift criteria in "What drift means" above.
+
+PR #68 changed fan-flames substantially: the REVIEW phase gained a no-test-surface branch, the phase diagram no longer says `cargo test`, the Workspace Integrity Check now compares against a baseline recorded at PLAN rather than assuming an empty `@`, the fix loop re-runs that check and records a pre-fix commit ID, FAN IN's conflict check moved from `jj resolve --list` to `jj log -r 'conflicts()'`, and the ledger gained two event types. Task briefs are now self-contained (the preamble is prepended).
+
+If the README summarises any of that — phases, flags, the diagram, the ledger, behaviour — verify the summary against `skills/fan-flames.md` **as it exists now**. If the README does not summarise something, that is not automatically drift: only criterion 1 (missing *user-facing* components) forces documentation.
+
+- [ ] **Step 3: Fix the drift**
+
+Edit `plugins/workspace-jj/README.md` only. Do **not** edit the skill — the README describes it, not the reverse.
+
+- [ ] **Step 4: Verify**
+
+Confirm the README's account of fan-flames' phases and flags matches `plugins/workspace-jj/skills/fan-flames.md`.
+
+---
+
+### Task 3: commit-commands-jj README vs the post-#69 /finish
+
+**Files:**
+- Modify: `plugins/commit-commands-jj/README.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Inventory what exists**
+
+Read every command file under `plugins/commit-commands-jj/commands/` (there are 16) and the one script. Read `commands/finish.md` especially closely — it changed in #69.
+
+- [ ] **Step 2: Audit the README against that inventory**
+
+Check the README against all four drift criteria in "What drift means" above.
+
+PR #69 rewrote `/finish`'s post-merge cleanup: it now fetches first, verifies trunk actually contains the work before abandoning anything, moves the working copy onto the merged trunk, and deletes the bookmark — plus a note that `gh pr merge --delete-branch` fails in a jj repo.
+
+The README's `/finish` section describes the command in four numbered steps. Decide, with evidence, whether it is now inaccurate (criterion 3) or merely brief. **Being incomplete is not the same as being wrong** — do not pad the README with detail it never claimed to carry. If it is accurate as far as it goes, say so and change nothing.
+
+- [ ] **Step 3: Fix the drift**
+
+Edit `plugins/commit-commands-jj/README.md` only. Keep the existing structure and voice.
+
+- [ ] **Step 4: Verify**
+
+Confirm the set of commands named in the README exactly equals the set of files in `plugins/commit-commands-jj/commands/`, and that the `/finish` description does not contradict `commands/finish.md`.
+
+---
+
+## Verification (whole plan)
+
+1. At most three files changed, one README per plugin.
+2. No source component (command, script, skill, agent, template) was modified.
+3. For each plugin: the set of components named in the README equals the set on disk.
+4. Any task reporting "no drift" verified that claim against the components, rather than assuming it.

--- a/plugins/commit-commands-jj/README.md
+++ b/plugins/commit-commands-jj/README.md
@@ -336,7 +336,7 @@ Undoes the last jj operation by restoring the repository to its previous state.
 
 **What it does:**
 1. Reviews the operation log to identify the last operation
-2. Runs `jj undo` to reverse it
+2. Runs `jj op revert <op-id>` to reverse it
 3. Confirms the result and reports what was undone
 
 **Usage:**
@@ -608,7 +608,7 @@ claude plugins add ./plugins/commit-commands-jj
 | `git checkout <commit>` | `jj edit` — move working copy to a change |
 | `git pull --rebase` | `jj git fetch` + `jj rebase` |
 | `git rebase -i` (squash) | `jj squash` |
-| `git reset HEAD~1` | `jj undo` |
+| `git reset HEAD~1` | `jj op revert` |
 | `git reflog` | `jj op log` |
 | branch | bookmark |
 | `git branch` | `jj bookmark` |

--- a/plugins/permission-gateway/README.md
+++ b/plugins/permission-gateway/README.md
@@ -16,7 +16,7 @@ Seven evaluation stages, one exit per command. Each decision is logged for rule 
 
 | Tier | Action | Examples |
 |------|--------|---------|
-| **Gate-the-Gate** | Confirms config writes | Write/Edit to `*permission-gateway*` files |
+| **Gate-the-Gate** | Confirms config writes | Write/Edit to `*permission-gate*`, `.claude/settings*`, or `.claude-plugin/` paths |
 | **Deny** | Blocked, never runs | `rm -rf /`, `sudo`, `eval`, `dd`, `kill -9` |
 | **Confirm** | Human sees prompt | `npm publish`, `ssh`, `mv`, `docker run`, `xargs` |
 | **Approve** | Silent, no prompt | `ls`, `npm test`, `jj log`, `cargo build`, `grep` |
@@ -26,7 +26,7 @@ Seven evaluation stages, one exit per command. Each decision is logged for rule 
 
 **One-way ratchet:** Hardcoded deny runs before `.local.md` rules. No override can loosen a deny — the deny tier is an immutable floor. This prevents prompt injection attacks where malicious content instructs Claude to write `.local.md` rules promoting dangerous commands.
 
-**Gate the gate:** Writes to files matching `permission-gateway` trigger a human confirmation prompt via a separate Write/Edit hook (`gate-config-writes.sh`). The injection attempt is caught before the file is modified.
+**Gate the gate:** Writes to the gateway's own scripts/config (`*permission-gate*`), hook registration (`.claude/settings*`), or the plugin manifest (`.claude-plugin/`) trigger a human confirmation prompt via a separate Write/Edit hook (`gate-config-writes.sh`). The injection attempt is caught before the file is modified.
 
 **Full-string scanning:** Dangerous patterns (`rm -rf`, `> ~/path`) are scanned in the full command string, not just the leading command. This prevents bypass via wrappers like `find -exec`, `xargs`, or redirect clobbers to paths outside the project directory.
 
@@ -87,7 +87,7 @@ The command scans the log, normalizes commands into patterns (`pip install reque
 - `scripts/gate-config-writes.sh` — gate-the-gate hook (Write/Edit to config files)
 - `prompts/permission-evaluate.md` — Tier 2 LLM evaluation prompt template
 - `commands/tune.md` — `/tune` command for log-based rule self-tuning
-- `tests/test-permission-gate.sh` — 124 tests
+- `tests/test-permission-gate.sh` — 127 tests
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Output of the **fan-flames re-run** that validated #68/#69 against the fixed skill. Three tasks, one wave, three parallel workspaces. Two READMEs had real drift; one was verified accurate and correctly left alone.

## What drifted

**`permission-gateway`** (never audited before — it was excluded from the 2026-07-14 run):
- Test count said **124**; the suite reports **127**. The implementer *ran* it rather than trusting the number.
- The Gate-the-Gate description understated its own protection — `gate-config-writes.sh` also guards `.claude/settings*` and `.claude-plugin/`, not just `*permission-gateway*` files.

**`commit-commands-jj`**:
- `/undo` was documented as running `jj undo`. `commands/undo.md` explicitly forbids that and runs `jj op revert <op-id>`. Fixed in two places.

**`workspace-jj`**: no drift. Audited against the post-#68 skill — flags table, phase diagram, `--skip-review` semantics, change-ID fan-in rationale, WorktreeCreate/Remove behaviour all matched, and no stale `cargo test` / `resolve --list` / empty-`@` references survive. The reviewer verified this negative claim independently rather than accepting it.

## This run was also the test for #68/#69

Three prose fixes from #68 had no automated test. This run exercised them:

| Fix | Evidence |
|---|---|
| **Self-contained briefs** | Briefs carried Global Constraints + drift criteria. **Task 1's agent acted on the "evidence over assumption" constraint by running the permission-gateway suite** — which is how the 124→127 drift was caught. That constraint only reached it because the brief now carries the plan preamble. |
| **Baseline recorded at PLAN** | `@` held the plan doc (133 insertions). Recorded at PLAN, matched at COLLECT. The old skill compared against zero and would have escalated a false `WORKSPACE_LEAK` for this exact state. |
| **no-test-surface branch** | Docs-only wave → recorded `wave 1: no-test-surface`, ran no suite, told the reviewer no automated check had validated the work. |
| **`jj log -r 'conflicts()'`** | Exit 0, empty, on all three squashes. `jj resolve --list` would have exited 2 each time. |
| **Model selection** | Reviewer template offers `opus` only. All 4 dispatches explicit (3× sonnet, 1× opus). |
| **Empty changes** | Task 2's empty change squashed silently as a no-op, as now documented. |

**Not exercised:** the fix loop never fired (no critical/important findings), so the recorded-commit-ID fix delta and the fix-loop integrity re-check remain untested. Not manufacturing a finding to trigger them.

## Spun out of this run

- **#71** — `jj op` allowlist gap: `/op-show`, `/undo`, and fan-flames' abort path all prompted the user on their own tooling.
- **#70** — `permission-gate.sh` fails open on malformed input while `gate-config-writes.sh` fails closed. Filed as a design question rather than patched.

## One finding against fan-flames itself

The artifacts directory is **per-repo, not per-run**. It still held the previous run's `task-4-brief.md` and `task-5-report.md`. The skill's "start fresh" says only *"overwrite the ledger"* — everything else persists indistinguishably, so a 5-task run following a 3-task run would read the wrong report. Cleaned manually; the skill should say so. Not fixed here.

## Test plan

- [x] Three files changed, no source component touched
- [x] For each plugin: components named in the README == components on disk
- [x] `permission-gateway` suite run to confirm 127, not trusted from the README
- [x] The "no drift" verdict on `workspace-jj` was verified, not assumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)