### PR TITLE
chore: refresh this repo's CLAUDE.md from the current project-setup template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,9 @@
-<!-- jj-project-setup:start hash:422ef786 -->
+<!-- jj-project-setup:start hash:fe023f83 -->
 ## VCS — jj (Jujutsu)
 
 This project uses **jj (Jujutsu)** as its VCS. Never use raw git commands. Use jj equivalents instead (e.g. `jj log`, `jj status`, `jj diff`). The only exceptions are `jj git` subcommands (e.g. `jj git push`) and the `gh` CLI for GitHub operations.
+
+In jj, the working copy IS a commit. There is no uncommitted state. Never ask "want to commit?" or "ready to commit?" — the work is already committed. Use `jj new` to start a new change, `jj describe` to set intent. The only meaningful checkpoint questions are "want to start a new change?", "want to describe this change?", or "want to push?"
 
 ### Superpowers overrides
 
@@ -10,7 +12,7 @@ When superpowers skills reference git-based workflows, use these jj-native repla
 | Superpowers skill | Use instead | Why |
 |---|---|---|
 | `finishing-a-development-branch` | `/finish` | jj-native: bookmarks, `jj git push`, workspace cleanup |
-| `subagent-driven-development` | `workspace-jj:kaisen` | jj-native workspace isolation with reunification |
+| `subagent-driven-development` | `workspace-jj:kaisen` | jj-native: wave-based parallel execution with spec review gates |
 <!-- jj-project-setup:end -->
 
 # CLAUDE.md


### PR DESCRIPTION
This repo's own CLAUDE.md had been stale for four months. Fixing it also settles #85's last outstanding gate and gives #78 evidence it was missing.

## The staleness

`CLAUDE.md` carried `<!-- jj-project-setup:start hash:422ef786 -->` — the **original** marker from #24 (2026-03-14), the PR that introduced hash-based CLAUDE.md updates. It had never been refreshed since, so it was missing guidance the template has carried for months:

> In jj, the working copy IS a commit. There is no uncommitted state. Never ask "want to commit?" or "ready to commit?" — the work is already committed.

That is the same guidance the maintainer has had to give Claude by hand. **It existed in the template the whole time and never reached the repo that needed it.**

Marker: `422ef786` → `fe023f83`. The override table's description also syncs to the template's wording.

Everything outside the managed markers is byte-identical — verified.

## This is #86, live

#86 (filed today) argues that nothing enforces the template's hash↔content invariant, and that a stale marker silently skips the update forever while reporting success. This repo is the proof: four months of drift, no symptom, and a real cost — the guidance that would have prevented a hand-correction never arrived.

It also confirms #86's claim that **the drift is invisible to whoever causes it.** A stale hash installs perfectly on a fresh repo (no marker → create path). It only bites existing projects with an older marker.

## Settles #85's last gate

#85's spec listed a post-merge gate it could not run: *prove a changed hash reaches an existing project with an old marker*. This is that gate, executed. Hashes differed → case 2 took the **replace** path, not the skip. The mechanism works; nobody had run it.

## Evidence for #78

#78 notes `/project-setup` is untested and its settings merge is idempotent "by design, but nothing verifies that". Re-running it here, against a fully-configured repo:

| | before → after |
|---|---|
| `SessionStart` | 1 → 1 |
| `PreToolUse` | 1 → 1 |
| `WorktreeCreate` / `WorktreeRemove` | 1 → 1 each |
| `PreCompact` | **0 → 1** |
| `permissions.allow` | 89 → 89, **set-identical** |
| `permissions.deny` | 1 → 1 |

Every existing entry deduped cleanly. Nothing was added or lost from the permission set — a large diff appears only because `jq`'s `unique` re-sorts the array. **The merge is idempotent**, which #78 lists as unverified.

The one real change: `PreCompact` (from #64) was missing here and is now installed. Two minor corrections for #78 while we're at it — the command targets `.claude/settings.local.json`, not `.claude/settings.json`, and `.claude/` is gitignored in this repo, so nothing it writes is tracked.

Settings changes are local and untracked; this PR contains only the CLAUDE.md refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)