### PR TITLE
ci: run the seven shell test suites on every PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,60 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: macos-latest
+    # macOS runners bill at a 10x multiplier and the job default is 6 hours.
+    # A hung suite should cost minutes, not a day's budget.
+    timeout-minutes: 15
+    env:
+      # Load-bearing, not defensive: the suites rely on the developer's
+      # ~/.config/jj/config.toml for an identity and never mention it. Without
+      # this, test-statusline-jj.sh fails 6/8 (measured against a clean $HOME).
+      JJ_USER: CI
+      JJ_EMAIL: ci@example.invalid
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install jj
+        run: brew install jj
+
+      - name: Run all suites
+        run: |
+          # Glob, never a hardcoded list: a list goes stale silently when a
+          # suite is added, and CI stays green while checking less. That is the
+          # #82 failure inside the fix for #82.
+          suites=$(find plugins -path '*/tests/test-*.sh' | sort)
+          count=$(printf '%s' "$suites" | grep -c . || true)
+
+          # A glob that matches nothing passes by doing nothing — #82's other
+          # half. This repo has seven suites; zero means the glob rotted.
+          if [ "$count" -eq 0 ]; then
+            echo "::error::no test suites found — the glob is broken, not the repo clean"
+            exit 1
+          fi
+          echo "found $count suite(s)"
+
+          # `while read`, not `for t in $suites`: the latter word-splits on IFS
+          # and glob-expands. Harmless for today's paths, but the failure mode
+          # of an unquoted expansion is silent and wrong, not loud.
+          failed=0
+          while IFS= read -r t; do
+            [ -n "$t" ] || continue
+            echo "::group::$t"
+            if bash "$t"; then
+              echo "PASS $t"
+            else
+              echo "::error::FAIL $t"
+              failed=$((failed + 1))
+            fi
+            echo "::endgroup::"
+          done <<< "$suites"
+
+          echo "---"
+          echo "$((count - failed))/$count suites passed"
+          [ "$failed" -eq 0 ]

