### PR TITLE
Cross-project hardening: jj-repo gating (#45) + fail-closed permission gate (#70)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           count=$(printf '%s' "$suites" | grep -c . || true)
 
           # A glob that matches nothing passes by doing nothing — #82's other
-          # half. This repo has seven suites; zero means the glob rotted.
+          # half. Zero means the glob rotted, not that the repo is clean.
           if [ "$count" -eq 0 ]; then
             echo "::error::no test suites found — the glob is broken, not the repo clean"
             exit 1

--- a/docs/superpowers/plans/2026-07-18-cross-project-hardening.md
+++ b/docs/superpowers/plans/2026-07-18-cross-project-hardening.md
@@ -1,0 +1,376 @@
+# Cross-Project Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Gate the raw-git block on jj-repo presence so the plugins are usable at user (global) scope (#45), and make the primary permission gate fail closed on unparseable input (#70).
+
+**Architecture:** Two independent changes to shell PreToolUse hooks. #45 adds a `.jj`-directory walk-up at the top of `block-raw-git.sh` and unifies its three drifted copies into one byte-identical superset, guarded by a new drift-detecting test. #70 mirrors the `ERR`-trap fail-closed construct from the sibling `gate-config-writes.sh` into `permission-gate.sh` and proves via test that it never fires a wrong-direction decision.
+
+**Tech Stack:** POSIX-ish bash, `jq`, `shasum`. Tests are plain bash suites run by `.github/workflows/test.yml`.
+
+**Spec:** `docs/superpowers/specs/2026-07-17-cross-project-hardening-design.md`
+
+## Global Constraints
+
+- **VCS is jj (Jujutsu), not git.** The working copy IS a commit. "Commit" steps below use `jj describe` to set the message and `jj new` to start the next task's change. Never run raw `git` — a PreToolUse hook blocks it. Use `gh` for GitHub.
+- **bash 3.2 compatibility (hard requirement).** Suites run on macOS `/bin/bash` (3.2.57) and ubuntu bash 5. No globstar (`**`), no associative arrays, no `mapfile`. Detection loops use `while [ "$dir" != "/" ]` + `dirname`.
+- **CI fails red on an unbumped plugin (#84).** Any changed byte under `plugins/<name>/` — including test files — requires bumping that plugin's `version` in `plugins/<name>/.claude-plugin/plugin.json`. Required bumps: `commit-commands-jj` 0.1.0→0.1.1, `peer-review-jj` 0.1.1→0.1.2, `project-setup-jj` 0.1.1→0.1.2, `permission-gateway` 0.1.0→0.1.1.
+- **Test discovery glob:** `find plugins .github -path '*/tests/test-*.sh'`. New suites must live at `plugins/<name>/tests/test-*.sh` to be found.
+- **The three `block-raw-git.sh` copies must end byte-identical** (same sha256), taking `project-setup-jj`'s superset as canonical. Enforced by a drift-guard test.
+
+---
+
+## Task 1: #45 — gate `block-raw-git.sh` on jj-repo presence + unify copies
+
+**Files:**
+- Create: `plugins/project-setup-jj/tests/test-block-raw-git.sh`
+- Modify: `plugins/project-setup-jj/scripts/block-raw-git.sh` (add gate after `input=$(cat)`)
+- Modify: `plugins/commit-commands-jj/scripts/block-raw-git.sh` (replace with canonical copy)
+- Modify: `plugins/peer-review-jj/scripts/block-raw-git.sh` (replace with canonical copy)
+- Modify: `plugins/commit-commands-jj/.claude-plugin/plugin.json` (0.1.0→0.1.1)
+- Modify: `plugins/peer-review-jj/.claude-plugin/plugin.json` (0.1.1→0.1.2)
+- Modify: `plugins/project-setup-jj/.claude-plugin/plugin.json` (0.1.1→0.1.2)
+
+**Interfaces:**
+- Consumes: the PreToolUse hook payload on stdin — a JSON object with `.tool_input.command` (string) and `.cwd` (absolute path string, may be absent).
+- Produces: nothing consumed by later tasks (Task 2 is independent). Behavioral contract: inside a jj repo (a `.jj` directory at `.cwd` or any ancestor) the hook emits a `deny` JSON for raw `git`/git-internals and `exit 0`; outside a jj repo it emits nothing and `exit 0` (pass-through).
+
+- [ ] **Step 1: Write the failing test suite**
+
+Create `plugins/project-setup-jj/tests/test-block-raw-git.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# project-setup-jj is the canonical superset copy; behaviour is tested against
+# it, and the drift-guard proves the other two are byte-identical.
+HOOK="$REPO_ROOT/plugins/project-setup-jj/scripts/block-raw-git.sh"
+
+COPIES="plugins/commit-commands-jj/scripts/block-raw-git.sh
+plugins/peer-review-jj/scripts/block-raw-git.sh
+plugins/project-setup-jj/scripts/block-raw-git.sh"
+
+pass=0
+fail=0
+
+# Run the hook with a command + cwd; capture stdout (hook never uses stderr).
+run_hook() {
+  local cmd="$1"
+  local cwd="$2"
+  local json='{"tool_input":{"command":"'"$cmd"'"},"tool_name":"Bash","hook_event_name":"PreToolUse","cwd":"'"$cwd"'"}'
+  echo "$json" | bash "$HOOK" 2>/dev/null || true
+}
+
+assert_blocked() {
+  local name="$1" cmd="$2" cwd="$3"
+  local out
+  out=$(run_hook "$cmd" "$cwd")
+  if echo "$out" | jq -r '.hookSpecificOutput.permissionDecision' 2>/dev/null | grep -q '^deny$'; then
+    echo "  PASS: $name"; pass=$((pass + 1))
+  else
+    echo "  FAIL: $name — expected deny, got: $out"; fail=$((fail + 1))
+  fi
+}
+
+assert_passthrough() {
+  local name="$1" cmd="$2" cwd="$3"
+  local out
+  out=$(run_hook "$cmd" "$cwd")
+  if [ -z "$out" ]; then
+    echo "  PASS: $name"; pass=$((pass + 1))
+  else
+    echo "  FAIL: $name — expected pass-through (no output), got: $out"; fail=$((fail + 1))
+  fi
+}
+
+# Temp repos: one jj (with a subdir), one pure-git.
+JJ_DIR=$(mktemp -d); mkdir -p "$JJ_DIR/.jj" "$JJ_DIR/sub/deep"
+GIT_DIR=$(mktemp -d); mkdir -p "$GIT_DIR/.git" "$GIT_DIR/src"
+trap 'rm -rf "$JJ_DIR" "$GIT_DIR"' EXIT
+
+echo "=== jj repo: raw git is blocked ==="
+assert_blocked "git status at jj root"      "git status"            "$JJ_DIR"
+assert_blocked "git status in jj subdir"    "git status"            "$JJ_DIR/sub/deep"
+assert_blocked "git commit at jj root"      "git commit -m x"       "$JJ_DIR"
+assert_blocked "git config (internals)"     "git config user.name x" "$JJ_DIR"
+assert_blocked "git rev-parse (internals)"  "git rev-parse HEAD"    "$JJ_DIR"
+
+echo "=== jj repo: interop seams and non-git pass through ==="
+assert_passthrough "jj git push allowed"    "jj git push"           "$JJ_DIR"
+assert_passthrough "gh allowed"             "gh pr list"            "$JJ_DIR"
+assert_passthrough "non-git command"        "ls -la"               "$JJ_DIR"
+
+echo "=== non-jj repo: git is allowed ==="
+assert_passthrough "git status in git root"   "git status"          "$GIT_DIR"
+assert_passthrough "git status in git subdir" "git status"          "$GIT_DIR/src"
+assert_passthrough "git commit in non-jj"     "git commit -m x"     "$GIT_DIR"
+assert_passthrough "git config in non-jj"     "git config user.name x" "$GIT_DIR"
+
+echo "=== drift-guard: all three copies are byte-identical ==="
+uniq_hashes=$( (cd "$REPO_ROOT" && shasum -a 256 $COPIES) | awk '{print $1}' | sort -u | grep -c . )
+if [ "$uniq_hashes" = "1" ]; then
+  echo "  PASS: block-raw-git.sh copies share one sha256"; pass=$((pass + 1))
+else
+  echo "  FAIL: block-raw-git.sh copies have diverged:"; fail=$((fail + 1))
+  (cd "$REPO_ROOT" && shasum -a 256 $COPIES)
+fi
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi
+```
+
+- [ ] **Step 2: Run the test to confirm it fails (red)**
+
+Run: `bash plugins/project-setup-jj/tests/test-block-raw-git.sh`
+Expected: FAIL. The three "non-jj repo: git is allowed" cases fail (the current hook has no gate, so it blocks git regardless of cwd → output present, not empty), and "drift-guard" fails (the three copies currently differ). The jj-repo blocking cases already pass.
+
+- [ ] **Step 3: Add the jj-repo gate to the canonical copy**
+
+In `plugins/project-setup-jj/scripts/block-raw-git.sh`, insert the gate immediately after the `input=$(cat)` line (currently line 6), before `command=$(echo "$input" | jq ...)`:
+
+```bash
+input=$(cat)
+
+# Gate on jj-repo presence (#45). This hard wall is intended only inside a jj
+# repo. Installed at the user (global) level the hook fires in every project,
+# and blocking git in a non-jj project is collateral damage, not the design.
+# Detect a .jj directory at cwd or any ancestor; if absent, pass through so git
+# is allowed. bash 3.2-safe: no globstar, no associative arrays.
+cwd=$(echo "$input" | jq -r '.cwd // ""')
+[ -n "$cwd" ] || cwd="$PWD"
+jj_repo=false
+dir="$cwd"
+while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+  if [ -d "$dir/.jj" ]; then
+    jj_repo=true
+    break
+  fi
+  dir=$(dirname "$dir")
+done
+[ "$jj_repo" = true ] || exit 0
+
+command=$(echo "$input" | jq -r '.tool_input.command // ""')
+```
+
+Leave the rest of the file (the `has_raw_git` and `has_git_internals` logic) unchanged.
+
+- [ ] **Step 4: Sync the other two copies to the canonical one**
+
+Overwrite both lagging copies with the canonical file so all three are byte-identical (this backports the `has_git_internals` block, the `remotes`→`remote` typo fix, the `jj plugins`→`jj repos` wording, and the new gate in one move):
+
+```bash
+cp plugins/project-setup-jj/scripts/block-raw-git.sh plugins/commit-commands-jj/scripts/block-raw-git.sh
+cp plugins/project-setup-jj/scripts/block-raw-git.sh plugins/peer-review-jj/scripts/block-raw-git.sh
+```
+
+- [ ] **Step 5: Run the test to confirm it passes (green)**
+
+Run: `bash plugins/project-setup-jj/tests/test-block-raw-git.sh`
+Expected: PASS (`0 failed`). All jj-repo blocks hold, all non-jj pass-throughs hold, drift-guard reports one shared sha256.
+
+- [ ] **Step 6: Verify byte-identity directly**
+
+Run: `shasum -a 256 plugins/commit-commands-jj/scripts/block-raw-git.sh plugins/peer-review-jj/scripts/block-raw-git.sh plugins/project-setup-jj/scripts/block-raw-git.sh`
+Expected: three identical hashes.
+
+- [ ] **Step 7: Bump the three plugin versions**
+
+Edit each manifest's `version` string:
+- `plugins/commit-commands-jj/.claude-plugin/plugin.json`: `"0.1.0"` → `"0.1.1"`
+- `plugins/peer-review-jj/.claude-plugin/plugin.json`: `"0.1.1"` → `"0.1.2"`
+- `plugins/project-setup-jj/.claude-plugin/plugin.json`: `"0.1.1"` → `"0.1.2"`
+
+- [ ] **Step 8: Verify the version-bump lint is satisfied**
+
+Run:
+```bash
+CHANGED_FILES="$(printf '%s\n' \
+  plugins/commit-commands-jj/scripts/block-raw-git.sh \
+  plugins/peer-review-jj/scripts/block-raw-git.sh \
+  plugins/project-setup-jj/scripts/block-raw-git.sh \
+  plugins/project-setup-jj/tests/test-block-raw-git.sh)" \
+BASE_DIR="" \
+bash .github/scripts/require-version-bump.sh; echo "exit=$?"
+```
+Expected: `exit=0` (with `BASE_DIR=""` every touched plugin is treated as new, which passes; this is a smoke check that the script runs clean — the real base-ref comparison happens in CI).
+
+- [ ] **Step 9: Commit (jj)**
+
+```bash
+jj describe -m "fix(#45): gate block-raw-git on jj-repo presence; unify the three copies
+
+Walk up from cwd for a .jj directory; pass through (allow git) when absent, so
+the hook is safe to install at user scope. Sync commit-commands-jj and
+peer-review-jj to project-setup-jj's superset (git-internals block + wording +
+typo fix) so all three are byte-identical, guarded by a new drift test."
+jj new
+```
+
+---
+
+## Task 2: #70 — fail closed on malformed input in `permission-gate.sh`
+
+**Files:**
+- Modify: `plugins/permission-gateway/tests/test-permission-gate.sh` (append a fail-closed section before the summary at line 353)
+- Modify: `plugins/permission-gateway/scripts/permission-gate.sh` (insert `ERR` trap between the shebang and `set -euo pipefail`)
+- Modify: `plugins/permission-gateway/.claude-plugin/plugin.json` (0.1.0→0.1.1)
+
+**Interfaces:**
+- Consumes: the same PreToolUse payload on stdin.
+- Produces: on any uncaught error (e.g. unparseable JSON, or a Tier-2 command whose metacharacters break the prompt `sed`), the script now emits an `ask` decision and `exit 0` instead of exiting non-zero with no output.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `plugins/permission-gateway/tests/test-permission-gate.sh`, insert this block immediately before the `# ---- Summary ----` line (currently line 353), reusing the existing `pass`/`fail` counters and `assert_decision` helper:
+
+```bash
+echo ""
+echo "=== #70: fail-closed on malformed / unparseable input ==="
+
+# run_gate builds valid JSON, so it cannot exercise the malformed path. Feed
+# raw stdin directly instead.
+run_gate_raw() {
+  printf '%s' "$1" | bash "$GATE" 2>/dev/null || true
+}
+
+assert_raw_ask() {
+  local test_name="$1" raw="$2"
+  local output
+  output=$(run_gate_raw "$raw")
+  if echo "$output" | jq -r '.hookSpecificOutput.permissionDecision' 2>/dev/null | grep -q '^ask$'; then
+    echo "  PASS: $test_name"; pass=$((pass + 1))
+  else
+    echo "  FAIL: $test_name — expected fail-closed ask, got: $output"; fail=$((fail + 1))
+  fi
+}
+
+# Unparseable / wrong-shape input must fail CLOSED (ask), not open (silent).
+assert_raw_ask "malformed: not json"       'not json at all'
+assert_raw_ask "malformed: truncated json" '{"tool_input":}'
+assert_raw_ask "wrong-shape: array"        '[1,2,3]'
+assert_raw_ask "wrong-shape: bare number"  '42'
+
+# Tier-2 command with a bare `|`: the prompt sed `s|{{COMMAND}}|$command|g`
+# breaks on the extra delimiter. Today that path fails OPEN; the trap must turn
+# it into fail-closed ask — never approve/deny. This is the case the four clean
+# decision paths below would miss.
+assert_decision "tier2 metachar pipe" "frobnicate a|b" "ask"
+
+# The clean decision paths must be UNCHANGED — the trap must not misfire.
+assert_decision "no-misfire: deny path"    "rm -rf /"      "deny"
+assert_decision "no-misfire: ask path"     "git push origin main" "ask"
+assert_decision "no-misfire: approve path" "ls -la"        "silent"
+assert_decision "no-misfire: tier2 clean"  "htop"          "ask"
+```
+
+- [ ] **Step 2: Run the test to confirm it fails (red)**
+
+Run: `bash plugins/permission-gateway/tests/test-permission-gate.sh`
+Expected: FAIL. The four `assert_raw_ask` cases and `tier2 metachar pipe` fail — the current script exits non-zero with empty stdout on those inputs (fail-open), so no `ask` is emitted. The four `no-misfire` cases already pass (they exercise the current behavior, which the fix must preserve).
+
+- [ ] **Step 3: Add the fail-closed ERR trap**
+
+In `plugins/permission-gateway/scripts/permission-gate.sh`, replace the first two lines:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+```
+
+with:
+
+```bash
+#!/usr/bin/env bash
+
+# Fail-closed (#70): a crashed gate must not be a bypass. Mirrors the ERR trap
+# in gate-config-writes.sh so the two hooks agree. On any uncaught error, emit
+# `ask`. Parity + defense-in-depth: Claude Code builds the hook payload, so the
+# malformed-input path is likely unreachable here — this is consistency with
+# the sibling gate, not the patch of a demonstrated hole. The trap can only ever
+# emit `ask`, never approve/deny, so it cannot loosen a decision.
+trap 'cat <<EREOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": "Permission gateway: permission-gate encountered an error and is failing closed. Human approval required."
+  }
+}
+EREOF
+exit 0' ERR
+
+set -euo pipefail
+```
+
+Leave the rest of the script unchanged.
+
+- [ ] **Step 4: Run the test to confirm it passes (green)**
+
+Run: `bash plugins/permission-gateway/tests/test-permission-gate.sh`
+Expected: PASS (`0 failed`). Malformed/wrong-shape/metachar inputs now return `ask`; every clean decision path is unchanged.
+
+- [ ] **Step 5: Manually re-verify the original fail-open probe from the issue**
+
+Run:
+```bash
+printf 'not json at all' | bash plugins/permission-gateway/scripts/permission-gate.sh; echo "exit=$?"
+```
+Expected: prints the `ask` JSON and `exit=0` (was: exit 5, no output).
+
+- [ ] **Step 6: Bump the plugin version**
+
+Edit `plugins/permission-gateway/.claude-plugin/plugin.json`: `"version": "0.1.0"` → `"0.1.1"`.
+
+- [ ] **Step 7: Update the stale suite-count comment**
+
+In `.github/workflows/test.yml`, the comment on line ~37 reads "This repo has seven suites". Task 1 added an eighth. Change `seven` → `eight` so the comment stays honest. (This file is under `.github`, not `plugins/`, so it triggers no version-bump lint.)
+
+- [ ] **Step 8: Run the full suite set the way CI does**
+
+Run:
+```bash
+for t in $(find plugins .github -path '*/tests/test-*.sh' | sort); do
+  echo "== $t =="; bash "$t" >/dev/null && echo PASS || echo FAIL
+done
+```
+Expected: every suite prints `PASS` (identities depend on `~/.config/jj/config.toml`, present locally).
+
+- [ ] **Step 9: Commit (jj)**
+
+```bash
+jj describe -m "fix(#70): fail closed on malformed input in permission-gate
+
+Mirror gate-config-writes.sh's ERR trap so the primary gate emits ask instead
+of exiting non-zero with no output (which does not block) on unparseable input.
+Parity + defense-in-depth; the trap only ever emits ask, and it also closes a
+latent Tier-2 sed fail-open. Tests cover malformed/wrong-shape/metacharacter
+input and assert the clean decision paths do not misfire."
+jj new
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- #45 jj-repo gating (§ Detection) → Task 1, Steps 3.
+- #45 sync three copies to superset (§ Reconciliation) → Task 1, Steps 4, 6.
+- #45 drift-guard + behavior tests (§ Testing, `.cwd` injection note) → Task 1, Step 1.
+- #45 fail-open-on-inconclusive-cwd (§ Detection) → encoded in the `[ -n "$cwd" ] || cwd="$PWD"` + `|| exit 0` of Step 3; no separate task.
+- #70 ERR trap (§ Fix) → Task 2, Step 3.
+- #70 corrected no-misfire proof incl. Tier-2 metacharacter case (§ Testing) → Task 2, Step 1.
+- #70 reachability caveat in-source → Task 2, Step 3 comment.
+- Version bumps (§ Version bumps) → Task 1 Step 7, Task 2 Step 6.
+- Out-of-scope items (README nit, latent Tier-2 sed bug) → deliberately not implemented; sed bug noted in Task 2 Step 1 comment.
+
+**Placeholder scan:** none — every step has literal code, exact paths, and expected output.
+
+**Type/name consistency:** helper names (`run_hook`/`assert_blocked`/`assert_passthrough` in Task 1; `run_gate_raw`/`assert_raw_ask` reusing existing `run_gate`/`assert_decision`/`pass`/`fail` in Task 2) are consistent within each suite. `HOOK`/`GATE` variables match their suites. Version strings match the Global Constraints table.
+
+**One residual watch-item for the implementer:** in Task 1 Step 1, `shasum -a 256 $COPIES` relies on word-splitting `$COPIES` on newlines — intentional and bash 3.2-safe; keep it unquoted.

