### PR TITLE
fix(fan-flames): clear stale artifacts when starting a fresh run

### DIFF
--- a/plugins/workspace-jj/skills/fan-flames.md
+++ b/plugins/workspace-jj/skills/fan-flames.md
@@ -182,7 +182,36 @@ fresh. On resume:
   re-dispatching
 - Trust the ledger and `jj log` over your own recollection
 
-On start fresh: overwrite the ledger with a new header when PLAN initializes it.
+If it exists and **does** end with `run: complete`, the previous run finished.
+There is nothing to resume — but its artifacts are still sitting there, so
+this is a start-fresh, not a no-op.
+
+### Starting Fresh — clear the artifacts directory
+
+The artifacts directory is **per-repo, not per-run**: every run in this repo
+reuses it. Any file a new run does not happen to overwrite survives from the
+old one, and nothing distinguishes the two. A three-task run following a
+five-task run leaves `task-4-report.md` and `task-5-report.md` in place; hand
+a reviewer that path and it reads the previous run's work as if it were this
+one's. So does a reviewer whose implementer died before writing its report.
+
+Clear them before PLAN:
+
+```bash
+ART=$(../scripts/fan-flames-artifacts)
+find "$ART" -maxdepth 1 \( -name 'task-*-brief.md' -o -name 'task-*-report.md' \
+  -o -name 'prior-waves.md' \) -delete
+```
+
+`find`, not `rm -f task-*.md`: an unmatched glob is an error in zsh (`no
+matches found`) and fails before `rm` runs, so the glob form breaks on the
+first run in a repo, when there is nothing to clear yet. `find` is a no-op
+when nothing matches, in every shell.
+
+PLAN then writes the ledger header and the briefs this run needs.
+
+**On resume, clear nothing.** The ledger and the reports are the recovery
+map — deleting them is deleting the reason you resumed.
 
 ## Model Selection
 


### PR DESCRIPTION
## Summary

The artifacts directory is **per-repo, not per-run** — `/tmp/jj-workspaces/<repo>/artifacts` is reused by every run in that repo. The Resume Check said only:

> On start fresh: overwrite the ledger with a new header when PLAN initializes it.

One file out of four. Every other artifact survived into the next run, indistinguishable from the current one's.

## Two gaps, both hit for real

**1. No branch for a *completed* previous run.** The check tested `does not end with 'run: complete'` → interrupted → ask the user. If the ledger **did** end with `run: complete`, the skill said nothing at all and the orchestrator just proceeded — with the previous run's briefs and reports still sitting there. That's the common case, and it was unhandled.

**2. "Start fresh" only meant the ledger.** Observed on the 2026-07-15 re-run: the directory still held `task-4-brief.md` (`### Task 4: project-setup-jj README audit`) and `task-5-report.md` from the earlier five-task run, while that run had three tasks.

Why it matters: a three-task run following a five-task run inherits `task-4-report.md` and `task-5-report.md` wholesale. Hand a reviewer that path and it reads the previous run's work as this run's. Same for an implementer that dies before writing its report — the reviewer gets the old one and never knows.

## The fix

- The `run: complete` case is now named: nothing to resume, but it *is* a start-fresh, not a no-op.
- Start fresh clears briefs, reports, and `prior-waves.md` before PLAN.
- **Resume clears nothing** — the ledger and reports are the recovery map; deleting them deletes the reason you resumed.

## Why `find` and not `rm -f task-*.md`

The first draft of this fix used a glob. Testing it found it **breaks in zsh**:

```
$ rm -f "$ART"/task-*-brief.md      # on an empty dir
zsh: no matches found: .../task-*-brief.md
exit 1
```

zsh errors on an unmatched glob *before* `rm` runs, so `-f` can't help. bash passes the literal through and `rm -f` swallows it — so the glob form works in bash and fails in zsh, and would break on the **first run in a repo**, when there is nothing to clear yet. `find … -delete` is a no-op when nothing matches, in every shell. The reason is recorded inline so nobody "simplifies" it back.

## Verified

Ran, not reasoned about — all four cases:

```
empty dir (first-ever run)     exit 0, no-op          ✓
completed 5-task run's files   12 files → progress.md ✓
run twice (idempotent)         exit 0                 ✓
under bash, not just zsh       exit 0                 ✓
```

The ledger survives every case, which is what the Resume Check needs until PLAN overwrites it.

- `test-fan-flames-scripts.sh` → 22 passed
- `test-model-selection-lint.sh` → 4 passed
- Checked for restatements — the artifact lifecycle is described only in `fan-flames.md`

## Provenance

Found by the 2026-07-15 fan-flames re-run validating #68/#69, reported in #72's body, and left unfixed until now — the last known defect from that run still on the floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)