### PR TITLE
fix(project-setup-jj): statusline cache never hit, leaked ~8k /tmp files, and masked a stale-key bug

### DIFF
--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/scripts/project-setup-install.sh
+++ b/plugins/project-setup-jj/scripts/project-setup-install.sh
@@ -46,10 +46,19 @@ echo "require_jj_new=copied"
 echo "workspace_hooks=copied"
 
 # --- 2. settings.local.json merge ---
-SS="$DST/jj-session-start.sh"
-RJN="$DST/require-jj-new.sh"
-WSC="$DST/jj-workspace-create.sh"
-WSR="$DST/jj-workspace-remove.sh"
+# Hook commands are written $CLAUDE_PROJECT_DIR-relative rather than as absolute
+# paths. An absolute /Users/... path is machine-specific: it pins the settings file
+# to one checkout, so it cannot be shared with collaborators and breaks in any clone
+# or jj workspace living at a different path. Claude Code expands
+# $CLAUDE_PROJECT_DIR to the project root when the hook runs.
+# The endswith() upsert below matches on the shared suffix, so re-running the
+# installer over a pre-existing absolute-path entry replaces it in place instead of
+# leaving a duplicate (covered by the "stale" case in test-project-setup-install.sh).
+HOOK_DIR='$CLAUDE_PROJECT_DIR/.claude/scripts'
+SS="$HOOK_DIR/jj-session-start.sh"
+RJN="$HOOK_DIR/require-jj-new.sh"
+WSC="$HOOK_DIR/jj-workspace-create.sh"
+WSR="$HOOK_DIR/jj-workspace-remove.sh"
 
 merged=$(printf '%s' "$base" | jq \
   --arg ss "$SS" --arg rjn "$RJN" --arg wsc "$WSC" --arg wsr "$WSR" '

--- a/plugins/project-setup-jj/scripts/statusline-jj.sh
+++ b/plugins/project-setup-jj/scripts/statusline-jj.sh
@@ -70,9 +70,41 @@ fi
 
 # Cache: only re-query jj if repo state changed
 # Stores raw pipe-delimited values for segment building
-CACHE_FILE="/tmp/statusline-jj-$$-cache"
-JJ_DIR="$(jj root --ignore-working-copy 2>/dev/null)/.jj"
-CACHE_KEY="$(stat -f '%m' "$JJ_DIR/repo" 2>/dev/null || echo "0")"
+JJ_ROOT="$(jj root --ignore-working-copy 2>/dev/null)"
+JJ_DIR="$JJ_ROOT/.jj"
+
+# Cache validity key. `.jj/repo`'s own mtime is NOT a usable signal: it only moves
+# when that directory gains an entry (adding a workspace, say), so it can sit frozen
+# through hours of commits and serve a permanently stale statusline. This went
+# unnoticed only because the $$-keyed filename below meant the cache never hit.
+# Track instead the two things the rendered segments actually depend on:
+#   op_heads/heads        — bumped by every jj operation (commit, describe, bookmark)
+#   working_copy/checkout — bumped when this workspace's working copy is snapshotted
+# %Fm is nanosecond-precision, so two operations in the same second still differ.
+# In a workspace `.jj/repo` is a FILE holding a relative pointer to the main repo
+# directory; in the main repo it is that directory itself.
+if [ -d "$JJ_DIR/repo" ]; then
+  REPO_DIR="$JJ_DIR/repo"
+else
+  REPO_DIR="$JJ_DIR/$(cat "$JJ_DIR/repo" 2>/dev/null || echo "")"
+fi
+OP_MTIME="$(stat -f '%Fm' "$REPO_DIR/op_heads/heads" 2>/dev/null || echo "")"
+WC_MTIME="$(stat -f '%Fm' "$JJ_DIR/working_copy/checkout" 2>/dev/null || echo "")"
+if [ -n "$OP_MTIME" ] && [ -n "$WC_MTIME" ]; then
+  CACHE_KEY="${OP_MTIME}:${WC_MTIME}"
+else
+  # Signal unresolvable — e.g. jj changed its internal layout. Force a miss rather
+  # than risk serving stale state: correctness over speed, never silently wrong.
+  CACHE_KEY="uncacheable:$$"
+fi
+
+# Key the cache file by repo path, NOT by $$. Claude Code spawns this script as a
+# new process on every redraw, so a PID-keyed name never matches on the next run:
+# the cache-hit branch below became dead code (all 11 jj queries ran every redraw)
+# and each redraw leaked another /tmp file. A cksum collision only degrades to a
+# cache miss — CACHE_KEY (repo mtime) still gates validity.
+CACHE_DIR="${STATUSLINE_JJ_CACHE_DIR:-/tmp}"
+CACHE_FILE="$CACHE_DIR/statusline-jj-$(printf '%s' "$JJ_ROOT" | cksum | cut -d' ' -f1)-cache"
 
 if [ -f "$CACHE_FILE" ] && [ "$(head -1 "$CACHE_FILE")" = "$CACHE_KEY" ]; then
   IFS='|' read -r BOOKMARK CHANGE_ID DESC TRUNK_LABEL TRUNK_CLR < <(tail -1 "$CACHE_FILE") || true

--- a/plugins/project-setup-jj/tests/test-project-setup-install.sh
+++ b/plugins/project-setup-jj/tests/test-project-setup-install.sh
@@ -46,6 +46,15 @@ for ev in SessionStart PreCompact PreToolUse WorktreeCreate WorktreeRemove; do
   [ "$(jq --arg e "$ev" '(.hooks[$e]|length) > 0' "$P/.claude/settings.local.json")" = true ] \
     && ok "fresh: hooks.$ev present" || bad "fresh" "hooks.$ev missing"
 done
+# Hook commands must be portable: $CLAUDE_PROJECT_DIR-relative, never an absolute
+# machine path. An absolute path pins the settings file to one checkout — it cannot
+# be shared with collaborators and resolves to nothing in a clone or jj workspace
+# living elsewhere on disk.
+allcmds=$(jq -r '[.hooks[][].hooks[].command] | .[]' "$P/.claude/settings.local.json")
+n_abs=$(printf '%s\n' "$allcmds" | grep -c '^/' || true)
+[ "$n_abs" -eq 0 ] && ok "fresh: no absolute hook paths" || bad "fresh" "$n_abs hook command(s) absolute: $allcmds"
+n_portable=$(printf '%s\n' "$allcmds" | grep -c '^\$CLAUDE_PROJECT_DIR/\.claude/scripts/' || true)
+[ "$n_portable" -eq 4 ] && ok "fresh: 4 hook paths use \$CLAUDE_PROJECT_DIR" || bad "fresh" "expected 4 portable hook paths, got $n_portable"
 [ "$(jq '.permissions.allow | index("Bash(gh *)") != null' "$P/.claude/settings.local.json")" = true ] && ok "fresh: allow has gh" || bad "fresh" "allow missing gh"
 [ "$(jq '.permissions.deny | index("Bash(git *)") != null' "$P/.claude/settings.local.json")" = true ] && ok "fresh: deny has git" || bad "fresh" "deny missing git"
 [ -f "$P/CLAUDE.md" ] && grep -q 'jj-project-setup:start' "$P/CLAUDE.md" && ok "fresh: CLAUDE.md created w/ marker" || bad "fresh" "CLAUDE.md missing marker"

--- a/plugins/project-setup-jj/tests/test-statusline-jj.sh
+++ b/plugins/project-setup-jj/tests/test-statusline-jj.sh
@@ -129,6 +129,42 @@ code3=$?
 out3=$(cat /tmp/sl-test-out3)
 assert_ok "no crash when master bookmark missing (pipefail regression)" "$out3" "$code3"
 
+# ── Test 7: one cache file is shared across invocations ──
+# Regression: Claude Code spawns the statusline as a NEW PROCESS per redraw, so a
+# $$-keyed cache filename can never match on the next run. That made the cache-hit
+# branch dead code (all 11 jj queries re-ran every redraw) and leaked one /tmp file
+# per redraw — ~6,000 files / 24MB had accumulated before this was caught.
+CACHE_PROBE="$TMPDIR_ROOT/cache-probe"
+mkdir -p "$CACHE_PROBE"
+
+for _i in 1 2 3; do
+  STATUSLINE_JJ_CACHE_DIR="$CACHE_PROBE" bash "$SL" <<<"$STDIN" >/dev/null 2>&1 || true
+done
+
+n_cache=$(find "$CACHE_PROBE" -type f | wc -l | tr -d ' ')
+if [ "$n_cache" -eq 1 ]; then
+  echo "  PASS: three invocations share one cache file"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: three invocations produced $n_cache cache files (expected 1)"
+  fail=$((fail + 1))
+fi
+
+# ── Test 8: the cache-hit branch is actually taken ──
+# Poison the cached payload while keeping the validity key intact. A genuine hit
+# renders the sentinel; a miss re-queries jj and the sentinel never appears.
+# Without this, test 7 alone would still pass if the cache were written but never read.
+cache_file=$(find "$CACHE_PROBE" -type f | head -1)
+if [ -n "$cache_file" ]; then
+  _key=$(head -1 "$cache_file")
+  printf '%s\n%s' "$_key" "|sentin3l|poisoned|@trunk|healthy" > "$cache_file"
+  out7=$(STATUSLINE_JJ_CACHE_DIR="$CACHE_PROBE" bash "$SL" <<<"$STDIN" 2>/dev/null || true)
+  assert_contains "cache-hit branch is used (sentinel rendered)" "$out7" "sentin3l"
+else
+  echo "  FAIL: no cache file created — cannot verify cache-hit branch"
+  fail=$((fail + 1))
+fi
+
 # ── Summary ──
 echo ""
 total=$((pass + fail))


### PR DESCRIPTION
## What

Fixes the `statusline-jj.sh` cache, which never hit and leaked one `/tmp` file per redraw, and makes `/project-setup` emit portable hook paths.

## The bug, and the bug underneath it

`CACHE_FILE` was keyed by `$$`. Claude Code spawns the statusline as a **new process per redraw**, so the filename never matched on the next run. Two symptoms, one cause: the cache-hit branch was dead code (all 11 `jj` queries ran every redraw — the statusline lag), and every redraw wrote another file. **6,035 files / 24 MB** had accumulated locally; the installed copy was still adding ~86 per 15 minutes while this was being written.

Keying the filename by repo path made the cache start hitting — which immediately broke the existing `shows asterisk when ahead of origin` test. The test was right. `CACHE_KEY` used the mtime of `.jj/repo`, which only moves when that directory *gains an entry*; it sat unchanged through 35 minutes of commits. **Shipping only the filename fix would have traded a visible leak for a permanently stale statusline** — a silent failure, and the worse of the two.

`CACHE_KEY` now combines `op_heads/heads` and `working_copy/checkout` mtimes at nanosecond precision (`%Fm`, so same-second operations still differ), resolving `.jj/repo`'s pointer-file form inside workspaces. If either signal can't be read — a future jj layout change — it falls back to a guaranteed cache miss. Slow beats silently stale.

## Portable hook paths

The installer wrote hook commands as absolute `/Users/…` paths, which pin the settings file to one checkout. It now emits `$CLAUDE_PROJECT_DIR/.claude/scripts/…`. The existing `endswith()` upsert migrates pre-existing absolute entries in place rather than duplicating them — already covered by the `stale` case.

This removes the hard blocker on ever tracking these settings, but does **not** decide whether to. That's #97.

## Verification

- **12/12 suites pass.**
- Four new tests. Two statusline: three invocations share one cache file, and a poisoned cache payload proves the hit branch actually executes (without the second, the first would still pass if the cache were written but never read). Two installer: no absolute hook paths, and four use `$CLAUDE_PROJECT_DIR`.
- **Ablation-checked**: restoring `$$` produces 3 cache files against the asserted 1, so the test catches the original bug rather than merely the new env var.
- Version `0.1.3` → `0.2.0` — minor, not patch, because the emitted settings format changes. The version-bump gate was verified to **exit 1 without the bump** when given real `CHANGED_FILES`/`BASE_DIR` inputs; with them empty it passes vacuously, so a bare run proves nothing.

## Follow-ups

- #97 — whether `/project-setup` should write a tracked `settings.json`.
- `statusline-jj-setup.md:39` still registers an absolute `statusLine.command`. Left deliberately: unverified whether Claude Code expands `$CLAUDE_PROJECT_DIR` in `statusLine.command` as it does in hook commands, and a wrong guess breaks the statusline silently.

**After merging, re-run `/statusline-jj-setup`** — the installed script is a copy, so the leak continues until it's refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