--- a/docs/superpowers/specs/2026-07-17-cross-project-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-17-cross-project-hardening-design.md
@@ -1,0 +1,196 @@
+# Cross-project hardening: jj-repo gating + fail-closed gate (#45, #70)
+
+**Status:** approved, pre-implementation
+**Date:** 2026-07-17
+**Issues:**
+- #45 — "Raw .git block bans Claude from using git. Even though project is not using jj"
+- #70 — "permission-gateway: permission-gate.sh fails open on malformed input; gate-config-writes.sh fails closed"
+
+**Theme:** both changes harden the layer other projects and other agents depend on. #45 removes install friction so the plugins are usable at the user (global) level; #70 closes a fail-open asymmetry in the primary permission gate. They are independent (different files, different plugins) but scoped and shipped together as one Tier-1 unit.
+
+---
+
+## § #45 — gate `block-raw-git.sh` on jj-repo presence
+
+### Problem
+
+The jj plugins install a `PreToolUse`/`Bash` hook (`block-raw-git.sh`) that denies raw `git` commands and hands back the jj equivalent. Per the README (#92), this is deliberate: a **hard wall**, not a reminder — enforcement below the level an LLM can rationalize past.
+
+The wall is correct **inside a jj repo**. The friction is entirely **collateral damage of a user-level (global) install**: once the hook is registered globally it fires in *every* project, including git-only ones, banning git where jj was never chosen. That is the whole of #45 — not "the wall is too strong" but "the wall stands in rooms that have no jj."
+
+### Invariant to enforce
+
+> `block-raw-git.sh` blocks git **only when the invocation is inside a jj repo**
+> (a `.jj` directory exists at cwd or any ancestor). Outside a jj repo it is a
+> silent pass-through (`exit 0`, no output → git allowed).
+
+This preserves the hard wall everywhere it is meant to stand and removes it only where it was never meant to be.
+
+### Why `.jj` presence is the correct signal
+
+- A jj repo — colocated or not — always has a `.jj/` directory at its workspace root. Secondary workspaces have one too.
+- A **colocated** repo (`jj git init --colocate`) has **both** `.jj/` and `.git/`. Detecting `.jj` correctly still blocks git there — which is right, because colocation is a choice to live in jj. This is why `.jj` presence, not `.git` absence, is the discriminator.
+- A pure git repo has only `.git/`, no `.jj/` → git allowed.
+
+### Detection (bash 3.2-safe, dependency-free)
+
+Inserted **after `input=$(cat)`** reads stdin (line 6), before any blocking logic — the snippet consumes `$input`, so placing it above that read would leave `$input` empty and silently fall back to the hook process's `$PWD`, which need not equal the payload cwd:
+
+```bash
+cwd=$(echo "$input" | jq -r '.cwd // ""')
+[ -n "$cwd" ] || cwd="$PWD"
+jj_repo=false
+dir="$cwd"
+while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+  [ -d "$dir/.jj" ] && { jj_repo=true; break; }
+  dir=$(dirname "$dir")
+done
+[ "$jj_repo" = true ] || exit 0   # not a jj repo → allow git
+```
+
+- Reads `.cwd` from the same hook payload the sibling `permission-gate.sh` already consumes, so cwd is available to us.
+- Walks up ancestors so a command run from a subdirectory of the repo still detects `.jj` at the root.
+- No `jj` binary, no globstar, no associative arrays — runs under macOS bash 3.2 (the test-suite floor) and ubuntu bash 5.
+
+**Inconclusive-cwd behavior (deliberate, flag for review):** if `.cwd` is empty *and* the `$PWD` fallback yields no `.jj` on the walk, the script errs **open** (allows git). Rationale: the entire purpose of #45 is to not block outside jj, so when jj genuinely cannot be confirmed, friction-removal wins. In practice cwd is always present for Bash `PreToolUse` hooks, so this branch is near-degenerate. It is called out here so the choice is explicit rather than accidental.
+
+### Reconciliation: sync all three copies to the superset
+
+`block-raw-git.sh` exists in **three** plugins. Verified by sha256:
+
+- `commit-commands-jj` and `peer-review-jj` are **byte-identical**.
+- `project-setup-jj` is a **superset**: it additionally carries a `has_git_internals` block (denies `.git/` access, `git config`, `git rev-parse`) and fixes a typo the other two carry (`jj git remotes list` → `jj git remote list`).
+
+History (`#5`/`#14` added the superset to project-setup; the other two are unchanged since the initial commit) shows the divergence is **lag, not intentional per-plugin design** — nothing is deliberately specialized. Leaving it re-invites silent drift; that drift *is* the root cause this issue exposes.
+
+Therefore all three become **byte-identical**, adopting project-setup's superset plus the new gate:
+1. backport the `has_git_internals` block into `commit-commands-jj` and `peer-review-jj`
+2. adopt project-setup's message text verbatim in those two — both the `remotes`→`remote` typo fix and the `"...not allowed in jj plugins"`→`"...in jj repos"` wording, so the deny reason is identical everywhere
+3. add the jj-detection gate to all three
+
+After this, `diff` across the three (and a shared sha256) yields zero difference.
+
+Consequence, chosen with eyes open: `commit-commands-jj` and `peer-review-jj` **gain** the `.git/`-internals block. It only ever fires inside a real jj repo (it sits below the new gate), so it is consistent with the hard-wall philosophy and inert in git-only projects.
+
+The gate wraps the **entire** script: when not a jj repo, neither the raw-git branch nor the internals branch runs.
+
+### Note on self-containment
+
+Plugins ship self-contained under `${CLAUDE_PLUGIN_ROOT}`; a single shared script across plugins is not the model. "Byte-identical" here means three copies with identical content, kept honest by the drift-guard test below — not one physical file.
+
+---
+
+## § #70 — fail closed on malformed input in `permission-gate.sh`
+
+### Problem
+
+The plugin's two hooks disagree about what a crashed gate means:
+
+- **`gate-config-writes.sh` fails closed:** an `ERR` trap emits `ask`, with the in-source rationale *"A crashed gate should not be a bypass."*
+- **`permission-gate.sh` — the primary engine — has no trap**, and runs under `set -euo pipefail`. On any input `jq` cannot parse, the pipeline fails, the script exits non-zero with **no output**, and a `PreToolUse` hook that exits non-zero with no output **does not block** — so every Tier-1 deny (`rm -rf /`, `sudo`, force-push), the `.local.md` rules, and Tier-2 escalation are all silently skipped.
+
+The README frames the deny tier as an immutable floor against a file-based prompt-injection path. An input the gate cannot parse goes *around* the floor without touching `.local.md` at all: the ratchet holds; the input path bypasses it.
+
+### Reachability caveat (recorded, not assumed away)
+
+Claude Code constructs the hook payload itself, so the malformed-JSON path may be **unreachable in practice**. This fix is therefore **parity + defense-in-depth**, not the patch of a demonstrated live hole — and the source comment says exactly that, so no one later mistakes it for evidence the hole was reachable. The value is that the two gates stop disagreeing, and the primary gate's failure mode becomes the safe one.
+
+### Fix
+
+Mirror the exact construct from `gate-config-writes.sh` into `permission-gate.sh`, installed **after the shebang and before `set -euo pipefail`**, emitting `ask` on any uncaught error:
+
+```bash
+#!/usr/bin/env bash
+
+# Fail-closed: a crashed gate must not be a bypass. Mirrors the ERR trap in
+# gate-config-writes.sh so the two hooks agree. Parity + defense-in-depth:
+# Claude Code builds the hook payload, so malformed input is likely
+# unreachable here — this is consistency with the sibling gate, not the patch
+# of a demonstrated hole.
+trap 'cat <<EREOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": "Permission gateway: permission-gate encountered an error and is failing closed. Human approval required."
+  }
+}
+EREOF
+exit 0' ERR
+
+set -euo pipefail
+```
+
+The trap fires on the malformed-input path (`command=$(echo "$input" | jq -r …)` returns non-zero under errexit → ERR) and turns a silent bypass into `ask`.
+
+### The real work: prove no misfire
+
+The trap must not produce a **wrong-direction** decision (never a spurious `approve`/`deny`, and no `ask` on a command that would otherwise cleanly `approve`). The precise invariant, corrected after empirical review:
+
+> Every non-zero return in the script is **either** a `grep -q` no-match inside an `if` condition (exempt from `set -e`) and `check_local_rules … || true`, **or** it falls into the trap and emits `ask`. The trap can only ever emit `ask` — never `approve` or `deny` — so it cannot loosen a decision.
+
+The earlier framing ("*all* normal non-zero returns are `grep -q` in `if`s") was too strong. There is at least one non-grep failure source: the Tier-2 block runs `prompt_with_command=$(echo "$prompt_template" | sed "s|{{COMMAND}}|$command|g")`, and `sed`'s `|` delimiter breaks when `$command` contains a bare `|` (e.g. `a | b`). **Today that path already fails open** (exit 1, empty stdout → non-blocking); under the trap it becomes fail-closed `ask`. So the trap *improves* a latent Tier-2 fail-open — but it means the trap genuinely can fire on a real command, and the test set must cover that, not just the four clean paths. **This must be demonstrated by test, not assumed.**
+
+(The latent Tier-2 `sed`-delimiter bug is noted but **not fixed here** — the trap makes its failure safe, and fixing the substitution itself is out of scope for #70. Worth a separate issue.)
+
+---
+
+## § Testing
+
+### New: `test-block-raw-git.sh`
+
+No test currently covers `block-raw-git.sh`. The new suite (bash 3.2-safe, matching the existing suites' harness) asserts:
+
+1. `git status` is **blocked** when a `.jj` directory is present (at cwd and at an ancestor of cwd).
+2. `git status` **passes through** (exit 0, no output) when no `.jj` exists on the walk.
+3. `jj git push` and `gh …` are allowed regardless (the deliberate interop seams).
+4. the `has_git_internals` branch fires inside a jj repo (`.git/` access, `git config`, `git rev-parse`).
+5. **drift-guard:** all three copies share one sha256 — so the three cannot silently re-diverge. This directly closes the root cause.
+
+Placement: `project-setup-jj/tests/` (the canonical superset source); the drift-guard reads the other two copies by repo-relative path.
+
+**Harness note:** the existing `test-permission-gate.sh` `run_gate` helper builds payloads with **no `.cwd`** field. block-raw-git detection is cwd-driven, so the new suite cannot reuse that harness verbatim — each case must inject a `.cwd` pointing at a temp directory that does (or does not) contain `.jj`, created in the test's setup.
+
+### Extend: `test-permission-gate.sh`
+
+- malformed-JSON input (e.g. `not json`, `{"tool_input":}`) → asserts `ask` is emitted (exit 0 **with** the fail-closed JSON), i.e. the fix works.
+- wrong-shape valid JSON (e.g. `[1,2,3]`, `42`) → asserts fail-closed `ask` (desired, not a misfire).
+- regression across the clean decision paths (deny `rm -rf /` / ask `git push` / approve `ls` / a novel Tier-2 command) → asserts each still returns its own decision and the trap does **not** override it.
+- **Tier-2 command containing shell metacharacters** (a bare `|`, and backticks) → this is the path the corrected mechanism identifies; asserts it resolves to `ask` (fail-closed) and never to `approve`/`deny`. The four clean paths above would miss this — it is a required case, not optional.
+
+---
+
+## § Version bumps (CI-mandatory, #84)
+
+CI fails **red** on any change under `plugins/<name>/` without a version bump, because the plugin cache is keyed by version string. Required bumps:
+
+| Plugin | From | To | For |
+|---|---|---|---|
+| `commit-commands-jj` | 0.1.0 | 0.1.1 | #45 |
+| `peer-review-jj` | 0.1.1 | 0.1.2 | #45 |
+| `project-setup-jj` | 0.1.1 | 0.1.2 | #45 |
+| `permission-gateway` | 0.1.0 | 0.1.1 | #70 |
+
+---
+
+## § Out of scope
+
+- The README lists `workspace-jj` among the plugins carrying `block-raw-git.sh`, but that plugin ships no such hook. A documentation nit, tracked separately — not fixed here.
+- Broader deduplication of the three copies into a shared mechanism: contrary to the per-plugin self-containment model; the drift-guard test is the chosen safeguard instead.
+- The latent Tier-2 `sed "s|{{COMMAND}}|$command|g"` delimiter bug (breaks on commands containing a bare `|`). #70's trap makes its failure safe (fail-closed `ask`); fixing the substitution itself — e.g. a delimiter unlikely to appear in commands, or a different templating approach — is a separate issue.
+
+---
+
+## § Files touched
+
+**#45**
+- `plugins/commit-commands-jj/scripts/block-raw-git.sh` — gate + backport superset
+- `plugins/peer-review-jj/scripts/block-raw-git.sh` — gate + backport superset
+- `plugins/project-setup-jj/scripts/block-raw-git.sh` — gate
+- `plugins/project-setup-jj/tests/test-block-raw-git.sh` — new suite + drift-guard
+- three `plugin.json` version bumps
+
+**#70**
+- `plugins/permission-gateway/scripts/permission-gate.sh` — ERR trap
+- `plugins/permission-gateway/tests/test-permission-gate.sh` — malformed + non-misfire cases
+- `plugins/permission-gateway/.claude-plugin/plugin.json` — version bump

--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/scripts/block-raw-git.sh
+++ b/plugins/commit-commands-jj/scripts/block-raw-git.sh
@@ -4,6 +4,29 @@
 # Blocks: git * (bare git commands, not jj git subcommands)
 
 input=$(cat)
+
+# Gate on jj-repo presence (#45). This hard wall is intended only inside a jj
+# repo. Installed at the user (global) level the hook fires in every project,
+# and blocking git in a non-jj project is collateral damage, not the design.
+# Detect a .jj directory at cwd or any ancestor; if absent, pass through so git
+# is allowed. The walk stops at a dirname fixed point, which checks "/" too and
+# never hangs on a relative cwd (dirname "." == "."). bash 3.2-safe: no
+# globstar, no associative arrays.
+cwd=$(echo "$input" | jq -r '.cwd // ""')
+[ -n "$cwd" ] || cwd="$PWD"
+jj_repo=false
+dir="$cwd"
+prev=""
+while [ -n "$dir" ] && [ "$dir" != "$prev" ]; do
+  if [ -d "$dir/.jj" ]; then
+    jj_repo=true
+    break
+  fi
+  prev="$dir"
+  dir=$(dirname "$dir")
+done
+[ "$jj_repo" = true ] || exit 0
+
 command=$(echo "$input" | jq -r '.tool_input.command // ""')
 
 # Normalize: collapse newlines
@@ -17,13 +40,32 @@ if echo "$command_normalized" | grep -qE '(^|[;&|]\s*)git\s'; then
   fi
 fi
 
+# Check for .git/ access or git plumbing
+has_git_internals=false
+if echo "$command_normalized" | grep -qE '(\.git/|\.git[[:space:]]|git\s+config|git\s+rev-parse)'; then
+  has_git_internals=true
+fi
+
 if [ "$has_raw_git" = true ]; then
   cat <<'EOF'
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "deny",
-    "permissionDecisionReason": "BLOCKED: Raw git commands are not allowed in jj plugins. Use jj equivalents instead: git log → jj log, git diff → jj diff, git status → jj status, git blame → jj file annotate, git remote → jj git remotes list, git push → jj git push. For GitHub operations, use gh CLI."
+    "permissionDecisionReason": "BLOCKED: Raw git commands are not allowed in jj repos. Use jj equivalents instead: git log → jj log, git diff → jj diff, git status → jj status, git blame → jj file annotate, git remote → jj git remote list, git push → jj git push. For GitHub operations, use gh CLI."
+  }
+}
+EOF
+  exit 0
+fi
+
+if [ "$has_git_internals" = true ]; then
+  cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "BLOCKED: Git internals access detected. This project uses jj (Jujutsu). Avoid accessing .git/ directly or using git plumbing commands. Use jj equivalents:\n- git rev-parse HEAD → jj log -r @ --no-graph -T commit_id\n- git config → jj config list / jj config set\n- ls .git/ → not needed; use jj root\n- git remote -v → jj git remote list"
   }
 }
 EOF

