### PR TITLE
fix(commit-commands): correct /undo's false deprecation claim

### DIFF
--- a/plugins/commit-commands-jj/commands/undo.md
+++ b/plugins/commit-commands-jj/commands/undo.md
@@ -34,6 +34,12 @@ Notes:
 - For restoring to an older state, use `jj op restore <op-id>` (the op IDs are visible in `jj op log`)
 - The revert itself is an operation and can be reverted
 - This is much safer than git's approach — no risk of losing commits
-- Do NOT use `jj undo` — it is deprecated and will be removed in a future version
+- Prefer `jj op revert <op-id>` over bare `jj undo` here. `jj undo` is *not*
+  deprecated — it is current — but it is **sequential**: calling it twice walks
+  two operations back, not one. An agent that retries after an ambiguous result
+  will undo more than it meant to. `jj op revert <op-id>` names exactly what it
+  reverses, so it says the same thing every time it runs
+- `jj op undo` **was** deprecated in favour of `jj op revert`, and has been
+  removed. Don't confuse it with bare `jj undo`, which still exists
 
 You have the capability to call multiple tools in a single response. Perform the undo using a single message. Do not use any other tools or do anything else. Do not send any other text or messages besides these tool calls.


### PR DESCRIPTION
## Summary

`commands/undo.md:37` said:

> Do NOT use `jj undo` — it is deprecated and will be removed in a future version

That's a true statement about **a different command**. One word apart, and wrong as written.

## What upstream actually deprecated

| command | status |
|---|---|
| **`jj op undo`** | deprecated in favour of `jj op revert` — and **removed** |
| **`jj undo <operation>`** (argument form) | deprecated → `jj op revert <operation>` |
| **`jj undo --what`** | deprecated → `jj op restore --what` |
| **`jj undo`** (bare) | **current.** Not deprecated. |

On jj 0.43.0, `jj undo --help` documents it fully — "Undo the last operation", a note about the complementary `jj redo`, a pointer to `jj op restore` — with **no deprecation notice anywhere**. Meanwhile `jj op undo` doesn't exist at all: `error: unrecognized subcommand 'undo'`.

So the file told you not to use a command that works, citing the removal of one that's gone.

## The design survives — on better grounds

This PR does **not** switch `/undo` to bare `jj undo`. The two-step is still right, for a reason the file never gave:

**`jj undo` is now sequential.** Call it twice and it walks *two* operations back, not one. An agent that retries after an ambiguous result undoes more than it meant to. `jj op revert <op-id>` names exactly what it reverses, so it says the same thing every time it runs.

That's a real argument. "It's deprecated" wasn't.

## Why this is a two-line fix and not an issue

There's no decision to make. The claim is verifiably false, the design it justified holds up on other grounds, and the fix is swapping a wrong rationale for the true one. Issues are for judgment calls — cf. #70, which needs one.

## The part worth noticing

The README's `/undo` section (fixed in #72) is **correct** — and it got there by inheriting this false premise. Task 3 of the re-run found the README said `jj undo`, checked it against `commands/undo.md`, saw "do not use `jj undo`", and changed the README to match. Right answer, wrong reasoning, and **nothing in that diff would have revealed it**.

That's the fourth artifact today whose conclusion was right and whose reasoning wasn't. Consistent with everything else: the failure isn't in the conclusions, it's in claims nobody executed.

Found while chasing the `/undo` permission gap in #71.

## Verified

- `jj undo --help` on 0.43.0 — read in full, no deprecation notice
- `jj op undo --help` → `error: unrecognized subcommand 'undo'`
- Upstream: [jj CHANGELOG](https://github.com/jj-vcs/jj/blob/main/CHANGELOG.md), [operation-log docs](https://jj-vcs.github.io/jj/latest/operation-log/), [v0.33.0](https://github.com/jj-vcs/jj/releases/tag/v0.33.0), [v0.39.0](https://github.com/jj-vcs/jj/releases/tag/v0.39.0)
- Grepped for restatements — the claim existed only in this file; the README describes *what* `/undo` does without repeating *why*, so it never inherited it

## Test plan

- [x] False claim gone (`grep` → 0)
- [x] Frontmatter untouched (`validate-frontmatter` CI covers this file)
- [x] `test-model-selection-lint.sh` → 4 passed
- [x] No raw-git or interactive jj forms introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)