### PR TITLE
fix(finish): post-merge verify handles sibling PRs, not just a stack

### DIFF
--- a/plugins/commit-commands-jj/commands/finish.md
+++ b/plugins/commit-commands-jj/commands/finish.md
@@ -118,13 +118,34 @@ What would you like to do?
 
    b. **Verify trunk actually has the work — before abandoning anything.** A
       squash-merge rebuilds your changes as a new commit; nothing guarantees it
-      matches what you pushed, and the next step is destructive:
+      matches what you pushed, and the next step is destructive. Which check
+      is right depends on what you merged.
+
+      **One PR, or a stack merged as one PR** — the target should now be
+      identical to trunk:
       ```bash
       jj diff --from 'trunk()' --to <target> --stat
       ```
       Empty output means trunk's content equals the target's, so the local
       changes are redundant copies. **If it is not empty, stop and report** —
       something did not land, and abandoning would destroy the only copy.
+
+      **Sibling PRs merged separately** — do NOT use the check above. It will
+      report a failure on a perfectly clean merge: each sibling legitimately
+      differs from trunk by the *other* sibling's content, so whole-tree
+      equality is the wrong question. Ask instead whether each target's own
+      contribution landed — for every file it touched, trunk's copy must match
+      its copy:
+      ```bash
+      for f in $(jj diff -r <target> --summary | awk '{print $2}'); do
+        diff -q <(jj file show -r <target> "$f") \
+                <(jj file show -r 'trunk()' "$f") >/dev/null \
+          && echo "ok      $f" || echo "DIFFERS $f"
+      done
+      ```
+      Every file must report `ok`. A `DIFFERS` means either the merge dropped
+      something, or a later change touched the same file — **stop and look**
+      either way. Repeat per target; abandon only the targets that pass.
 
    c. **Abandon** the local changes now duplicated in trunk:
       ```bash


### PR DESCRIPTION
## Summary

`/finish`'s step 6b — added in #69 — tells you to confirm `jj diff --from 'trunk()' --to <target>` is empty before abandoning, and to **stop and report** if it isn't.

That question is only correct when the target is the only thing merged since it branched.

## What happened

Merging two sibling PRs (#71 and #72) produced non-empty output for **both**:

```
trunk() → mmuvmkyp:  133 deletions   (the READMEs — #72's content)
trunk() → rsmpxowk:   27 deletions   (the permission fix — #71's content)
```

Nothing was wrong. Each sibling legitimately differs from trunk by the *other* sibling's content. Following step 6b literally means halting a perfectly clean merge and reporting a failure — which is worse than having no check, because it teaches you to ignore the one case where it's telling the truth.

## The fix

The step now names both shapes:

- **One PR, or a stack merged as one PR** — whole-tree equality is still the right question. Unchanged.
- **Sibling PRs merged separately** — the right question is whether each target's *own contribution* landed. For every file the target touched, trunk's copy must match its copy.

```bash
for f in $(jj diff -r <target> --summary | awk '{print $2}'); do
  diff -q <(jj file show -r <target> "$f") \
          <(jj file show -r 'trunk()' "$f") >/dev/null \
    && echo "ok      $f" || echo "DIFFERS $f"
done
```

A `DIFFERS` means either the merge dropped something or a later change touched the same file — stop and look either way.

## Verified

The loop was run both directions rather than reasoned about:

```
against @ (unmerged content):  DIFFERS plugins/commit-commands-jj/commands/finish.md   ✓ detects a real difference
against trunk (merged content): ok × 6                                                  ✓ detects a match
```

`jj diff --summary` emits `M path`, so `awk '{print $2}'` is correct.

This is also how #71 and #72 were actually verified before being abandoned — every file from both targets matched trunk byte-for-byte.

## Provenance

Step 6b was written in #69 **while merging a stack**, and generalised from the one case in front of me. It was wrong for the second shape I tried, two hours later.

That is the same failure #68 was about, arriving on the freshest possible code: a confident claim about behaviour, written from the single example at hand, shipped without exercising the other case. Worth stating plainly rather than quietly patching — the fix for #69's step is the same discipline #69 was trying to install.

## Test plan

- [x] Loop verified to report `DIFFERS` on unmerged content and `ok` on merged content
- [x] `jj diff --summary` output format confirmed against `awk '{print $2}'`
- [x] `test-model-selection-lint.sh` → 4 passed (it scans all `plugins/**/*.md`)
- [x] No raw-git or interactive jj forms introduced
- [x] Checked for restatements elsewhere — the post-merge step exists only in `finish.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)