--- a/plugins/peer-review-jj/.claude-plugin/plugin.json
+++ b/plugins/peer-review-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "peer-review-jj",
   "description": "Unified change review for jj repos — generalist-first with emergent specialists, two-phase pipeline, structured findings",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/peer-review-jj/scripts/block-raw-git.sh
+++ b/plugins/peer-review-jj/scripts/block-raw-git.sh
@@ -4,6 +4,29 @@
 # Blocks: git * (bare git commands, not jj git subcommands)
 
 input=$(cat)
+
+# Gate on jj-repo presence (#45). This hard wall is intended only inside a jj
+# repo. Installed at the user (global) level the hook fires in every project,
+# and blocking git in a non-jj project is collateral damage, not the design.
+# Detect a .jj directory at cwd or any ancestor; if absent, pass through so git
+# is allowed. The walk stops at a dirname fixed point, which checks "/" too and
+# never hangs on a relative cwd (dirname "." == "."). bash 3.2-safe: no
+# globstar, no associative arrays.
+cwd=$(echo "$input" | jq -r '.cwd // ""')
+[ -n "$cwd" ] || cwd="$PWD"
+jj_repo=false
+dir="$cwd"
+prev=""
+while [ -n "$dir" ] && [ "$dir" != "$prev" ]; do
+  if [ -d "$dir/.jj" ]; then
+    jj_repo=true
+    break
+  fi
+  prev="$dir"
+  dir=$(dirname "$dir")
+done
+[ "$jj_repo" = true ] || exit 0
+
 command=$(echo "$input" | jq -r '.tool_input.command // ""')
 
 # Normalize: collapse newlines
