### PR TITLE
chore(plugins): bump workspace-jj and peer-review-jj to 0.1.1

### DIFF
--- a/plugins/peer-review-jj/.claude-plugin/plugin.json
+++ b/plugins/peer-review-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "peer-review-jj",
   "description": "Unified change review for jj repos — generalist-first with emergent specialists, two-phase pipeline, structured findings",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/workspace-jj/.claude-plugin/plugin.json
+++ b/plugins/workspace-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workspace-jj",
   "description": "Wave-based parallel orchestration with spec review gates for jj (Jujutsu) repositories",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"


### PR DESCRIPTION
Makes #81 actually ship. Without this, it can't.

## The problem

The plugin cache is keyed by **version string**:

```
~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/
```

Once `0.1.0/` exists, `claude plugin update` compares `0.1.0 == 0.1.0`, reports **"✔ already at the latest version (0.1.0)"**, and never re-fetches. **Content changes alone do not ship.** The success message is the misleading part — it's reporting on the version, not on the content.

## Caught in the act

#81 migrated these two plugins' skills to the `SKILL.md` layout. It merged green. It is still not live:

| Layer | State after #81 merged |
|---|---|
| source (`main`) | `skills/fan-flames/SKILL.md` ✅ |
| marketplace clone | `skills/fan-flames/SKILL.md` ✅ |
| **plugin cache `0.1.0/`** | **`skills/fan-flames.md` ❌ — what the Skill tool loads** |

And `claude plugin update` refuses to fix it, because the version matches.

The timeline pins the mechanism exactly (local = UTC−4):

| Event | Time |
|---|---|
| #76 merged | 15:32 |
| **cache `0.1.0/` first fetched** | **16:26** |
| #81 merged | 16:52 |
| `plugin update` → "already at latest" | ~16:55 |

The `0.1.0/` dir was first fetched at 16:26 — after #76, before #81. That's the whole reason #76's content is in the cache and #81's isn't. Nothing about #76 was special; it just merged on the lucky side of a one-time fetch.

## The wider gap

#73 pinned all six plugins at `0.1.0` this morning. **Every content change merged since is invisible to installed users until a version bumps.** #74, #75, and #76 all merged under the same pin — they reached the cache only by the accident of when that first fetch landed. #81 is simply the first to merge on the wrong side of it.

This PR unblocks the two plugins #81 touched. The policy gap — that a merge without a version bump silently never ships — is filed separately as #84.

## Verification

After merge: `marketplace update` → `plugin update` → a new `0.1.1/` cache dir appears containing `skills/<name>/SKILL.md`, and the skills load on restart for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)