--- a/docs/plans/2026-07-16-ci-test-runner-plan.md
+++ b/docs/plans/2026-07-16-ci-test-runner-plan.md
@@ -1,0 +1,307 @@
+# CI Test Runner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this
+> plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Do NOT use workspace-jj:kaisen for this plan.** It has one task and one file. There is nothing
+> to parallelise, and kaisen's own Parallelism Threshold rule directs you to sequential execution
+> below 40%. Inline execution is correct.
+
+**Goal:** Make CI run the seven shell test suites that have never executed in it.
+
+**Architecture:** One workflow, one job, one step that globs for suites and runs each. No new test
+code — the 193 assertions already exist and already pass locally. The only new thing is that
+something finally executes them.
+
+**Tech Stack:** GitHub Actions, bash, jj (Jujutsu), Homebrew.
+
+## Global Constraints
+
+- **jj, never git.** This repo uses Jujutsu. Use `jj` for all VCS operations. The only exceptions
+  are `jj git` subcommands and the `gh` CLI. Raw `git` is blocked by a PreToolUse hook.
+- **The workflow MUST NOT hardcode the suite count.** No `[ "$count" -ne 7 ]`, no expected-count
+  check. `7` is what the glob finds today, not a requirement. A hardcoded count is a hardcoded list
+  wearing a disguise and fails the same way. The only count rule is `count > 0`.
+- **No `paths:` filter.** A `paths:`-gated workflow that never triggers is indistinguishable from
+  one that passes — that is #82, and this workflow exists partly to not repeat it.
+- **Glob discovery, never a hardcoded list of suites.**
+- **Preserve the deliberate shell details.** `failed=$((failed + 1))` not `((failed++))` (the
+  latter returns 1 when incrementing from 0 and trips Actions' `bash -e`); `if bash "$t"` is
+  errexit-exempt so a failing suite is caught rather than aborting the step; `while IFS= read -r`
+  not `for t in $suites`. These look like nits and are not.
+- **Verify by reading the log, not the green tick.** A green run that found fewer suites than exist
+  is the exact failure being fixed.
+- Spec: `docs/specs/2026-07-16-ci-test-runner-design.md`
+
+---
+
+### Task 1: Add the test runner workflow
+
+The only task. It creates one file, verifies the shell logic locally before pushing, and commits.
+
+**Files:**
+- Create: `.github/workflows/test.yml`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a `test` job on every PR. No later task depends on it; the PR verification section
+  below is how it is proven.
+
+- [ ] **Step 1: Confirm the gap is real before fixing it**
+
+```bash
+cd /Users/muloka/projects/sonder-hale/tools/claude-plugins
+ls .github/workflows/
+grep -rn "tests/" .github/workflows/ || echo "NO WORKFLOW RUNS THE SUITES"
+```
+
+Expected: `close-external-prs.yml` and `validate-frontmatter.yml` only, then
+`NO WORKFLOW RUNS THE SUITES`. If a workflow already runs them, stop — this plan's premise is
+gone.
+
+- [ ] **Step 2: Confirm all seven suites pass locally**
+
+```bash
+for t in plugins/*/tests/test-*.sh; do
+  printf "%-42s %s\n" "$(basename $t)" "$(bash "$t" 2>&1 | tail -1)"
+done
+```
+
+Expected: seven lines, every one reporting `0 failed` or `ALL PASSED`. This is the baseline — if a
+suite is already red locally, fix that first or the first CI run's red tells you nothing new.
+
+- [ ] **Step 3: Create the workflow**
+
+Create `.github/workflows/test.yml` with exactly this content:
+
+```yaml
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: macos-latest
+    # macOS runners bill at a 10x multiplier and the job default is 6 hours.
+    # A hung suite should cost minutes, not a day's budget.
+    timeout-minutes: 15
+    env:
+      # Load-bearing, not defensive: the suites rely on the developer's
+      # ~/.config/jj/config.toml for an identity and never mention it. Without
+      # this, test-statusline-jj.sh fails 6/8 (measured against a clean $HOME).
+      JJ_USER: CI
+      JJ_EMAIL: ci@example.invalid
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install jj
+        run: brew install jj
+
+      - name: Run all suites
+        run: |
+          # Glob, never a hardcoded list: a list goes stale silently when a
+          # suite is added, and CI stays green while checking less. That is the
+          # #82 failure inside the fix for #82.
+          suites=$(find plugins -path '*/tests/test-*.sh' | sort)
+          count=$(printf '%s' "$suites" | grep -c . || true)
+
+          # A glob that matches nothing passes by doing nothing — #82's other
+          # half. This repo has seven suites; zero means the glob rotted.
+          if [ "$count" -eq 0 ]; then
+            echo "::error::no test suites found — the glob is broken, not the repo clean"
+            exit 1
+          fi
+          echo "found $count suite(s)"
+
+          # `while read`, not `for t in $suites`: the latter word-splits on IFS
+          # and glob-expands. Harmless for today's paths, but the failure mode
+          # of an unquoted expansion is silent and wrong, not loud.
+          failed=0
+          while IFS= read -r t; do
+            [ -n "$t" ] || continue
+            echo "::group::$t"
+            if bash "$t"; then
+              echo "PASS $t"
+            else
+              echo "::error::FAIL $t"
+              failed=$((failed + 1))
+            fi
+            echo "::endgroup::"
+          done <<< "$suites"
+
+          echo "---"
+          echo "$((count - failed))/$count suites passed"
+          [ "$failed" -eq 0 ]
+```
+
+- [ ] **Step 4: Verify the YAML parses**
+
+```bash
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/test.yml')); print('valid YAML')" 2>/dev/null \
+  || ruby -ryaml -e "YAML.load_file('.github/workflows/test.yml'); puts 'valid YAML'"
+```
+
+Expected: `valid YAML`. If neither interpreter has a YAML module available, skip — Step 7's real CI
+run is the authoritative parse, and a malformed workflow simply never triggers.
+
+- [ ] **Step 5: Run the step's shell logic locally, under Actions' shell**
+
+GitHub Actions runs `run:` blocks as `bash -e {0}`. Reproduce that exactly:
+
+```bash
+bash -e -c '
+suites=$(find plugins -path "*/tests/test-*.sh" | sort)
+count=$(printf "%s" "$suites" | grep -c . || true)
+if [ "$count" -eq 0 ]; then echo "::error::no test suites found"; exit 1; fi
+echo "found $count suite(s)"
+failed=0
+while IFS= read -r t; do
+  [ -n "$t" ] || continue
+  if bash "$t" >/dev/null 2>&1; then echo "  PASS $(basename $t)"; else echo "  FAIL $(basename $t)"; failed=$((failed + 1)); fi
+done <<< "$suites"
+echo "$((count - failed))/$count suites passed"
+[ "$failed" -eq 0 ]
+'
+echo "exit: $?"
+```
+
+Expected: `found 7 suite(s)`, seven `PASS` lines, `7/7 suites passed`, `exit: 0`.
+
+- [ ] **Step 6: Verify the zero-suites guard fails loudly**
+
+The guard is the whole anti-#82 point. A guard that has never been seen firing has not been shown
+to work.
+
+```bash
+bash -e -c '
+suites=$(find /nonexistent -path "*/tests/test-*.sh" 2>/dev/null | sort)
+count=$(printf "%s" "$suites" | grep -c . || true)
+if [ "$count" -eq 0 ]; then echo "::error::no test suites found — the glob is broken, not the repo clean"; exit 1; fi
+echo "SHOULD NOT REACH HERE"
+'
+echo "exit: $?"
+```
+
+Expected: the `::error::` line, then `exit: 1`. `SHOULD NOT REACH HERE` must not appear.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj commit -m "ci: run the seven shell test suites on every PR
+
+CI ran zero tests. Seven suites (193 assertions, including
+permission-gateway's 133) had never executed in CI; they passed only
+because a human ran them by hand. Any PR could have broken every one of
+them and CI would have been green.
+
+test-skill-paths.sh was added in #85 specifically to catch rules that
+nothing executes — and nothing executed it.
+
+Discovery is a glob, never a hardcoded list: a list goes stale silently
+when a suite is added, which is #82's failure inside the precondition
+for fixing #82. Zero suites found fails loudly, for the same reason.
+
+No paths: filter — a workflow that never triggers is indistinguishable
+from one that passes.
+
+JJ_USER/JJ_EMAIL are load-bearing, not defensive: the suites rely on the
+developer's ~/.config/jj/config.toml for an identity and never mention
+it. Measured against a clean HOME, test-statusline-jj.sh fails 6/8
+without them and passes 8/8 with them.
+
+macos-latest for now: statusline-jj.sh is macOS-only and degrades
+silently on Linux (#88).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## PR verification
+
+The steps above prove the shell logic on a developer laptop. They do **not** prove the workflow —
+that needs GitHub to parse it, trigger it, install jj, and run the suites on a machine that has
+never seen this repo. Every landmine in the spec was invisible locally.
+
+- [ ] **Step 1: Push and open the PR**
+
+```bash
+jj git push --change @-
+gh pr create --base main --head <bookmark-from-push> \
+  --title "ci: run the seven shell test suites on every PR" \
+  --body "See docs/specs/2026-07-16-ci-test-runner-design.md. Closes no issue; precondition for #82, #84, #86."
+```
+
+- [ ] **Step 2: Confirm it triggered at all**
+
+```bash
+gh pr checks <PR>
+```
+
+Expected: a `test` check appears. It has no `paths:` filter, so it must run on a PR that touches
+only `.github/`. **If no `test` check appears, that is #82 happening again, live** — the workflow
+did not trigger and its absence looks identical to success.
+
+- [ ] **Step 3: Read the log — do not trust the tick**
+
+```bash
+gh run view <run-id> --log | grep -E "found [0-9]+ suite|PASS plugins|FAIL plugins|suites passed"
+```
+
+Expected: `found 7 suite(s)`, seven `PASS plugins/...` lines naming each suite, and
+`7/7 suites passed`. Compare the seven names against `find plugins -path '*/tests/test-*.sh'`.
+
+**A green tick is not the check.** A run that found five suites and passed all five is green and
+wrong. The list is the check.
+
+- [ ] **Step 4: Prove it can go red**
+
+If any suite failed in Step 3, that is the proof — skip to Step 5. If all seven passed, force it:
+
+```bash
+jj new -m "TEMP: prove CI goes red — do not merge"
+printf '\nexit 1  # TEMP: prove CI goes red\n' >> plugins/workspace-jj/tests/test-skill-paths.sh
+jj git push --change @
+```
+
+`exit 1`, not a fabricated assertion call. The suite's helper is `bad()`, not `fail()`, and the
+script's last line is already `test "$FAIL" -eq 0` — an appended `fail "..."` exits 127
+(`command not found`) and turns the suite red *by accident*, blaming a missing command rather than
+a failed check. Verified 2026-07-16: `exit 1` → exit 1; `fail "..."` → exit 127.
+
+`test-skill-paths.sh` is the target because it is the fastest suite, has no external dependencies,
+and is the one this workflow exists to finally execute.
+
+Expected on the run: the `test` job goes **red**; the log shows `::error::FAIL` naming
+`plugins/workspace-jj/tests/test-skill-paths.sh`; `6/7 suites passed`; and the **other six suites
+still appear in the log**, proving non-fail-fast.
+
+- [ ] **Step 5: Remove the proof commit**
+
+```bash
+jj abandon @
+jj git push --change @-
+jj log -r 'main::@' --no-graph -T 'change_id.short(8) ++ " " ++ description.first_line() ++ "\n"'
+```
+
+Expected: no `TEMP:` change in the output. It must not reach main.
+
+- [ ] **Step 6: Confirm green again, then merge**
+
+```bash
+gh pr checks <PR>
+gh pr merge <PR> --squash
+```
+
+Expected: `test` passes. Merge without `--delete-branch` — it fails in this jj-colocated repo.
+Clean up with `jj git fetch`, then `jj bookmark delete <name>`, `jj git push --deleted`.
+
+## What this does not prove
+
+- **That the suites pass on Linux.** Deferred to #88; `statusline-jj.sh` is macOS-only and degrades
+  silently rather than failing.
+- **That the suites are good tests.** This plan makes existing assertions run. Whether they assert
+  the right things is #79's question.

--- a/docs/specs/2026-07-16-ci-test-runner-design.md
+++ b/docs/specs/2026-07-16-ci-test-runner-design.md
@@ -1,0 +1,298 @@
+# CI Test Runner: Making the Suites Actually Run
+
+**Date:** 2026-07-16
+**Status:** Approved, pending implementation
+**Precondition for:** #82, #84, #86
+
+## Summary
+
+**CI runs zero tests.** Seven shell suites — **185 counted assertions** — have never executed in
+CI. They pass only because a human runs them by hand. Any PR could break every one of them and CI
+would be green.
+
+This spec covers the precondition: a workflow that runs the existing suites. It closes no issue on
+its own. It is what makes #82/#84/#86's lint-based fixes possible, because a lint added today
+would never execute.
+
+## The gap
+
+`.github/workflows/` contains exactly two workflows:
+
+| Workflow | What it does |
+|---|---|
+| `close-external-prs.yml` | membership check — not a test |
+| `validate-frontmatter.yml` | frontmatter of changed agent/skill/command `.md` only |
+
+Nothing runs (counts measured 2026-07-16; all seven pass locally):
+
+| Suite | Assertions |
+|---|---|
+| `permission-gateway/tests/test-permission-gate.sh` | 133 |
+| `workspace-jj/tests/test-kaisen-scripts.sh` | 22 |
+| `agent-helpers-jj/tests/test-agent-helpers-install.sh` | 15 |
+| `agent-helpers-jj/tests/test-jj-agent-helpers.sh` | 8 |
+| `workspace-jj/tests/test-model-selection-lint.sh` | 4 |
+| `workspace-jj/tests/test-skill-paths.sh` | 3 |
+| `project-setup-jj/tests/test-statusline-jj.sh` | 8 |
+| **Total** | **193** |
+
+`test-statusline-jj.sh` uses a different output format from the other six — it prints
+`Results: 8/8 passed` followed by `ALL PASSED`, where the others print `N passed, M failed`. The
+runner does not parse these numbers (it keys on exit status), so the inconsistency is harmless
+here; it would matter to any future "assertion count" metric.
+
+**This count has been wrong twice, both times by looking at too little output.** The first draft
+said 162, having summed four of the seven suites. The correction said 185, having read each suite's
+output with `tail -1` — which showed `ALL PASSED` and hid the `Results: 8/8 passed` line directly
+above it. The number is 193. A spec whose thesis is *quiet miscounting* miscounted quietly, twice,
+and the second time was the same truncation error that let an over-broad `jj abandon` swallow an
+unrelated four-month-old change earlier the same day (its `and 8 more` was on a line `tail -1` did
+not show). **Read the whole output, not its last line.**
+
+**The recursion:** `test-skill-paths.sh` was added on 2026-07-15 (#85) specifically to catch rules
+that nothing executes — and nothing executes it. A guard against unexecuted prose, left unexecuted.
+
+## Why this is not one gate with #82/#84/#86
+
+The working assumption when this was scoped was *"one CI job closes three issues."* Exploration
+killed it. The three share a **theme** — a stated rule nothing enforces — but not a **mechanism**:
+
+| Issue | Needs | Shape |
+|---|---|---|
+| #86 — hash ≠ body | nothing; pure static | a lint |
+| #82 — glob matches zero files | nothing; pure static | a lint (assert each glob matches ≥1 file) |
+| #84 — version not bumped | the PR diff vs base | a CI step |
+
+Two static lints and one diff-aware check — **and both lints are inert until something runs
+lints.** Hence: runner first, as its own PR.
+
+## Design
+
+One workflow, `.github/workflows/test.yml`, one job.
+
+### Discovery: glob, never a list
+
+Suites are found with `find plugins -path '*/tests/test-*.sh'`, not enumerated.
+
+A hardcoded list goes stale silently: someone adds `test-foo.sh`, forgets the list, CI stays green
+while checking nothing. **That is #82 verbatim** — it would reintroduce the bug inside the
+precondition for fixing it.
+
+### Zero suites found ⇒ fail
+
+A glob has #82's *other* failure mode: matching nothing and passing by doing nothing. So the run
+fails loudly if the glob returns zero. The repo has seven suites; zero means the glob rotted, not
+that the repo is clean.
+
+This is the same rule `test-skill-paths.sh` applies to itself, applied one level up.
+
+### No `paths:` filter
+
+`validate-frontmatter.yml` is `paths:`-gated, and #82 exists precisely because a workflow that
+never triggers is indistinguishable from one that passes. This runs on every PR, unconditionally.
+
+Fixing `validate-frontmatter.yml`'s own `paths:` gate is #82's business, not this spec's.
+
+### Run all, don't fail-fast
+
+Every suite runs; failures are collected and reported together. Fail-fast would surface one broken
+suite per push.
+
+### Platform: `macos-latest`
+
+The suites have only ever run on macOS. `plugins/project-setup-jj/scripts/statusline-jj.sh` uses
+macOS-only `stat -f` (lines 75, 134) and `date -j` (line 183) — GNU `stat -f` means
+`--file-system`, something else entirely. Each call has a `|| echo "0"` fallback, so on Linux it
+would degrade rather than crash, and whether `test-statusline-jj.sh` still passes there is
+unknown.
+
+Running on macOS gets all 185 assertions enforced today, on the platform where they are known to
+work.
+Linux portability is deferred to a separate issue — it is real (#79 calls it out: "everything has
+only ever run in *this* repo"), but it is not this PR's job and would block it.
+
+## Landmines
+
+Three, found during exploration. All are properties of CI that the local environment hides.
+
+### 1. No `.jj/` in a CI checkout
+
+`.jj/` is gitignored (`.gitignore:3`), and `actions/checkout` produces a plain **git** checkout.
+There is no jj repo in CI.
+
+**Not a problem:** no suite calls `jj root`. The jj-dependent suites (`test-jj-agent-helpers.sh`,
+`test-statusline-jj.sh`, `test-kaisen-scripts.sh`) each run `jj git init` in their own `mktemp`
+directory. They never assume the checkout is a jj repo.
+
+### 2. No jj identity in CI
+
+**No suite sets one.** They silently rely on the developer's `~/.config/jj/config.toml` for
+`user.name` / `user.email`. CI has no such file, and jj needs an author for the working-copy
+commit.
+
+**This is measured, not predicted.** Running `test-statusline-jj.sh` against a `mktemp` `$HOME`
+(2026-07-16):
+
+| Environment | Result |
+|---|---|
+| clean `$HOME`, no identity | `Results: 6/8 passed` — **FAILED** |
+| clean `$HOME` + `JJ_USER`/`JJ_EMAIL` | `Results: 8/8 passed` — ALL PASSED |
+
+So the job-level env block is **load-bearing**, not defensive: without it the first CI run is red,
+and the cause — a config file the suites never mention — is not visible from the failure.
+
+This dependency is worth naming for its own sake: the suites are not as self-contained as they
+look, and every one of them passes locally *because of a file outside the repo*.
+
+### 3. `jj` is not installed
+
+`brew install jj`. `jq`, `bash`, and `python3` are preinstalled on GitHub's macOS images.
+
+## The workflow
+
+```yaml
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: macos-latest
+    # macOS runners bill at a 10x multiplier and the job default is 6 hours.
+    # A hung suite should cost minutes, not a day's budget.
+    timeout-minutes: 15
+    env:
+      # Load-bearing, not defensive: the suites rely on the developer's
+      # ~/.config/jj/config.toml for an identity and never mention it. Without
+      # this, test-statusline-jj.sh fails 6/8 (measured against a clean $HOME).
+      JJ_USER: CI
+      JJ_EMAIL: ci@example.invalid
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install jj
+        run: brew install jj
+
+      - name: Run all suites
+        run: |
+          # Glob, never a hardcoded list: a list goes stale silently when a
+          # suite is added, and CI stays green while checking less. That is the
+          # #82 failure inside the fix for #82.
+          suites=$(find plugins -path '*/tests/test-*.sh' | sort)
+          count=$(printf '%s' "$suites" | grep -c . || true)
+
+          # A glob that matches nothing passes by doing nothing — #82's other
+          # half. This repo has seven suites; zero means the glob rotted.
+          if [ "$count" -eq 0 ]; then
+            echo "::error::no test suites found — the glob is broken, not the repo clean"
+            exit 1
+          fi
+          echo "found $count suite(s)"
+
+          # `while read`, not `for t in $suites`: the latter word-splits on IFS
+          # and glob-expands. Harmless for today's paths, but the failure mode
+          # of an unquoted expansion is silent and wrong, not loud.
+          failed=0
+          while IFS= read -r t; do
+            [ -n "$t" ] || continue
+            echo "::group::$t"
+            if bash "$t"; then
+              echo "PASS $t"
+            else
+              echo "::error::FAIL $t"
+              failed=$((failed + 1))
+            fi
+            echo "::endgroup::"
+          done <<< "$suites"
+
+          echo "---"
+          echo "$((count - failed))/$count suites passed"
+          [ "$failed" -eq 0 ]
+```
+
+Two shell details are deliberate and should survive review. `failed=$((failed + 1))` rather than
+`((failed++))` — the latter returns 1 when incrementing from 0 and would trip Actions' `bash -e`.
+And `if bash "$t"` is errexit-exempt, so a failing suite is caught rather than aborting the step.
+
+## Verification
+
+**The count is an observation, never an assertion.**
+
+> The workflow MUST NOT hardcode the number of suites. No `[ "$count" -ne 7 ]`, no expected-count
+> check, nothing that must be edited when a suite is added. `7` is what the glob finds on
+> 2026-07-16 — it is a fact about today's repo, not a requirement. **A hardcoded count is a
+> hardcoded list wearing a disguise**, and it fails the same way: someone adds a suite, CI goes red
+> for a correct change, and the fix is to edit a number nobody remembers exists. The only count
+> rule in the workflow is `count > 0`.
+
+If a future run reports a number other than 7, that means a suite was added or removed. That is
+information, not a failure. Verify against **the list of suites in the log**, not against 7.
+
+**Mechanical:**
+
+1. The workflow triggers on the PR that adds it — it has no `paths:` filter, so it must.
+2. The run reports `found N suite(s)` where N equals `find plugins -path '*/tests/test-*.sh' | wc -l`
+   in the merge commit. On 2026-07-16 that is 7.
+3. **Every** suite present on disk appears as its own `::group::` section in the log — verify by
+   **reading the log and comparing it to the filesystem**, not by the green tick and not by the
+   number. A green run that silently found fewer suites is the failure being fixed.
+4. `N/N suites passed`.
+
+**The gate that proves it:** a runner that has never been observed failing has not been shown to
+work. `test-skill-paths.sh` applies the same discipline — its first run had to fail before it was
+trusted.
+
+If any suite fails on the first run, that is the proof: a red CI naming the suite. If all suites
+pass immediately, force the negative case explicitly, using this exact procedure:
+
+```bash
+# 1. Force the cheapest suite to fail (3 assertions, no deps, ~instant).
+jj new -m "TEMP: prove CI goes red — do not merge"
+printf '\nexit 1  # TEMP: prove CI goes red\n' \
+  >> plugins/workspace-jj/tests/test-skill-paths.sh
+
+# 2. Push to the SAME PR and read the run.
+jj git push --change @
+```
+
+`exit 1`, not a fabricated assertion call. The suite's helper is `bad()`, not `fail()`, and its
+last line is already `test "$FAIL" -eq 0` — so an appended `fail "..."` would exit 127
+(`command not found`) and turn the suite red *by accident*, with a log that blames a missing
+command rather than a failed check. Verified 2026-07-16: appending `exit 1` exits 1; appending
+`fail "..."` exits 127. Both are red; only one is honest.
+
+Expected: the `test` job goes **red**, the log names `plugins/workspace-jj/tests/test-skill-paths.sh`
+under `::error::FAIL`, `N-1/N suites passed`, and — critically — the **other suites still appear in
+the log**, proving non-fail-fast.
+
+```bash
+# 3. Remove the proof commit entirely; it must not reach main.
+jj abandon @
+jj git push --change @-
+```
+
+Confirm with `jj log -r 'main::@'` that the TEMP change is gone before merging.
+
+`test-skill-paths.sh` is the designated target: it is the fastest suite, has no external
+dependencies, and — fittingly — is the one this workflow exists to finally execute.
+
+**Not verified by this PR:** that the suites pass on Linux. Deferred, see below.
+
+## Follow-ups
+
+- **File: statusline / Linux portability.** `statusline-jj.sh` is macOS-only (`stat -f`, `date -j`)
+  and degrades silently rather than failing. Any Linux user's statusline is affected today, with
+  no symptom. Related to #79's portability section.
+- **#82, #84, #86** become implementable once this lands, as: two static lints picked up by the
+  glob for free, plus one diff-aware CI step.
+
+## Related
+
+- #82 — a validation glob matching zero files passes silently
+- #84 — a merge without a version bump never ships
+- #86 — a stale template hash silently skips the update
+- #79 — ~20 user-facing commands never executed; portability unmeasured
+- #85 — added `test-skill-paths.sh`, which this workflow finally executes


### PR DESCRIPTION
**CI runs zero tests.** Seven shell suites — **193 assertions**, including permission-gateway's 133 — have never executed in CI. They pass only because a human runs them by hand. Any PR could break every one and CI would be green.

Closes no issue. It is the **precondition** for #82, #84, and #86: those wanted lint-based fixes, and a lint added today would never run.

Spec: `docs/specs/2026-07-16-ci-test-runner-design.md` · Plan: `docs/plans/2026-07-16-ci-test-runner-plan.md` (both included here).

## The recursion

`test-skill-paths.sh` was added in #85 *specifically to catch rules that nothing executes* — and nothing executes it. This PR is what finally runs it.

## Design decisions, each load-bearing

- **Glob discovery, never a hardcoded list.** A list goes stale silently when a suite is added — that is #82's failure inside the fix for #82.
- **Zero suites found ⇒ fail loudly.** A glob matching nothing passes by doing nothing. Same bug, other half.
- **No `count == 7` check.** A hardcoded count is a hardcoded list in disguise. The only count rule is `> 0`.
- **No `paths:` filter.** A workflow that never triggers is indistinguishable from one that passes.
- **Non-fail-fast.** One broken suite shouldn't hide the state of the other six.

## Landmines, all invisible on a laptop

- **No jj identity in CI.** The suites silently rely on the developer's `~/.config/jj/config.toml`. Measured against a clean `$HOME`: `test-statusline-jj.sh` fails **6/8** without `JJ_USER`/`JJ_EMAIL`, passes **8/8** with them. The env block is load-bearing, not precautionary.
- **No `.jj/` in a CI checkout** (gitignored). Fine — no suite calls `jj root`; the jj-dependent ones make temp repos.
- **`jj` not installed** → `brew install jj`.

## Platform

`macos-latest`. The suites have only ever run on macOS; `statusline-jj.sh` is macOS-only (`stat -f`, `date -j`) and degrades silently on Linux. Portability tracked in #88.

## Verification note for the reviewer

**Read the log, not the tick.** A run that found five suites and passed all five is green and wrong. Expected: `found 7 suite(s)`, seven `PASS plugins/...` lines, `7/7 suites passed`. Every shell path was verified locally under `bash -e` (Actions' invocation), and — per the plan — this PR forces one red run to prove the runner reports failure, then removes the proof commit before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)