@@ -17,13 +40,32 @@ if echo "$command_normalized" | grep -qE '(^|[;&|]\s*)git\s'; then
   fi
 fi
 
+# Check for .git/ access or git plumbing
+has_git_internals=false
+if echo "$command_normalized" | grep -qE '(\.git/|\.git[[:space:]]|git\s+config|git\s+rev-parse)'; then
+  has_git_internals=true
+fi
+
 if [ "$has_raw_git" = true ]; then
   cat <<'EOF'
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "deny",
-    "permissionDecisionReason": "BLOCKED: Raw git commands are not allowed in jj plugins. Use jj equivalents instead: git log → jj log, git diff → jj diff, git status → jj status, git blame → jj file annotate, git remote → jj git remotes list, git push → jj git push. For GitHub operations, use gh CLI."
+    "permissionDecisionReason": "BLOCKED: Raw git commands are not allowed in jj repos. Use jj equivalents instead: git log → jj log, git diff → jj diff, git status → jj status, git blame → jj file annotate, git remote → jj git remote list, git push → jj git push. For GitHub operations, use gh CLI."
+  }
+}
+EOF
+  exit 0
+fi
+
+if [ "$has_git_internals" = true ]; then
+  cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "BLOCKED: Git internals access detected. This project uses jj (Jujutsu). Avoid accessing .git/ directly or using git plumbing commands. Use jj equivalents:\n- git rev-parse HEAD → jj log -r @ --no-graph -T commit_id\n- git config → jj config list / jj config set\n- ls .git/ → not needed; use jj root\n- git remote -v → jj git remote list"
   }
 }
 EOF

