### PR TITLE
chore(plugins): declare version 0.1.0 on all six plugins

### DIFF
--- a/plugins/agent-helpers-jj/.claude-plugin/plugin.json
+++ b/plugins/agent-helpers-jj/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "agent-helpers-jj",
   "description": "Machine-level jj (Jujutsu) query shortcuts for agents — read-only helpers that bake in --ignore-working-copy so concurrent workspaces don't race",
+  "version": "0.1.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests",
+  "version": "0.1.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/peer-review-jj/.claude-plugin/plugin.json
+++ b/plugins/peer-review-jj/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "peer-review-jj",
   "description": "Unified change review for jj repos — generalist-first with emergent specialists, two-phase pipeline, structured findings",
+  "version": "0.1.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/permission-gateway/.claude-plugin/plugin.json
+++ b/plugins/permission-gateway/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "permission-gateway",
   "description": "Tiered permission gateway — auto-approves safe commands, blocks dangerous ones, escalates edge cases to human",
+  "version": "0.1.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
+  "version": "0.1.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/workspace-jj/.claude-plugin/plugin.json
+++ b/plugins/workspace-jj/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "workspace-jj",
   "description": "Wave-based parallel orchestration with spec review gates for jj (Jujutsu) repositories",
+  "version": "0.1.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"


### PR DESCRIPTION
## Summary

Adds `"version": "0.1.0"` to all six plugin manifests. This was the only validation warning across every plugin; all six now pass clean.

**Six files, +1 line each, zero deletions.**

## Why it matters more than a warning suggests

Without a version, `claude plugin list` reports the marketplace sha (`dbcf4e3efef7`) as the version. Consumers can't pin, and `claude plugin update` moves everyone to whatever `main` is with no rollback. `claude plugin tag` already exists to cut per-plugin release tags — and validates `plugin.json` against the marketplace entry — but there was nothing for it to check.

## Why 0.1.0 and not 1.0.0

semver 0.x means *"initial development; anything may change at any time."* That is precisely true right now:

- `commit-commands-jj` ships **16 commands with zero tests**
- `/project-setup` writes hooks into a consumer's `.claude/settings.json` and has **no test**
- `fan-flames` produced **nine defects the first time anyone ran it** (#68, yesterday)

Declaring 1.0.0 the day after that would be a stability claim with nothing behind it. 1.0.0 is available once the untested surface is actually exercised — the eval suite parked in `docs/plans/2026-07-13-jj-agent-safety-plan.md` is the mechanism.

## A near-miss worth recording

The first attempt at this used `jq '{name, description, version, author}'` — a **selection**, not an addition. It silently deleted the `hooks` block from four plugins:

- `permission-gateway` — its own `permission-gate.sh` and both `gate-config-writes.sh` registrations
- `peer-review-jj` — `block-raw-git.sh` + `block-review-markers.sh`
- `commit-commands-jj`, `project-setup-jj` — `block-raw-git.sh`

**`claude plugin validate` returned ✔ on all six with every hook stripped out.** The validator does not check that hooks survive. Caught only by reading the diff and running an explicit lost-key comparison.

The shipped version adds rather than selects: `{name, description, version} + (del(.name) | del(.description))`.

## Verified three ways

```
lost=[] added=[version]      on all six  (comm against trunk's key set)
hooks byte-identical         on all four that have them (jq -S diff)
6 files changed, 6 insertions(+), 0 deletions(-)
```

Plus a live probe that the gateway still gates after the restore: `rm -rf /` → deny, `jj git push` → ask, `jj op revert` → approve.

## Test plan

- [x] `claude plugin validate` → passes clean on all six, no warnings (was: 6 warnings)
- [x] `test-permission-gate.sh` → 133 passed
- [x] `test-fan-flames-scripts.sh` → 22 passed
- [x] `test-model-selection-lint.sh` → 4 passed
- [x] `test-jj-agent-helpers.sh` → 8 passed
- [x] `test-agent-helpers-install.sh` → 15 passed
- [x] `test-statusline-jj.sh` → 8/8

🤖 Generated with [Claude Code](https://claude.com/claude-code)