--- a/plugins/permission-gateway/.claude-plugin/plugin.json
+++ b/plugins/permission-gateway/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "permission-gateway",
   "description": "Tiered permission gateway — auto-approves safe commands, blocks dangerous ones, escalates edge cases to human",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/permission-gateway/scripts/permission-gate.sh
+++ b/plugins/permission-gateway/scripts/permission-gate.sh
@@ -1,4 +1,24 @@
 #!/usr/bin/env bash
+
+# Fail-closed (#70): a crashed gate must not be a bypass. Mirrors the ERR trap
+# in gate-config-writes.sh so the two hooks agree. On any uncaught error, emit
+# `ask`. Parity + defense-in-depth: Claude Code builds the hook payload, so the
+# malformed-input path is likely unreachable here — this is consistency with
+# the sibling gate, not the patch of a demonstrated hole. It does, incidentally,
+# close one reachable fail-open: a Tier-2 command containing a bare `|` breaks the
+# prompt-template `sed` below and would otherwise exit non-zero with no output. The
+# trap can only ever emit `ask`, never approve/deny, so it cannot loosen a decision.
+trap 'cat <<EREOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": "Permission gateway: permission-gate encountered an error and is failing closed. Human approval required."
+  }
+}
+EREOF
+exit 0' ERR
+
 set -euo pipefail
 
 # Permission Gateway — PreToolUse hook

--- a/plugins/permission-gateway/tests/test-permission-gate.sh
+++ b/plugins/permission-gateway/tests/test-permission-gate.sh
@@ -350,6 +350,44 @@ else
   fail=$((fail + 1))
 fi
 
+echo ""
+echo "=== #70: fail-closed on malformed / unparseable input ==="
+
+# run_gate builds valid JSON, so it cannot exercise the malformed path. Feed
+# raw stdin directly instead.
+run_gate_raw() {
+  printf '%s' "$1" | bash "$GATE" 2>/dev/null || true
+}
+
+assert_raw_ask() {
+  local test_name="$1" raw="$2"
+  local output
+  output=$(run_gate_raw "$raw")
+  if echo "$output" | jq -r '.hookSpecificOutput.permissionDecision' 2>/dev/null | grep -q '^ask$'; then
+    echo "  PASS: $test_name"; pass=$((pass + 1))
+  else
+    echo "  FAIL: $test_name — expected fail-closed ask, got: $output"; fail=$((fail + 1))
+  fi
+}
+
+# Unparseable / wrong-shape input must fail CLOSED (ask), not open (silent).
+assert_raw_ask "malformed: not json"       'not json at all'
+assert_raw_ask "malformed: truncated json" '{"tool_input":}'
+assert_raw_ask "wrong-shape: array"        '[1,2,3]'
+assert_raw_ask "wrong-shape: bare number"  '42'
+
+# Tier-2 command with a bare `|`: the prompt sed `s|{{COMMAND}}|$command|g`
+# breaks on the extra delimiter. Today that path fails OPEN; the trap must turn
+# it into fail-closed ask — never approve/deny. This is the case the four clean
+# decision paths below would miss.
+assert_decision "tier2 metachar pipe" "frobnicate a|b" "ask"
+
+# The clean decision paths must be UNCHANGED — the trap must not misfire.
+assert_decision "no-misfire: deny path"    "rm -rf /"      "deny"
+assert_decision "no-misfire: ask path"     "git push origin main" "ask"
+assert_decision "no-misfire: approve path" "ls -la"        "silent"
+assert_decision "no-misfire: tier2 clean"  "htop"          "ask"
+
 # ---- Summary ----
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/scripts/block-raw-git.sh
+++ b/plugins/project-setup-jj/scripts/block-raw-git.sh
@@ -4,6 +4,29 @@
 # Blocks: git * (bare git commands, not jj git subcommands)
 
 input=$(cat)
+
+# Gate on jj-repo presence (#45). This hard wall is intended only inside a jj
+# repo. Installed at the user (global) level the hook fires in every project,
+# and blocking git in a non-jj project is collateral damage, not the design.
+# Detect a .jj directory at cwd or any ancestor; if absent, pass through so git
+# is allowed. The walk stops at a dirname fixed point, which checks "/" too and
+# never hangs on a relative cwd (dirname "." == "."). bash 3.2-safe: no
+# globstar, no associative arrays.
+cwd=$(echo "$input" | jq -r '.cwd // ""')
+[ -n "$cwd" ] || cwd="$PWD"
+jj_repo=false
+dir="$cwd"
+prev=""
+while [ -n "$dir" ] && [ "$dir" != "$prev" ]; do
+  if [ -d "$dir/.jj" ]; then
+    jj_repo=true
+    break
+  fi
+  prev="$dir"
+  dir=$(dirname "$dir")
+done
+[ "$jj_repo" = true ] || exit 0
+
 command=$(echo "$input" | jq -r '.tool_input.command // ""')
 
 # Normalize: collapse newlines

--- a/plugins/project-setup-jj/tests/test-block-raw-git.sh
+++ b/plugins/project-setup-jj/tests/test-block-raw-git.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# project-setup-jj is the canonical superset copy; behaviour is tested against
+# it, and the drift-guard proves the other two are byte-identical.
+HOOK="$REPO_ROOT/plugins/project-setup-jj/scripts/block-raw-git.sh"
+
+COPIES="plugins/commit-commands-jj/scripts/block-raw-git.sh
+plugins/peer-review-jj/scripts/block-raw-git.sh
+plugins/project-setup-jj/scripts/block-raw-git.sh"
+
+pass=0
+fail=0
+
+# Run the hook with a command + cwd; capture stdout (hook never uses stderr).
+run_hook() {
+  local cmd="$1"
+  local cwd="$2"
+  local json='{"tool_input":{"command":"'"$cmd"'"},"tool_name":"Bash","hook_event_name":"PreToolUse","cwd":"'"$cwd"'"}'
+  echo "$json" | bash "$HOOK" 2>/dev/null || true
+}
+
+assert_blocked() {
+  local name="$1" cmd="$2" cwd="$3"
+  local out
+  out=$(run_hook "$cmd" "$cwd")
+  if echo "$out" | jq -r '.hookSpecificOutput.permissionDecision' 2>/dev/null | grep -q '^deny$'; then
+    echo "  PASS: $name"; pass=$((pass + 1))
+  else
+    echo "  FAIL: $name — expected deny, got: $out"; fail=$((fail + 1))
+  fi
+}
+
+assert_passthrough() {
+  local name="$1" cmd="$2" cwd="$3"
+  local out
+  out=$(run_hook "$cmd" "$cwd")
+  if [ -z "$out" ]; then
+    echo "  PASS: $name"; pass=$((pass + 1))
+  else
+    echo "  FAIL: $name — expected pass-through (no output), got: $out"; fail=$((fail + 1))
+  fi
+}
+
+# Temp repos: one jj (with a subdir), one pure-git.
+JJ_DIR=$(mktemp -d); mkdir -p "$JJ_DIR/.jj" "$JJ_DIR/sub/deep"
+GIT_DIR=$(mktemp -d); mkdir -p "$GIT_DIR/.git" "$GIT_DIR/src"
+trap 'rm -rf "$JJ_DIR" "$GIT_DIR"' EXIT
+
+echo "=== jj repo: raw git is blocked ==="
+assert_blocked "git status at jj root"      "git status"            "$JJ_DIR"
+assert_blocked "git status in jj subdir"    "git status"            "$JJ_DIR/sub/deep"
+assert_blocked "git commit at jj root"      "git commit -m x"       "$JJ_DIR"
+assert_blocked "git config (internals)"     "git config user.name x" "$JJ_DIR"
+assert_blocked "git rev-parse (internals)"  "git rev-parse HEAD"    "$JJ_DIR"
+
+echo "=== jj repo: interop seams and non-git pass through ==="
+assert_passthrough "jj git push allowed"    "jj git push"           "$JJ_DIR"
+assert_passthrough "gh allowed"             "gh pr list"            "$JJ_DIR"
+assert_passthrough "non-git command"        "ls -la"               "$JJ_DIR"
+
+echo "=== non-jj repo: git is allowed ==="
+assert_passthrough "git status in git root"   "git status"          "$GIT_DIR"
+assert_passthrough "git status in git subdir" "git status"          "$GIT_DIR/src"
+assert_passthrough "git commit in non-jj"     "git commit -m x"     "$GIT_DIR"
+assert_passthrough "git config in non-jj"     "git config user.name x" "$GIT_DIR"
+
+echo "=== drift-guard: all three copies are byte-identical ==="
+uniq_hashes=$( (cd "$REPO_ROOT" && shasum -a 256 $COPIES) | awk '{print $1}' | sort -u | grep -c . )
+if [ "$uniq_hashes" = "1" ]; then
+  echo "  PASS: block-raw-git.sh copies share one sha256"; pass=$((pass + 1))
+else
+  echo "  FAIL: block-raw-git.sh copies have diverged:"; fail=$((fail + 1))
+  (cd "$REPO_ROOT" && shasum -a 256 $COPIES)
+fi
+
+echo "=== regression: relative cwd must terminate (no infinite dirname loop) ==="
+# Relative cwd values are resolved against the test process's real PWD, so
+# run these from inside the non-jj $GIT_DIR — anchoring anywhere under this
+# repo's own jj working copy would let the walk-up find the real .jj and
+# report "blocked" instead of the pass-through these assertions check for.
+_orig_pwd="$PWD"
+cd "$GIT_DIR"
+assert_passthrough "relative cwd terminates, passes through" "git status" "some/relative/path"
+assert_passthrough "bare-dot cwd terminates, passes through" "git status" "."
+cd "$_orig_pwd"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Two independent hardenings of the layer other projects/agents depend on:

- **#45 — `block-raw-git.sh` no longer bans git in non-jj projects.** The hook now walks up from `cwd` for a `.jj` directory and passes through (allows git) when absent, so the jj plugins are safe to install at **user (global) scope** instead of blocking git in every git-only project. The hard wall is preserved wherever a jj repo actually exists (including colocated repos). The three drifted copies (`commit-commands-jj`, `peer-review-jj`, `project-setup-jj`) are unified to project-setup's superset and are now **byte-identical**, guarded by a new drift test. The walk-up terminates on a `dirname` fixed point so a relative/malformed `cwd` can't hang the hook.
- **#70 — `permission-gate.sh` fails closed on malformed input.** It now mirrors `gate-config-writes.sh`'s `ERR` trap and emits `ask` on unparseable input instead of exiting non-zero with no output (which does not block). Parity + defense-in-depth; the trap only ever emits `ask` and also closes a latent Tier-2 `sed` fail-open.

Version bumps (CI-mandatory, #84): `commit-commands-jj` 0.1.1, `peer-review-jj` 0.1.2, `project-setup-jj` 0.1.2, `permission-gateway` 0.1.1. Also de-hardcoded a stale suite-count comment in `test.yml`.

Design spec and implementation plan are included as the first commit (`docs/superpowers/specs/`, `docs/superpowers/plans/`).

## Test plan

- [x] `test-block-raw-git.sh` (new): blocks raw git / git-internals inside a jj repo; passes git through outside one; interop seams (`jj git`, `gh`) allowed; relative-cwd terminates; drift-guard asserts all three copies share one sha256 — 15/0
- [x] `test-permission-gate.sh` (extended): malformed / wrong-shape / Tier-2 metacharacter input → fail-closed `ask`; clean deny/ask/approve/Tier-2 paths do not misfire — 142/0
- [x] Full suite set: 11/11 passing
- [x] Version-bump lint green; three `block-raw-git.sh` copies byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)