### PR TITLE
Eval suite (#79 tranche 1): ablation-gated runner, Part A cut on measurement, and a raw-git wall fix (#101)

### DIFF
--- a/.github/scripts/run-evals.sh
+++ b/.github/scripts/run-evals.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Run plugin eval cases with ablation and gate on the delta.
+# bash 3.2-safe: no globstar, no associative arrays.
+set -euo pipefail
+
+DISCOVER_ONLY=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --discover-only) DISCOVER_ONLY=1; shift ;;
+    *) printf 'unknown argument: %s\n' "$1" >&2; exit 64 ;;
+  esac
+done
+
+# Discover case directories. BOTH supported formats: `case.yaml` and the
+# `prompt.md` + graders/ layout that `claude plugin eval init --bare` writes.
+# A single-format glob would silently skip officially-scaffolded cases (#82).
+discover_cases() {
+  find plugins \
+    \( -path '*/evals/*/case.yaml' -o -path '*/evals/*/prompt.md' \) \
+    -type f 2>/dev/null | sed 's#/[^/]*$##' | sort -u
+}
+
+CASES=$(discover_cases)
+
+if [ -z "$CASES" ]; then
+  printf 'ERROR: no eval cases found under plugins/*/evals/.\n' >&2
+  printf 'A glob matching nothing is indistinguishable from passing (#82).\n' >&2
+  exit 3
+fi
+
+if [ "$DISCOVER_ONLY" -eq 1 ]; then
+  printf '%s\n' "$CASES"
+  exit 0
+fi
+
+# stderr, not stdout — stdout carries the TSV that Task 7 pipes to a file.
+printf 'discovered %d case(s)\n' "$(printf '%s\n' "$CASES" | wc -l | tr -d ' ')" >&2

--- a/.github/scripts/run-evals.sh
+++ b/.github/scripts/run-evals.sh
@@ -30,6 +30,17 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+# Validate the gate name HERE, at parse time, not inside classify(). Every
+# argument this script gates on is known before a token is spent; validating
+# after the run means a typo burns the whole budget, prints an ungated TSV, and
+# then exits 64 anyway. Without the check at all, a typo falls through to
+# report semantics — silently turning a strict Part B gate permissive and green.
+case "$GATE" in
+  strict|report) ;;
+  *) printf 'ERROR: --gate must be "strict" or "report", got "%s"\n' "$GATE" >&2
+     exit 64 ;;
+esac
+
 # Classify an aggregate-result.json into verdicts and set the exit code.
 # Field paths are FLAT snake_case and verified against a real run:
 #   .cases[].delta / .score / .score_without / .pass_rate / .pass_rate_without
@@ -52,6 +63,16 @@ classify() {
     exit 65
   fi
 
+  # Budget breach FIRST. A run truncated before any case finished produces
+  # {"partial":true,"cases":[]}, and testing zero-cases ahead of .partial
+  # diagnoses that as a discovery bug (#82) — pointing the operator at a
+  # nonexistent glob problem when the fix is a larger --max-cost-usd.
+  if [ "$(jq -r '.partial // false' "$file")" = "true" ]; then
+    printf 'ERROR: run was truncated by --max-cost-usd (.partial=true).\n' >&2
+    printf 'Paid graders were skipped; deltas are not trustworthy.\n' >&2
+    exit 6
+  fi
+
   # Zero cases is never success. `.cases[]` over an empty array prints
   # nothing, bad_count is 0, and the gate exits green having measured
   # nothing at all — #82's failure mode, one level in.
@@ -60,54 +81,59 @@ classify() {
     exit 3
   fi
 
-  # Budget breach: paid graders were skipped, so scores are partial.
-  if [ "$(jq -r '.partial // false' "$file")" = "true" ]; then
-    printf 'ERROR: run was truncated by --max-cost-usd (.partial=true).\n' >&2
-    printf 'Paid graders were skipped; deltas are not trustworthy.\n' >&2
-    exit 6
-  fi
-
   # Tripwire: any missing OR non-numeric delta means the result schema moved.
   # null is not the only drift shape: jq sorts every string above every
   # number, so a string "0.0" delta passes every comparison, classifies
   # DISCRIMINATING, and gates green. Key on type — never let a non-number
   # reach a comparison.
-  if [ "$(jq -r '[.cases[]? | select((.delta | type) != "number")] | length' "$file")" != "0" ]; then
-    printf 'ERROR: a case has a null or non-numeric delta — result schema drift.\n' >&2
-    printf 'Expected flat numeric .cases[].delta. Every verdict would be meaningless.\n' >&2
+  #
+  # The SCORE fields are checked with the same rigour, and for a sharper
+  # reason: `.score == 0 and .score_without == 0` is false when both are null,
+  # so a drift confined to the score field names leaves .delta numeric, kills
+  # the both-arms-zero BROKEN detector outright, and gates a run whose scores
+  # are literally null as green.
+  if [ "$(jq -r '[.cases[]?
+                  | select((.delta          | type) != "number"
+                        or (.score          | type) != "number"
+                        or (.score_without  | type) != "number")] | length' "$file")" != "0" ]; then
+    printf 'ERROR: a case has a null or non-numeric delta/score — result schema drift.\n' >&2
+    printf 'Expected flat numeric .cases[].delta/.score/.score_without.\n' >&2
+    printf 'Every verdict would be meaningless.\n' >&2
     exit 5
   fi
 
+  # The 0.5 threshold is compared with a tolerance, and it is load-bearing.
+  # The CLI computes .delta by floating-point subtraction, so a case scoring
+  # 7/10 with and 2/10 without — a textbook shipping case exactly at the
+  # documented threshold — arrives as 0.49999999999999994 and is filed PARTIAL,
+  # failing CI and inviting a human to cut it. 1e-9 is orders of magnitude
+  # below any delta a run of at most 50 samples per arm can produce, so it
+  # absorbs IEEE754 error and nothing else.
   jq -r '
+    def eps: 1e-9;
     .cases[]?
     | [ .name,
         (.score          | tostring),
         (.score_without  | tostring),
         (.delta          | tostring),
         ( if   (.score == 0 and .score_without == 0) then "BROKEN"
-          elif .delta <  0    then "REGRESSION"
-          elif .delta == 0    then "NO_GAP"
-          elif .delta <  0.5  then "PARTIAL"
-          else                     "DISCRIMINATING"
+          elif .delta <  -eps         then "REGRESSION"
+          elif .delta <   eps         then "NO_GAP"
+          elif .delta <  (0.5 - eps)  then "PARTIAL"
+          else                             "DISCRIMINATING"
           end )
       ] | @tsv
   ' "$file"
 
-  # Validate the gate name. Without this, any typo falls through to report
-  # semantics — silently turning a strict Part B gate permissive and green.
-  case "$GATE" in
-    strict|report) ;;
-    *) printf 'ERROR: --gate must be "strict" or "report", got "%s"\n' "$GATE" >&2
-       exit 64 ;;
-  esac
-
   # Gate. strict (Part B): only DISCRIMINATING passes.
   # report (Part A): NO_GAP and PARTIAL are findings, not failures — but
   # BROKEN and REGRESSION always fail, in both modes.
+  # Same tolerance as the TSV above: a gate that disagrees with the verdict it
+  # printed fails a case the table calls DISCRIMINATING.
   if [ "$GATE" = "strict" ]; then
-    bad_count=$(jq -r '[.cases[] | select((.score == 0 and .score_without == 0) or .delta < 0.5)] | length' "$file")
+    bad_count=$(jq -r '[.cases[]? | select((.score == 0 and .score_without == 0) or .delta < (0.5 - 1e-9))] | length' "$file")
   else
-    bad_count=$(jq -r '[.cases[] | select((.score == 0 and .score_without == 0) or .delta < 0)] | length' "$file")
+    bad_count=$(jq -r '[.cases[]? | select((.score == 0 and .score_without == 0) or .delta < -1e-9)] | length' "$file")
   fi
 
   if [ "$bad_count" != "0" ]; then
@@ -121,6 +147,14 @@ if [ -n "$CLASSIFY_FILE" ]; then
   exit 0
 fi
 
+# Split the grant ONCE, into one tool per line. The CLI's --allow-tools is
+# variadic (`<tools...>`), so every tool must reach it as its own argv element:
+# forwarding the operator's "Bash,Write" as a single element hands the CLI one
+# tool name that matches nothing, the agent is denied the tool in BOTH arms,
+# and the result reads 0.00/0.00 — the exact zero-vs-zero the guard below
+# exists to prevent, manufactured by the runner itself.
+GRANTED=$(printf '%s' "$ALLOW_TOOLS" | tr ', ' '\n\n' | grep -v '^$' || true)
+
 # Discover case directories. BOTH supported formats: `case.yaml` and the
 # `prompt.md` + graders/ layout that `claude plugin eval init --bare` writes.
 # A single-format glob would silently skip officially-scaffolded cases (#82).
@@ -129,6 +163,17 @@ discover_cases() {
     \( -path '*/evals/*/case.yaml' -o -path '*/evals/*/prompt.md' \) \
     -type f 2>/dev/null | sed 's#/[^/]*$##' | sort -u
 }
+
+# `find plugins` on a missing directory fails; 2>/dev/null eats the message and
+# `set -e` + pipefail then kill the assignment below at exit 1 with no output
+# at all. Exit 1 is not in the documented contract, and a wrong cwd is the most
+# likely way to get here — every documented invocation is relative to the repo
+# root. Diagnose it, and exit with the documented code.
+if [ ! -d plugins ]; then
+  printf 'ERROR: no plugins/ directory in %s — run from the repo root.\n' "$PWD" >&2
+  printf 'A glob matching nothing is indistinguishable from passing (#82).\n' >&2
+  exit 3
+fi
 
 CASES=$(discover_cases)
 
@@ -146,40 +191,167 @@ fi
 # stderr, not stdout — stdout carries the TSV that Task 7 pipes to a file.
 printf 'discovered %d case(s)\n' "$(printf '%s\n' "$CASES" | wc -l | tr -d ' ')" >&2
 
+# Print a prose .md file's YAML frontmatter, and nothing else. The prose below
+# it may quote `allowed_tools:` while declaring nothing.
+frontmatter() {
+  awk 'NR == 1 { if ($0 !~ /^---[ \t]*$/) exit; next }
+       /^---[ \t]*$/ { exit }
+       { print }' "$1"
+}
+
+# First top-level `name:` value on stdin. No early exit: this runs downstream
+# of another process, and quitting early would SIGPIPE it into a pipefail.
+first_name_key() {
+  awk '/^name:[ \t]*/ {
+         if (!found) {
+           s = $0
+           sub(/^name:[ \t]*/, "", s)
+           sub(/[ \t]*#.*$/, "", s)
+           v = s; found = 1
+         }
+       }
+       END { if (found) print v }'
+}
+
+# The name the CLI will match --case against. Verified against 2.1.220: the
+# glob is applied to the case's `name:` field, and a prose-layout case that
+# declares none defaults to its directory basename. Scoping on the basename
+# instead lets the guard's set and the CLI's set go disjoint in both
+# directions — inspecting a case that will not run, and running one that was
+# never inspected.
+case_name_of() {
+  d="$1"
+  n=""
+  if [ -f "$d/case.yaml" ]; then
+    n=$(first_name_key < "$d/case.yaml" | tr -d " \"'")
+  fi
+  if [ -z "$n" ] && [ -f "$d/prompt.md" ]; then
+    n=$(frontmatter "$d/prompt.md" | first_name_key | tr -d " \"'")
+  fi
+  if [ -z "$n" ]; then
+    n=$(basename "$d")
+  fi
+  printf '%s' "$n"
+}
+
+# Every tool a case declares, one per line. Handles BOTH YAML forms and BOTH
+# case layouts, because a guard that silently reads nothing is worse than no
+# guard: it lets the run proceed and then reports the missing grant as "no gap".
+#   - flow:  allowed_tools: [Bash, "Write", 'Edit']
+#   - block: allowed_tools: / # comment / - Bash / - Write
+#     (comments and blank lines do NOT end a YAML block sequence; a range that
+#     stops at "the first line that is not a - item" drops every tool after the
+#     first comment, and ALL of them when the comment comes first)
+#   - the key is ANCHORED: an unanchored match also fires on a
+#     `disallowed_tools:` companion key, and the guard then demands the very
+#     tool the case exists to forbid.
+extract_allowed_tools() {
+  awk '
+    { line = $0; sub(/\r$/, "", line) }
+    line ~ /^[ \t]*(-[ \t]*)?allowed_tools[ \t]*:/ {
+      inblock = 0
+      ind = 0
+      while (substr(line, ind + 1, 1) == " " || substr(line, ind + 1, 1) == "\t") ind++
+      rest = substr(line, index(line, ":") + 1)
+      sub(/^[ \t]+/, "", rest)
+      if (substr(rest, 1, 1) == "[") {
+        endb = index(rest, "]")
+        if (endb > 0) inner = substr(rest, 2, endb - 2); else inner = substr(rest, 2)
+        n = split(inner, item, ",")
+        for (i = 1; i <= n; i++) print item[i]
+      } else if (rest == "" || substr(rest, 1, 1) == "#") {
+        inblock = 1
+        blockind = ind
+      }
+      next
+    }
+    inblock == 1 {
+      if (line ~ /^[ \t]*$/) next
+      if (line ~ /^[ \t]*#/) next
+      ind = 0
+      while (substr(line, ind + 1, 1) == " " || substr(line, ind + 1, 1) == "\t") ind++
+      if (line ~ /^[ \t]*-[ \t]*[^ \t]/ && ind >= blockind) {
+        item0 = line
+        sub(/^[ \t]*-[ \t]*/, "", item0)
+        sub(/[ \t]*#.*$/, "", item0)
+        print item0
+      } else {
+        inblock = 0
+      }
+    }
+  ' | tr -d " \"'" | grep -v '^$' || true
+}
+
+# Both layouts. The prose layout keeps its execution keys in prompt.md
+# frontmatter (the CLI's set: model, max_turns, timeout_seconds, allowed_tools,
+# append_system_prompt, env), so a guard that requires case.yaml and
+# `continue`s otherwise is blind to every case `eval init --bare` scaffolds —
+# exactly the format discovery was widened to find.
+#
+# A directory holding BOTH files is legal, and there the CLI lets prompt.md
+# override case.yaml while this takes the union. Deliberate: for a guard,
+# over-approximating costs a pre-spend abort carrying the file and tool name,
+# and under-approximating costs the whole run.
+declared_tools() {
+  d="$1"
+  {
+    if [ -f "$d/case.yaml" ]; then
+      extract_allowed_tools < "$d/case.yaml"
+    fi
+    if [ -f "$d/prompt.md" ]; then
+      frontmatter "$d/prompt.md" | extract_allowed_tools
+    fi
+  } | sort -u
+}
+
 # Scope the guard to what this invocation will actually run. Scanning every
 # discovered case makes an unrelated plugin's Write-requiring case abort a run
 # that never touches it.
+#
+# `while read`, never `for case_dir in $CASES`: the unquoted expansion splits
+# on spaces, so a case path containing one becomes fragments, none of which is
+# a case directory — the guard then inspects nothing and fails open on exactly
+# the input it should reject.
 SCOPED=""
-for case_dir in $CASES; do
+while IFS= read -r case_dir; do
+  [ -n "$case_dir" ] || continue
   if [ -n "$PLUGIN" ]; then
     case "$case_dir" in plugins/"$PLUGIN"/*) ;; *) continue ;; esac
   fi
   if [ -n "$CASE_GLOB" ]; then
     # shellcheck disable=SC2254
-    case "$(basename "$case_dir")" in $CASE_GLOB) ;; *) continue ;; esac
+    case "$(case_name_of "$case_dir")" in $CASE_GLOB) ;; *) continue ;; esac
   fi
   SCOPED="$SCOPED$case_dir
 "
-done
+done <<SCOPE_EOF
+$CASES
+SCOPE_EOF
+
+# Scoped to nothing is #82 one level in: the CLI would load zero cases, the run
+# would measure nothing, and a silent exit 0 here is indistinguishable from
+# guarded-and-clean.
+if [ -z "$SCOPED" ]; then
+  printf 'ERROR: --plugin/--case selected none of the discovered cases.\n' >&2
+  printf 'plugin="%s" case="%s". Nothing would be measured (#82).\n' "$PLUGIN" "$CASE_GLOB" >&2
+  printf 'Note --case is globbed against the case name, not the directory.\n' >&2
+  exit 3
+fi
 
 # Guard: every gated tool a case declares must appear in the grant. Without
 # this, the agent cannot call the tool, BOTH arms score 0.00, and the delta
 # reads 0.00 — which the gate would otherwise interpret as "measures the
 # model, cut the case". That silently deletes the best cases in the suite.
-for case_dir in $SCOPED; do
-  [ -f "$case_dir/case.yaml" ] || continue
-  # Extract BOTH YAML forms. Flow (`[Bash, Write]`) and block sequence
-  # (`- Bash` on following lines). A block-form-blind guard misses exactly the
-  # layout `claude plugin eval init` scaffolds — i.e. the case it exists for.
-  declared=$( { sed -n 's/.*allowed_tools:[[:space:]]*\[\(.*\)\].*/\1/p' "$case_dir/case.yaml" | tr ',' '\n'
-                sed -n '/allowed_tools:[[:space:]]*$/,/^[[:space:]]*[^[:space:]-]/ s/^[[:space:]]*-[[:space:]]*//p' "$case_dir/case.yaml"
-              } | tr -d ' "' | grep -v '^$' || true )
-  for tool in $declared; do
+while IFS= read -r case_dir; do
+  [ -n "$case_dir" ] || continue
+  declared=$(declared_tools "$case_dir")
+  while IFS= read -r tool; do
+    [ -n "$tool" ] || continue
     case "$tool" in
       Bash|Write|Edit|WebFetch|mcp__*)
         # Exact match against the grant list — an unanchored grep lets
         # `--allow-tools BashOutput` satisfy a requirement for `Bash`.
-        if ! printf '%s' "$ALLOW_TOOLS" | tr ', ' '\n\n' | grep -qx "$tool"; then
+        if ! printf '%s\n' "$GRANTED" | grep -qx "$tool"; then
           printf 'ERROR: %s declares gated tool "%s" but --allow-tools is "%s".\n' \
             "$case_dir" "$tool" "$ALLOW_TOOLS" >&2
           printf 'Both ablation arms would score 0.00 and read as "no gap".\n' >&2
@@ -187,8 +359,12 @@ for case_dir in $SCOPED; do
         fi
         ;;
     esac
-  done
-done
+  done <<TOOL_EOF
+$declared
+TOOL_EOF
+done <<GUARD_EOF
+$SCOPED
+GUARD_EOF
 
 TARGET="plugins/${PLUGIN}"
 [ -n "$PLUGIN" ] || TARGET="plugins"
@@ -199,11 +375,24 @@ OUT_DIR="${TMPDIR:-/tmp}/eval-results-$$"
 # classify() ever runs. The delta gate would be permanently unreachable, and
 # every case the sweep exists to measure scores below 1.00 by definition.
 set -- "$TARGET" --ablation with-without --scaffold \
-  --allow-tools "$ALLOW_TOOLS" --threshold 0 \
+  --threshold 0 \
   --output-dir "$OUT_DIR" --max-cost-usd "$MAX_COST"
 [ -z "$CASE_GLOB" ] || set -- "$@" --case "$CASE_GLOB"
 [ -z "$RUNS" ]      || set -- "$@" --runs "$RUNS"
 [ "$KEEP_TEMP" -eq 0 ] || set -- "$@" --keep-temp
+
+# --allow-tools goes LAST, one tool per argv element. It is variadic, so it
+# consumes every following non-flag token; putting it at the end means it can
+# never swallow another option's value.
+if [ -n "$GRANTED" ]; then
+  set -- "$@" --allow-tools
+  while IFS= read -r tool; do
+    [ -n "$tool" ] || continue
+    set -- "$@" "$tool"
+  done <<GRANT_EOF
+$GRANTED
+GRANT_EOF
+fi
 
 if [ "$DRY_RUN" -eq 1 ]; then
   printf 'CLAUDE_CODE_WALNUT_SPIRE=1 JJ_USER=%s JJ_EMAIL=%s claude plugin eval %s\n' \
@@ -227,7 +416,18 @@ if [ "$eval_rc" -gt 2 ]; then
   exit "$eval_rc"
 fi
 
-RESULT="$(find "$OUT_DIR" -name aggregate-result.json | head -1)"
+RESULT="$(find "$OUT_DIR" -name aggregate-result.json 2>/dev/null | head -1 || true)"
+
+# No result file is not a crash to die on with a bare `find:` message. The CLI
+# writes no output directory when it loads zero cases, and under set -e that
+# killed the runner one line before classify() — exit 1, no diagnosis, and the
+# `result JSON:` line below never printed.
+if [ -z "$RESULT" ]; then
+  printf 'ERROR: no aggregate-result.json under %s — nothing was measured.\n' "$OUT_DIR" >&2
+  printf 'The CLI writes no result when it loads zero cases (#82).\n' >&2
+  exit 3
+fi
+
 # Task 7 reads per-grader results (the exercised precondition) from this
 # file; print the path where a human can find it.
 printf 'result JSON: %s\n' "$RESULT" >&2

--- a/.github/scripts/run-evals.sh
+++ b/.github/scripts/run-evals.sh
@@ -6,12 +6,26 @@ set -euo pipefail
 DISCOVER_ONLY=0
 CLASSIFY_FILE=""
 GATE="strict"
+PLUGIN=""
+CASE_GLOB=""
+RUNS=""
+KEEP_TEMP=0
+MAX_COST="5"
+ALLOW_TOOLS="Bash"
+DRY_RUN=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --discover-only) DISCOVER_ONLY=1; shift ;;
     --classify)      CLASSIFY_FILE="$2"; shift 2 ;;
     --gate)          GATE="$2"; shift 2 ;;
+    --plugin)        PLUGIN="$2"; shift 2 ;;
+    --case)          CASE_GLOB="$2"; shift 2 ;;
+    --runs)          RUNS="$2"; shift 2 ;;
+    --allow-tools)   ALLOW_TOOLS="$2"; shift 2 ;;
+    --max-cost-usd)  MAX_COST="$2"; shift 2 ;;
+    --keep-temp)     KEEP_TEMP=1; shift ;;
+    --dry-run)       DRY_RUN=1; shift ;;
     *) printf 'unknown argument: %s\n' "$1" >&2; exit 64 ;;
   esac
 done
@@ -131,3 +145,90 @@ fi
 
 # stderr, not stdout — stdout carries the TSV that Task 7 pipes to a file.
 printf 'discovered %d case(s)\n' "$(printf '%s\n' "$CASES" | wc -l | tr -d ' ')" >&2
+
+# Scope the guard to what this invocation will actually run. Scanning every
+# discovered case makes an unrelated plugin's Write-requiring case abort a run
+# that never touches it.
+SCOPED=""
+for case_dir in $CASES; do
+  if [ -n "$PLUGIN" ]; then
+    case "$case_dir" in plugins/"$PLUGIN"/*) ;; *) continue ;; esac
+  fi
+  if [ -n "$CASE_GLOB" ]; then
+    # shellcheck disable=SC2254
+    case "$(basename "$case_dir")" in $CASE_GLOB) ;; *) continue ;; esac
+  fi
+  SCOPED="$SCOPED$case_dir
+"
+done
+
+# Guard: every gated tool a case declares must appear in the grant. Without
+# this, the agent cannot call the tool, BOTH arms score 0.00, and the delta
+# reads 0.00 — which the gate would otherwise interpret as "measures the
+# model, cut the case". That silently deletes the best cases in the suite.
+for case_dir in $SCOPED; do
+  [ -f "$case_dir/case.yaml" ] || continue
+  # Extract BOTH YAML forms. Flow (`[Bash, Write]`) and block sequence
+  # (`- Bash` on following lines). A block-form-blind guard misses exactly the
+  # layout `claude plugin eval init` scaffolds — i.e. the case it exists for.
+  declared=$( { sed -n 's/.*allowed_tools:[[:space:]]*\[\(.*\)\].*/\1/p' "$case_dir/case.yaml" | tr ',' '\n'
+                sed -n '/allowed_tools:[[:space:]]*$/,/^[[:space:]]*[^[:space:]-]/ s/^[[:space:]]*-[[:space:]]*//p' "$case_dir/case.yaml"
+              } | tr -d ' "' | grep -v '^$' || true )
+  for tool in $declared; do
+    case "$tool" in
+      Bash|Write|Edit|WebFetch|mcp__*)
+        # Exact match against the grant list — an unanchored grep lets
+        # `--allow-tools BashOutput` satisfy a requirement for `Bash`.
+        if ! printf '%s' "$ALLOW_TOOLS" | tr ', ' '\n\n' | grep -qx "$tool"; then
+          printf 'ERROR: %s declares gated tool "%s" but --allow-tools is "%s".\n' \
+            "$case_dir" "$tool" "$ALLOW_TOOLS" >&2
+          printf 'Both ablation arms would score 0.00 and read as "no gap".\n' >&2
+          exit 7
+        fi
+        ;;
+    esac
+  done
+done
+
+TARGET="plugins/${PLUGIN}"
+[ -n "$PLUGIN" ] || TARGET="plugins"
+OUT_DIR="${TMPDIR:-/tmp}/eval-results-$$"
+
+# --threshold 0 is LOAD-BEARING. It defaults to 1.0, so the CLI exits 1 on any
+# case scoring below 1.00 — which, under `set -e`, kills this script before
+# classify() ever runs. The delta gate would be permanently unreachable, and
+# every case the sweep exists to measure scores below 1.00 by definition.
+set -- "$TARGET" --ablation with-without --scaffold \
+  --allow-tools "$ALLOW_TOOLS" --threshold 0 \
+  --output-dir "$OUT_DIR" --max-cost-usd "$MAX_COST"
+[ -z "$CASE_GLOB" ] || set -- "$@" --case "$CASE_GLOB"
+[ -z "$RUNS" ]      || set -- "$@" --runs "$RUNS"
+[ "$KEEP_TEMP" -eq 0 ] || set -- "$@" --keep-temp
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf 'CLAUDE_CODE_WALNUT_SPIRE=1 JJ_USER=%s JJ_EMAIL=%s claude plugin eval %s\n' \
+    "${JJ_USER:-eval}" "${JJ_EMAIL:-eval@example.com}" "$*"
+  exit 0
+fi
+
+# Capture the CLI's exit code rather than letting set -e act on it. Exit 2 is
+# the documented --max-cost-usd breach, which must reach classify() so the
+# .partial tripwire can report it; anything above 2 is a real failure.
+# The CLI prints its human summary table to STDOUT (verified live, 2.1.220);
+# send it to stderr — stdout belongs to the TSV that Task 7 pipes to a file.
+eval_rc=0
+CLAUDE_CODE_WALNUT_SPIRE=1 \
+JJ_USER="${JJ_USER:-eval}" \
+JJ_EMAIL="${JJ_EMAIL:-eval@example.com}" \
+  claude plugin eval "$@" 1>&2 || eval_rc=$?
+
+if [ "$eval_rc" -gt 2 ]; then
+  printf 'ERROR: claude plugin eval failed (rc=%s)\n' "$eval_rc" >&2
+  exit "$eval_rc"
+fi
+
+RESULT="$(find "$OUT_DIR" -name aggregate-result.json | head -1)"
+# Task 7 reads per-grader results (the exercised precondition) from this
+# file; print the path where a human can find it.
+printf 'result JSON: %s\n' "$RESULT" >&2
+classify "$RESULT"

--- a/.github/scripts/run-evals.sh
+++ b/.github/scripts/run-evals.sh
@@ -213,6 +213,19 @@ first_name_key() {
        END { if (found) print v }'
 }
 
+# Strip leading/trailing whitespace and, if present, one matched pair of
+# surrounding quotes — preserving internal spaces exactly. The prior form
+# used by case_name_of, `tr -d " \"'"`, deleted every space and quote
+# ANYWHERE in the value, not just a surrounding pair: `name: my case` became
+# `mycase`, so --case 'my case' (which the CLI WOULD match) scoped to
+# nothing and --case 'mycase' (which the CLI would NOT match) scoped in and
+# passed the guard — the disjoint-set defect this closes.
+dequote() {
+  sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' \
+      -e 's/^"\(.*\)"$/\1/' \
+      -e "s/^'\(.*\)'\$/\1/"
+}
+
 # The name the CLI will match --case against. Verified against 2.1.220: the
 # glob is applied to the case's `name:` field, and a prose-layout case that
 # declares none defaults to its directory basename. Scoping on the basename
@@ -223,10 +236,10 @@ case_name_of() {
   d="$1"
   n=""
   if [ -f "$d/case.yaml" ]; then
-    n=$(first_name_key < "$d/case.yaml" | tr -d " \"'")
+    n=$(first_name_key < "$d/case.yaml" | dequote)
   fi
   if [ -z "$n" ] && [ -f "$d/prompt.md" ]; then
-    n=$(frontmatter "$d/prompt.md" | first_name_key | tr -d " \"'")
+    n=$(frontmatter "$d/prompt.md" | first_name_key | dequote)
   fi
   if [ -z "$n" ]; then
     n=$(basename "$d")

--- a/.github/scripts/run-evals.sh
+++ b/.github/scripts/run-evals.sh
@@ -4,13 +4,108 @@
 set -euo pipefail
 
 DISCOVER_ONLY=0
+CLASSIFY_FILE=""
+GATE="strict"
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --discover-only) DISCOVER_ONLY=1; shift ;;
+    --classify)      CLASSIFY_FILE="$2"; shift 2 ;;
+    --gate)          GATE="$2"; shift 2 ;;
     *) printf 'unknown argument: %s\n' "$1" >&2; exit 64 ;;
   esac
 done
+
+# Classify an aggregate-result.json into verdicts and set the exit code.
+# Field paths are FLAT snake_case and verified against a real run:
+#   .cases[].delta / .score / .score_without / .pass_rate / .pass_rate_without
+#   .partial (top level)
+# There is no .aggregates.* — see docs/specs/2026-07-20-eval-suite-design.md.
+classify() {
+  file="$1"
+
+  if [ ! -f "$file" ]; then
+    printf 'ERROR: no such result file: %s\n' "$file" >&2
+    exit 65
+  fi
+
+  # Malformed JSON must not be misdiagnosed. A `$(jq ...)` inside `[ ... ]`
+  # does NOT trip set -e, so without this check a parse error falls through
+  # the .partial test and then trips the null-delta tripwire, reporting
+  # "schema drift" with total confidence about a file that is simply corrupt.
+  if ! jq -e . "$file" >/dev/null 2>&1; then
+    printf 'ERROR: %s is not valid JSON\n' "$file" >&2
+    exit 65
+  fi
+
+  # Zero cases is never success. `.cases[]` over an empty array prints
+  # nothing, bad_count is 0, and the gate exits green having measured
+  # nothing at all — #82's failure mode, one level in.
+  if [ "$(jq -r '.cases | length' "$file")" = "0" ]; then
+    printf 'ERROR: result contains zero cases — nothing was measured (#82).\n' >&2
+    exit 3
+  fi
+
+  # Budget breach: paid graders were skipped, so scores are partial.
+  if [ "$(jq -r '.partial // false' "$file")" = "true" ]; then
+    printf 'ERROR: run was truncated by --max-cost-usd (.partial=true).\n' >&2
+    printf 'Paid graders were skipped; deltas are not trustworthy.\n' >&2
+    exit 6
+  fi
+
+  # Tripwire: any missing OR non-numeric delta means the result schema moved.
+  # null is not the only drift shape: jq sorts every string above every
+  # number, so a string "0.0" delta passes every comparison, classifies
+  # DISCRIMINATING, and gates green. Key on type — never let a non-number
+  # reach a comparison.
+  if [ "$(jq -r '[.cases[]? | select((.delta | type) != "number")] | length' "$file")" != "0" ]; then
+    printf 'ERROR: a case has a null or non-numeric delta — result schema drift.\n' >&2
+    printf 'Expected flat numeric .cases[].delta. Every verdict would be meaningless.\n' >&2
+    exit 5
+  fi
+
+  jq -r '
+    .cases[]?
+    | [ .name,
+        (.score          | tostring),
+        (.score_without  | tostring),
+        (.delta          | tostring),
+        ( if   (.score == 0 and .score_without == 0) then "BROKEN"
+          elif .delta <  0    then "REGRESSION"
+          elif .delta == 0    then "NO_GAP"
+          elif .delta <  0.5  then "PARTIAL"
+          else                     "DISCRIMINATING"
+          end )
+      ] | @tsv
+  ' "$file"
+
+  # Validate the gate name. Without this, any typo falls through to report
+  # semantics — silently turning a strict Part B gate permissive and green.
+  case "$GATE" in
+    strict|report) ;;
+    *) printf 'ERROR: --gate must be "strict" or "report", got "%s"\n' "$GATE" >&2
+       exit 64 ;;
+  esac
+
+  # Gate. strict (Part B): only DISCRIMINATING passes.
+  # report (Part A): NO_GAP and PARTIAL are findings, not failures — but
+  # BROKEN and REGRESSION always fail, in both modes.
+  if [ "$GATE" = "strict" ]; then
+    bad_count=$(jq -r '[.cases[] | select((.score == 0 and .score_without == 0) or .delta < 0.5)] | length' "$file")
+  else
+    bad_count=$(jq -r '[.cases[] | select((.score == 0 and .score_without == 0) or .delta < 0)] | length' "$file")
+  fi
+
+  if [ "$bad_count" != "0" ]; then
+    printf 'gate(%s): %s case(s) failed\n' "$GATE" "$bad_count" >&2
+    exit 4
+  fi
+}
+
+if [ -n "$CLASSIFY_FILE" ]; then
+  classify "$CLASSIFY_FILE"
+  exit 0
+fi
 
 # Discover case directories. BOTH supported formats: `case.yaml` and the
 # `prompt.md` + graders/ layout that `claude plugin eval init --bare` writes.

--- a/.github/tests/fixtures/evals/boundary.json
+++ b/.github/tests/fixtures/evals/boundary.json
@@ -1,2 +1,2 @@
 {"schema_version":"1.0","partial":false,"cost_usd":0.17,
- "cases":[{"name":"exactly-half","score":1,"score_without":0.5,"delta":0.5,"pass_rate":1,"pass_rate_without":0.5}]}
+ "cases":[{"name":"exactly-half","score":0.7,"score_without":0.2,"delta":0.49999999999999994,"pass_rate":0.7,"pass_rate_without":0.2}]}

--- a/.github/tests/fixtures/evals/boundary.json
+++ b/.github/tests/fixtures/evals/boundary.json
@@ -1,0 +1,2 @@
+{"schema_version":"1.0","partial":false,"cost_usd":0.17,
+ "cases":[{"name":"exactly-half","score":1,"score_without":0.5,"delta":0.5,"pass_rate":1,"pass_rate_without":0.5}]}

--- a/.github/tests/fixtures/evals/boundaryexact.json
+++ b/.github/tests/fixtures/evals/boundaryexact.json
@@ -1,0 +1,2 @@
+{"schema_version":"1.0","partial":false,"cost_usd":0.17,
+ "cases":[{"name":"literal-half","score":1,"score_without":0.5,"delta":0.5,"pass_rate":1,"pass_rate_without":0.5}]}

--- a/.github/tests/fixtures/evals/broken.json
+++ b/.github/tests/fixtures/evals/broken.json
@@ -1,0 +1,2 @@
+{"schema_version":"1.0","partial":false,"cost_usd":0.16,
+ "cases":[{"name":"missing-tool-grant","score":0,"score_without":0,"delta":0,"pass_rate":0,"pass_rate_without":0}]}

--- a/.github/tests/fixtures/evals/discriminating.json
+++ b/.github/tests/fixtures/evals/discriminating.json
@@ -1,0 +1,2 @@
+{"schema_version":"1.0","partial":false,"cost_usd":0.15,
+ "cases":[{"name":"hook-blocks-raw-git","score":1,"score_without":0,"delta":1,"pass_rate":1,"pass_rate_without":0}]}

--- a/.github/tests/fixtures/evals/driftedscores.json
+++ b/.github/tests/fixtures/evals/driftedscores.json
@@ -1,0 +1,2 @@
+{"schema_version":"1.0","partial":false,"cost_usd":0.12,
+ "cases":[{"name":"score-fields-renamed","scoreWith":0,"scoreWithout":0,"delta":1}]}

--- a/.github/tests/fixtures/evals/mixed.json
+++ b/.github/tests/fixtures/evals/mixed.json
@@ -1,0 +1,3 @@
+{"schema_version":"1.0","partial":false,"cost_usd":0.33,
+ "cases":[{"name":"good","score":1,"score_without":0,"delta":1,"pass_rate":1,"pass_rate_without":0},
+          {"name":"dead","score":0,"score_without":0,"delta":0,"pass_rate":0,"pass_rate_without":0}]}

--- a/.github/tests/fixtures/evals/nocases.json
+++ b/.github/tests/fixtures/evals/nocases.json
@@ -1,0 +1,1 @@
+{"schema_version":"1.0","partial":false,"cost_usd":0,"cases":[]}

--- a/.github/tests/fixtures/evals/nogap.json
+++ b/.github/tests/fixtures/evals/nogap.json
@@ -1,0 +1,2 @@
+{"schema_version":"1.0","partial":false,"cost_usd":0.21,
+ "cases":[{"name":"describe-noninteractive","score":1,"score_without":1,"delta":0,"pass_rate":1,"pass_rate_without":1}]}

--- a/.github/tests/fixtures/evals/nulldelta.json
+++ b/.github/tests/fixtures/evals/nulldelta.json
@@ -1,0 +1,2 @@
+{"schema_version":"1.0","partial":false,"cost_usd":0.15,
+ "cases":[{"name":"schema-drifted","aggregates":{"delta":1,"score":1,"scoreWithout":0}}]}

--- a/.github/tests/fixtures/evals/partial.json
+++ b/.github/tests/fixtures/evals/partial.json
@@ -1,0 +1,2 @@
+{"schema_version":"1.0","partial":true,"cost_usd":5.0,
+ "cases":[{"name":"budget-breached","score":1,"score_without":0,"delta":1,"pass_rate":1,"pass_rate_without":0}]}

--- a/.github/tests/fixtures/evals/partialgap.json
+++ b/.github/tests/fixtures/evals/partialgap.json
@@ -1,0 +1,2 @@
+{"schema_version":"1.0","partial":false,"cost_usd":0.19,
+ "cases":[{"name":"weak-gap","score":1,"score_without":0.7,"delta":0.3,"pass_rate":1,"pass_rate_without":0.7}]}

--- a/.github/tests/fixtures/evals/partialnocases.json
+++ b/.github/tests/fixtures/evals/partialnocases.json
@@ -1,0 +1,1 @@
+{"schema_version":"1.0","partial":true,"cost_usd":5.0,"cases":[]}

--- a/.github/tests/fixtures/evals/regression.json
+++ b/.github/tests/fixtures/evals/regression.json
@@ -1,0 +1,2 @@
+{"schema_version":"1.0","partial":false,"cost_usd":0.18,
+ "cases":[{"name":"plugin-makes-it-worse","score":0,"score_without":1,"delta":-1,"pass_rate":0,"pass_rate_without":1}]}

--- a/.github/tests/fixtures/evals/stringdelta.json
+++ b/.github/tests/fixtures/evals/stringdelta.json
@@ -1,0 +1,2 @@
+{"schema_version":"1.0","partial":false,"cost_usd":0.15,
+ "cases":[{"name":"drifted-to-string","score":"1","score_without":"0","delta":"0.0"}]}

--- a/.github/tests/test-run-evals.sh
+++ b/.github/tests/test-run-evals.sh
@@ -42,5 +42,144 @@ else
   bad "zero matches aborts with exit 3 (got rc=$rc)"
 fi
 
+FIX="$(cd "$(dirname "$0")" && pwd)/fixtures/evals"
+
+verdict_of() { /bin/bash "$SCRIPT" --classify "$1" 2>/dev/null | awk -F'\t' 'NR==1{print $5}'; }
+
+for pair in "discriminating:DISCRIMINATING" "nogap:NO_GAP" "broken:BROKEN" "regression:REGRESSION"; do
+  f="${pair%%:*}"; want="${pair##*:}"
+  got=$(verdict_of "$FIX/$f.json" || true)
+  if [ "$got" = "$want" ]; then
+    ok "classifies $f as $want"
+  else
+    bad "classifies $f as $want (got: ${got:-<empty>})"
+  fi
+done
+
+# BROKEN must NOT be reported as NO_GAP — a missing --allow-tools grant zeroes
+# both arms, and reading that as "no gap" silently deletes the best cases.
+# Require a NON-EMPTY verdict: bare != would pass vacuously on empty output
+# before classify() even exists (fail-first, third review).
+got=$(verdict_of "$FIX/broken.json" || true)
+if [ -n "$got" ] && [ "$got" != "NO_GAP" ]; then
+  ok "both-arms-zero is never NO_GAP"
+else
+  bad "both-arms-zero is never NO_GAP (got: ${got:-<empty>})"
+fi
+
+# Null delta must abort. jq yields null for a missing path and null sorts BELOW
+# every number, so `null < 0` is true — an ungated null files every case as
+# REGRESSION while looking like it works.
+set +e
+/bin/bash "$SCRIPT" --classify "$FIX/nulldelta.json" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 5 ]; then
+  ok "null delta trips the tripwire (exit 5)"
+else
+  bad "null delta trips the tripwire (exit 5) (got rc=$rc)"
+fi
+
+# A present-but-string delta is the same disease in the opposite direction:
+# jq sorts strings above every number, so "0.0" passes every comparison,
+# classifies DISCRIMINATING, and gates GREEN. The tripwire must key on type.
+set +e
+/bin/bash "$SCRIPT" --classify "$FIX/stringdelta.json" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 5 ]; then
+  ok "string-typed delta trips the tripwire (exit 5)"
+else
+  bad "string-typed delta trips the tripwire (exit 5) (got rc=$rc)"
+fi
+
+# A budget-breached run has partial scores; deltas must not be trusted.
+set +e
+/bin/bash "$SCRIPT" --classify "$FIX/partial.json" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 6 ]; then
+  ok "partial run aborts (exit 6)"
+else
+  bad "partial run aborts (exit 6) (got rc=$rc)"
+fi
+
+# strict gate (Part B): anything short of DISCRIMINATING fails.
+set +e
+/bin/bash "$SCRIPT" --classify "$FIX/nogap.json" --gate strict >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 4 ]; then
+  ok "strict gate fails on NO_GAP"
+else
+  bad "strict gate fails on NO_GAP (got rc=$rc)"
+fi
+
+# report gate (Part A): NO_GAP is data, not failure.
+set +e
+/bin/bash "$SCRIPT" --classify "$FIX/nogap.json" --gate report >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  ok "report gate tolerates NO_GAP"
+else
+  bad "report gate tolerates NO_GAP (got rc=$rc)"
+fi
+
+# PARTIAL is a declared verdict; assert it rather than leaving it untested.
+got=$(verdict_of "$FIX/partialgap.json" || true)
+if [ "$got" = "PARTIAL" ]; then
+  ok "classifies a sub-0.5 delta as PARTIAL"
+else
+  bad "classifies a sub-0.5 delta as PARTIAL (got: ${got:-<empty>})"
+fi
+
+# Boundary: exactly 0.5 ships (>= 0.5 per the spec taxonomy).
+got=$(verdict_of "$FIX/boundary.json" || true)
+if [ "$got" = "DISCRIMINATING" ]; then
+  ok "delta of exactly 0.5 is DISCRIMINATING"
+else
+  bad "delta of exactly 0.5 is DISCRIMINATING (got: ${got:-<empty>})"
+fi
+
+# Zero cases must abort. An empty .cases[] prints nothing and gates green,
+# having measured nothing — #82 one level in.
+set +e
+/bin/bash "$SCRIPT" --classify "$FIX/nocases.json" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 3 ]; then
+  ok "zero cases in result aborts (exit 3)"
+else
+  bad "zero cases in result aborts (exit 3) (got rc=$rc)"
+fi
+
+# Malformed JSON must report as malformed, not as schema drift.
+printf 'not json at all\n' > "$FIX/../badjson.json"
+set +e
+err=$(/bin/bash "$SCRIPT" --classify "$FIX/../badjson.json" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 65 ] && printf '%s' "$err" | grep -q 'not valid JSON'; then
+  ok "malformed JSON reports as invalid (exit 65)"
+else
+  bad "malformed JSON reports as invalid (exit 65) (got rc=$rc: $err)"
+fi
+rm -f "$FIX/../badjson.json"
+
+# An unknown gate name must abort, not silently fall through to permissive.
+# Require the gate-validation MESSAGE, not just rc 64 — before --classify
+# exists, the unknown-argument arm also exits 64, so a bare rc check passes
+# vacuously for the wrong reason (fail-first, third review).
+set +e
+err=$(/bin/bash "$SCRIPT" --classify "$FIX/nogap.json" --gate typo 2>&1 >/dev/null)
+rc=$?
+set -e
+if [ "$rc" -eq 64 ] && printf '%s' "$err" | grep -q -- '--gate must be'; then
+  ok "unknown --gate value aborts (exit 64)"
+else
+  bad "unknown --gate value aborts (exit 64) (got rc=$rc: ${err:-<empty>})"
+fi
+
 printf '%d passed, %d failed\n' "$PASS" "$FAIL"
 test "$FAIL" -eq 0

--- a/.github/tests/test-run-evals.sh
+++ b/.github/tests/test-run-evals.sh
@@ -181,5 +181,169 @@ else
   bad "unknown --gate value aborts (exit 64) (got rc=$rc: ${err:-<empty>})"
 fi
 
+D=$(mktemp -d)
+mkdir -p "$D/plugins/demo/evals/alpha"
+cat > "$D/plugins/demo/evals/alpha/case.yaml" <<'YAML'
+schema_version: "1.1"
+name: alpha
+execution:
+  prompt: hello
+  allowed_tools: [Bash]
+graders:
+  - type: regex
+    name: g
+    pattern: hi
+YAML
+mkdir -p "$D/plugins/demo/.claude-plugin"
+printf '{"name":"demo","description":"d","version":"0.0.1"}\n' \
+  > "$D/plugins/demo/.claude-plugin/plugin.json"
+
+cmd=$(cd "$D" && /bin/bash "$SCRIPT" --plugin demo --dry-run 2>&1) || true
+
+for flag in "--ablation with-without" "--allow-tools" "--scaffold" "--output-dir" "CLAUDE_CODE_WALNUT_SPIRE=1"; do
+  if printf '%s' "$cmd" | grep -q -- "$flag"; then
+    ok "dry-run includes $flag"
+  else
+    bad "dry-run includes $flag (got: $cmd)"
+  fi
+done
+
+# --output-dir must land OUTSIDE plugins/, or results trip the #84 version
+# lint. Anchor on the flag being PRESENT — a bare not-match is vacuously
+# green on empty or error output and can never fail first (third review).
+if printf '%s' "$cmd" | grep -q -- '--output-dir' \
+   && ! printf '%s' "$cmd" | grep -q -- '--output-dir[= ]*[^ ]*plugins/'; then
+  ok "output-dir stays outside plugins/"
+else
+  bad "output-dir stays outside plugins/ (got: $cmd)"
+fi
+
+# A case declaring a gated tool absent from the grant must abort loudly,
+# rather than scoring both arms 0.00 and reading as "no gap".
+mkdir -p "$D/plugins/demo/evals/needswrite"
+cat > "$D/plugins/demo/evals/needswrite/case.yaml" <<'YAML'
+schema_version: "1.1"
+name: needswrite
+execution:
+  prompt: hello
+  allowed_tools: [Bash, Write]
+graders:
+  - type: regex
+    name: g
+    pattern: hi
+YAML
+set +e
+(cd "$D" && /bin/bash "$SCRIPT" --plugin demo --allow-tools Bash --dry-run >/dev/null 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 7 ]; then
+  ok "ungranted gated tool aborts (exit 7)"
+else
+  bad "ungranted gated tool aborts (exit 7) (got rc=$rc)"
+fi
+
+# Block-style YAML must be caught too — it is the layout `eval init` writes,
+# so a flow-only guard is blind to precisely the cases it exists to protect.
+mkdir -p "$D/plugins/demo/evals/blockstyle"
+cat > "$D/plugins/demo/evals/blockstyle/case.yaml" <<'YAML'
+schema_version: "1.1"
+name: blockstyle
+execution:
+  prompt: hello
+  allowed_tools:
+    - Bash
+    - Write
+graders:
+  - type: regex
+    name: g
+    pattern: hi
+YAML
+set +e
+(cd "$D" && /bin/bash "$SCRIPT" --plugin demo --allow-tools Bash --dry-run >/dev/null 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 7 ]; then
+  ok "block-style allowed_tools caught by guard"
+else
+  bad "block-style allowed_tools caught by guard (got rc=$rc)"
+fi
+rm -rf "$D/plugins/demo/evals/blockstyle" "$D/plugins/demo/evals/needswrite"
+
+# --- LIVE PATH via a stub `claude` on PATH ---
+# Every exit-code test above goes through --classify directly. Without a live
+# test, `set -e` killing the runner before classify() is invisible — a green
+# suite that cannot fail, which is the exact disease this project exists to
+# prevent. These stubs cost nothing and cover the real invocation path.
+STUB=$(mktemp -d)
+mkdir -p "$STUB/bin"
+cat > "$STUB/bin/claude" <<'STUBEOF'
+#!/usr/bin/env bash
+# Emulate the CLI's exit contract: 1 when a case scores under --threshold,
+# 2 on --max-cost-usd breach. The real CLI also prints its human summary
+# table to STDOUT (verified live on 2.1.220) — the stub must too, or the
+# stdout-purity test below can only pass vacuously.
+printf 'CASE  WITH  W/OUT (stub table noise)\n'
+outdir=""
+prev=""
+for a in "$@"; do
+  [ "$prev" = "--output-dir" ] && outdir="$a"
+  prev="$a"
+done
+mkdir -p "$outdir"
+case "${STUB_MODE:-ok}" in
+  threshold)
+    printf '{"schema_version":"1.0","partial":false,"cases":[{"name":"c","score":0.5,"score_without":0,"delta":0.5}]}\n' > "$outdir/aggregate-result.json"
+    exit 1 ;;
+  maxcost)
+    printf '{"schema_version":"1.0","partial":true,"cases":[{"name":"c","score":1,"score_without":0,"delta":1}]}\n' > "$outdir/aggregate-result.json"
+    exit 2 ;;
+  *)
+    printf '{"schema_version":"1.0","partial":false,"cases":[{"name":"c","score":1,"score_without":0,"delta":1}]}\n' > "$outdir/aggregate-result.json"
+    exit 0 ;;
+esac
+STUBEOF
+chmod +x "$STUB/bin/claude"
+
+# A case scoring under 1.0 makes the CLI exit 1. The runner must survive it
+# and still classify — otherwise --threshold silently pre-empts the delta gate.
+out=$(cd "$D" && PATH="$STUB/bin:$PATH" STUB_MODE=threshold \
+  /bin/bash "$SCRIPT" --plugin demo 2>/dev/null) || true
+if printf '%s' "$out" | grep -q 'DISCRIMINATING'; then
+  ok "live path survives CLI exit 1 and still classifies"
+else
+  bad "live path survives CLI exit 1 and still classifies (got: ${out:-<empty>})"
+fi
+
+# The assembled command must carry --threshold 0, or the above is luck.
+cmd=$(cd "$D" && /bin/bash "$SCRIPT" --plugin demo --dry-run 2>/dev/null) || true
+if printf '%s' "$cmd" | grep -q -- '--threshold 0'; then
+  ok "assembles --threshold 0"
+else
+  bad "assembles --threshold 0 (got: $cmd)"
+fi
+
+# A budget breach is CLI exit 2; .partial must still reach classify as exit 6.
+set +e
+(cd "$D" && PATH="$STUB/bin:$PATH" STUB_MODE=maxcost \
+  /bin/bash "$SCRIPT" --plugin demo >/dev/null 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 6 ]; then
+  ok "budget breach reaches the .partial tripwire (exit 6)"
+else
+  bad "budget breach reaches the .partial tripwire (exit 6) (got rc=$rc)"
+fi
+
+# stdout must be pure TSV — Task 7 pipes it to a file. The stub prints a fake
+# summary table to stdout precisely because the real CLI does; if the runner
+# fails to redirect the CLI's stdout, this catches it.
+out=$(cd "$D" && PATH="$STUB/bin:$PATH" /bin/bash "$SCRIPT" --plugin demo 2>/dev/null) || true
+if printf '%s' "$out" | grep -q 'DISCRIMINATING' \
+   && ! printf '%s' "$out" | grep -qE 'discovered|stub table noise'; then
+  ok "stdout is pure TSV"
+else
+  bad "stdout is pure TSV (got: ${out:-<empty>})"
+fi
+
 printf '%d passed, %d failed\n' "$PASS" "$FAIL"
 test "$FAIL" -eq 0

--- a/.github/tests/test-run-evals.sh
+++ b/.github/tests/test-run-evals.sh
@@ -17,6 +17,19 @@ TMPROOT=$(mktemp -d)
 trap 'rm -rf "$TMPROOT"' EXIT
 new_tmp() { d=$(mktemp -d "$TMPROOT/t.XXXXXX"); printf '%s' "$d"; }
 
+# Baseline for the leak check at the bottom of this file. run-evals.sh
+# computes its OUT_DIR as "${TMPDIR:-/tmp}/eval-results-$$"; every
+# stub-driven invocation below that hits the live path (not --dry-run, not
+# --classify) must have ITS OWN TMPDIR pointed at $TMPROOT, or that directory
+# lands in the real $TMPDIR and outlives this suite — the same leak class
+# #98 fixed for /tmp files. Snapshot what is there BEFORE any of those run;
+# pre-existing directories from unrelated runs are not this suite's problem
+# and must not be flagged.
+REAL_TMPDIR="${TMPDIR:-/tmp}"
+BEFORE_LEAK_FILE="$TMPROOT/before-leak.txt"
+find "$REAL_TMPDIR" -maxdepth 1 -type d -name 'eval-results-*' 2>/dev/null \
+  | sort > "$BEFORE_LEAK_FILE"
+
 # A guard assertion gets its OWN tree, always. Sharing one tree is exactly how
 # the block-style assertion went vacuous: an unrelated flow-form case was left
 # on disk and tripped exit 7 first, so the assertion passed whether or not the
@@ -640,6 +653,32 @@ else
   bad "a --plugin matching nothing aborts (exit 3) (got rc=$rc)"
 fi
 
+# case_name_of previously ran the declared name through `tr -d " \"'"`, which
+# deletes every space and quote ANYWHERE, not just a surrounding pair — so
+# `name: my case` was seen by this guard as `mycase`. That desyncs the
+# guard's matching from the CLI's own: --case 'my case' (which the CLI WOULD
+# match) scoped to nothing here, and --case 'mycase' (which the CLI would
+# NOT match) scoped in and passed the guard. Assert the guard scopes on the
+# name exactly as declared, internal space intact.
+SPACENAME=$(mk_case_tree spacecase <<'YAML'
+schema_version: "1.1"
+name: my case
+execution:
+  prompt: hello
+  allowed_tools: [Bash, Write]
+graders:
+  - type: regex
+    name: g
+    pattern: hi
+YAML
+)
+rc=$(guard_rc "$SPACENAME" --plugin demo --case "my case" --allow-tools Bash)
+if [ "$rc" -eq 7 ]; then
+  ok "--case with an internal space scopes on the name the CLI matches"
+else
+  bad "--case with an internal space scopes on the name the CLI matches (got rc=$rc)"
+fi
+
 # --- LIVE PATH via a stub `claude` on PATH ---
 # Every exit-code test above goes through --classify directly. Without a live
 # test, `set -e` killing the runner before classify() is invisible — a green
@@ -688,7 +727,7 @@ chmod +x "$STUB/bin/claude"
 
 # A case scoring under 1.0 makes the CLI exit 1. The runner must survive it
 # and still classify — otherwise --threshold silently pre-empts the delta gate.
-out=$(cd "$D" && PATH="$STUB/bin:$PATH" STUB_MODE=threshold \
+out=$(cd "$D" && PATH="$STUB/bin:$PATH" TMPDIR="$TMPROOT" STUB_MODE=threshold \
   /bin/bash "$SCRIPT" --plugin demo 2>/dev/null) || true
 if printf '%s' "$out" | grep -q 'DISCRIMINATING'; then
   ok "live path survives CLI exit 1 and still classifies"
@@ -707,7 +746,7 @@ fi
 # The rendered dry-run is a proxy; this is the argv the CLI actually receives.
 ARGV="$STUB/argv.txt"
 rm -f "$ARGV"
-(cd "$D" && PATH="$STUB/bin:$PATH" STUB_ARGV_FILE="$ARGV" \
+(cd "$D" && PATH="$STUB/bin:$PATH" TMPDIR="$TMPROOT" STUB_ARGV_FILE="$ARGV" \
   /bin/bash "$SCRIPT" --plugin demo --allow-tools Bash,Write >/dev/null 2>&1) || true
 if [ -f "$ARGV" ] && grep -qx 'Bash' "$ARGV" && grep -qx 'Write' "$ARGV" \
    && ! grep -q ',' "$ARGV"; then
@@ -718,7 +757,7 @@ fi
 
 # A budget breach is CLI exit 2; .partial must still reach classify as exit 6.
 set +e
-(cd "$D" && PATH="$STUB/bin:$PATH" STUB_MODE=maxcost \
+(cd "$D" && PATH="$STUB/bin:$PATH" TMPDIR="$TMPROOT" STUB_MODE=maxcost \
   /bin/bash "$SCRIPT" --plugin demo >/dev/null 2>&1)
 rc=$?
 set -e
@@ -732,7 +771,7 @@ fi
 # fails under set -e and the runner dies at exit 1 with a bare `find:` message,
 # never reaching classify() and never naming what went wrong.
 set +e
-err=$(cd "$D" && PATH="$STUB/bin:$PATH" STUB_MODE=nooutput \
+err=$(cd "$D" && PATH="$STUB/bin:$PATH" TMPDIR="$TMPROOT" STUB_MODE=nooutput \
   /bin/bash "$SCRIPT" --plugin demo 2>&1 >/dev/null)
 rc=$?
 set -e
@@ -748,7 +787,7 @@ fi
 # see the difference — the sentinel is whether the CLI ran at all.
 rm -f "$ARGV"
 set +e
-(cd "$D" && PATH="$STUB/bin:$PATH" STUB_ARGV_FILE="$ARGV" \
+(cd "$D" && PATH="$STUB/bin:$PATH" TMPDIR="$TMPROOT" STUB_ARGV_FILE="$ARGV" \
   /bin/bash "$SCRIPT" --plugin demo --gate strcit >/dev/null 2>&1)
 rc=$?
 set -e
@@ -761,12 +800,27 @@ fi
 # stdout must be pure TSV — Task 7 pipes it to a file. The stub prints a fake
 # summary table to stdout precisely because the real CLI does; if the runner
 # fails to redirect the CLI's stdout, this catches it.
-out=$(cd "$D" && PATH="$STUB/bin:$PATH" /bin/bash "$SCRIPT" --plugin demo 2>/dev/null) || true
+out=$(cd "$D" && PATH="$STUB/bin:$PATH" TMPDIR="$TMPROOT" /bin/bash "$SCRIPT" --plugin demo 2>/dev/null) || true
 if printf '%s' "$out" | grep -q 'DISCRIMINATING' \
    && ! printf '%s' "$out" | grep -qE 'discovered|stub table noise'; then
   ok "stdout is pure TSV"
 else
   bad "stdout is pure TSV (got: ${out:-<empty>})"
+fi
+
+# No stub-driven invocation above may have left a NEW eval-results-* directory
+# in the REAL $TMPDIR (see #98: an ~8k-file leak of the same shape). Diff
+# against the baseline taken at the top of this file — pre-existing
+# directories from other runs are left alone; this fails only on growth this
+# suite run caused.
+AFTER_LEAK_FILE="$TMPROOT/after-leak.txt"
+find "$REAL_TMPDIR" -maxdepth 1 -type d -name 'eval-results-*' 2>/dev/null \
+  | sort > "$AFTER_LEAK_FILE"
+NEW_LEAK=$(comm -13 "$BEFORE_LEAK_FILE" "$AFTER_LEAK_FILE")
+if [ -z "$NEW_LEAK" ]; then
+  ok "no new eval-results-* directory leaked into \$TMPDIR"
+else
+  bad "no new eval-results-* directory leaked into \$TMPDIR (new: $(printf '%s' "$NEW_LEAK" | tr '\n' ' '))"
 fi
 
 printf '%d passed, %d failed\n' "$PASS" "$FAIL"

--- a/.github/tests/test-run-evals.sh
+++ b/.github/tests/test-run-evals.sh
@@ -8,8 +8,41 @@ FAIL=0
 ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
 
+# Every scratch tree lives under ONE root that is removed on exit. A suite that
+# leaks a temp dir per assertion per run is how a machine ends up with
+# thousands of them (see #98). One root, not a registry: half these trees are
+# created inside command substitutions, and a registry variable updated in a
+# subshell never reaches the trap.
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+new_tmp() { d=$(mktemp -d "$TMPROOT/t.XXXXXX"); printf '%s' "$d"; }
+
+# A guard assertion gets its OWN tree, always. Sharing one tree is exactly how
+# the block-style assertion went vacuous: an unrelated flow-form case was left
+# on disk and tripped exit 7 first, so the assertion passed whether or not the
+# parser under test worked at all.
+#   $1 = case directory name, stdin = case.yaml body, stdout = tree root
+mk_case_tree() {
+  root=$(new_tmp)
+  mkdir -p "$root/plugins/demo/.claude-plugin" "$root/plugins/demo/evals/$1"
+  printf '{"name":"demo","description":"d","version":"0.0.1"}\n' \
+    > "$root/plugins/demo/.claude-plugin/plugin.json"
+  cat > "$root/plugins/demo/evals/$1/case.yaml"
+  printf '%s' "$root"
+}
+
+# rc of a guard run against a tree. Never returns the tree's own noise.
+guard_rc() {  # $1 = tree, rest = args
+  tree="$1"; shift
+  set +e
+  (cd "$tree" && /bin/bash "$SCRIPT" "$@" --dry-run >/dev/null 2>&1)
+  rc=$?
+  set -e
+  printf '%s' "$rc"
+}
+
 # --- discovery: finds case.yaml ---
-T=$(mktemp -d)
+T=$(new_tmp)
 mkdir -p "$T/plugins/demo/evals/alpha"
 touch "$T/plugins/demo/evals/alpha/case.yaml"
 out=$(cd "$T" && /bin/bash "$SCRIPT" --discover-only 2>&1) || true
@@ -30,7 +63,7 @@ else
 fi
 
 # --- zero matches must ABORT, not silently pass (#82) ---
-E=$(mktemp -d)
+E=$(new_tmp)
 mkdir -p "$E/plugins/empty"
 set +e
 (cd "$E" && /bin/bash "$SCRIPT" --discover-only >/dev/null 2>&1)
@@ -42,9 +75,27 @@ else
   bad "zero matches aborts with exit 3 (got rc=$rc)"
 fi
 
+# No plugins/ directory at all — i.e. run from the wrong cwd, the single most
+# likely operator error since every documented invocation is relative. `find`
+# fails, 2>/dev/null eats the message and pipefail kills the assignment: exit 1
+# with no output, and 1 is not in the documented exit contract. Require the
+# documented exit 3 AND a message naming the cwd.
+NOPLUG=$(new_tmp)
+set +e
+err=$(cd "$NOPLUG" && /bin/bash "$SCRIPT" --discover-only 2>&1 >/dev/null)
+rc=$?
+set -e
+if [ "$rc" -eq 3 ] && printf '%s' "$err" | grep -q 'plugins/'; then
+  ok "missing plugins/ dir aborts with exit 3 and a diagnostic"
+else
+  bad "missing plugins/ dir aborts with exit 3 and a diagnostic (got rc=$rc: ${err:-<empty>})"
+fi
+
 FIX="$(cd "$(dirname "$0")" && pwd)/fixtures/evals"
 
 verdict_of() { /bin/bash "$SCRIPT" --classify "$1" 2>/dev/null | awk -F'\t' 'NR==1{print $5}'; }
+verdict_at() { /bin/bash "$SCRIPT" --classify "$1" 2>/dev/null | awk -F'\t' -v n="$2" 'NR==n{print $5}'; }
+row_count()  { /bin/bash "$SCRIPT" --classify "$1" 2>/dev/null | grep -c .; }
 
 for pair in "discriminating:DISCRIMINATING" "nogap:NO_GAP" "broken:BROKEN" "regression:REGRESSION"; do
   f="${pair%%:*}"; want="${pair##*:}"
@@ -93,6 +144,21 @@ else
   bad "string-typed delta trips the tripwire (exit 5) (got rc=$rc)"
 fi
 
+# Drift in the SCORE field names, with .delta still numeric. `.score == 0 and
+# .score_without == 0` is false when both are null, so the both-arms-zero
+# BROKEN detector — the headline defence against a dead run — goes silent and
+# the strict gate exits green on a result whose scores are literally null.
+# The tripwire must type-check the score fields, not just the delta.
+set +e
+/bin/bash "$SCRIPT" --classify "$FIX/driftedscores.json" --gate strict >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 5 ]; then
+  ok "renamed score fields trip the tripwire (exit 5)"
+else
+  bad "renamed score fields trip the tripwire (exit 5) (got rc=$rc)"
+fi
+
 # A budget-breached run has partial scores; deltas must not be trusted.
 set +e
 /bin/bash "$SCRIPT" --classify "$FIX/partial.json" >/dev/null 2>&1
@@ -102,6 +168,19 @@ if [ "$rc" -eq 6 ]; then
   ok "partial run aborts (exit 6)"
 else
   bad "partial run aborts (exit 6) (got rc=$rc)"
+fi
+
+# A run truncated BEFORE any case finished is a budget breach, not a discovery
+# failure. Checking zero-cases first points the operator at #82 and a
+# nonexistent glob bug when the actual fix is a larger --max-cost-usd.
+set +e
+err=$(/bin/bash "$SCRIPT" --classify "$FIX/partialnocases.json" 2>&1 >/dev/null)
+rc=$?
+set -e
+if [ "$rc" -eq 6 ] && printf '%s' "$err" | grep -q 'max-cost-usd'; then
+  ok "budget-truncated zero-case run reports the breach (exit 6)"
+else
+  bad "budget-truncated zero-case run reports the breach (exit 6) (got rc=$rc: ${err:-<empty>})"
 fi
 
 # strict gate (Part B): anything short of DISCRIMINATING fails.
@@ -134,12 +213,85 @@ else
   bad "classifies a sub-0.5 delta as PARTIAL (got: ${got:-<empty>})"
 fi
 
-# Boundary: exactly 0.5 ships (>= 0.5 per the spec taxonomy).
+# Boundary, as the CLI's ARITHMETIC produces it. 7/10 with and 2/10 without is
+# a textbook shipping case at exactly the documented threshold, but the CLI
+# computes .delta by subtraction and 0.7-0.2 is 0.49999999999999994 in IEEE754.
+# A hardcoded literal 0.5 fixture cannot see this: it asserts the taxonomy and
+# misses the boundary.
 got=$(verdict_of "$FIX/boundary.json" || true)
+if [ "$got" = "DISCRIMINATING" ]; then
+  ok "delta of 0.5 as the CLI computes it is DISCRIMINATING"
+else
+  bad "delta of 0.5 as the CLI computes it is DISCRIMINATING (got: ${got:-<empty>})"
+fi
+
+# ...and the gate must agree with the verdict. bad_count carries its own copy
+# of the comparison, so a fix applied only to the TSV leaves CI failing a case
+# the table calls DISCRIMINATING.
+set +e
+/bin/bash "$SCRIPT" --classify "$FIX/boundary.json" --gate strict >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  ok "strict gate passes the computed-0.5 boundary"
+else
+  bad "strict gate passes the computed-0.5 boundary (got rc=$rc)"
+fi
+
+# A delta that IS literally 0.5 must stay DISCRIMINATING too — the tolerance
+# must not be applied in the direction that cuts the boundary case.
+got=$(verdict_of "$FIX/boundaryexact.json" || true)
 if [ "$got" = "DISCRIMINATING" ]; then
   ok "delta of exactly 0.5 is DISCRIMINATING"
 else
   bad "delta of exactly 0.5 is DISCRIMINATING (got: ${got:-<empty>})"
+fi
+
+# --- multi-case results: every fixture above holds exactly ONE case, so
+# nothing here exercises the TSV's per-case iteration or the gate's cross-case
+# counting. A jq anchored to .cases[0] would pass all of them.
+n=$(row_count "$FIX/mixed.json" || true)
+if [ "$n" = "2" ]; then
+  ok "a two-case result prints two TSV rows"
+else
+  bad "a two-case result prints two TSV rows (got: ${n:-<empty>})"
+fi
+
+got=$(verdict_at "$FIX/mixed.json" 1 || true)
+if [ "$got" = "DISCRIMINATING" ]; then
+  ok "multi-case row 1 classifies DISCRIMINATING"
+else
+  bad "multi-case row 1 classifies DISCRIMINATING (got: ${got:-<empty>})"
+fi
+
+# The row that matters: a BROKEN case sitting BEHIND a healthy one. This is the
+# mixed result the taxonomy is built for and the one a .cases[0] gate misses.
+got=$(verdict_at "$FIX/mixed.json" 2 || true)
+if [ "$got" = "BROKEN" ]; then
+  ok "multi-case row 2 classifies BROKEN"
+else
+  bad "multi-case row 2 classifies BROKEN (got: ${got:-<empty>})"
+fi
+
+set +e
+/bin/bash "$SCRIPT" --classify "$FIX/mixed.json" --gate strict >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 4 ]; then
+  ok "strict gate counts a BROKEN case behind a passing one"
+else
+  bad "strict gate counts a BROKEN case behind a passing one (got rc=$rc)"
+fi
+
+# BROKEN fails in BOTH modes — report downgrades NO_GAP/PARTIAL, never a dead run.
+set +e
+/bin/bash "$SCRIPT" --classify "$FIX/mixed.json" --gate report >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 4 ]; then
+  ok "report gate still fails on a BROKEN case"
+else
+  bad "report gate still fails on a BROKEN case (got rc=$rc)"
 fi
 
 # Zero cases must abort. An empty .cases[] prints nothing and gates green,
@@ -155,9 +307,10 @@ else
 fi
 
 # Malformed JSON must report as malformed, not as schema drift.
-printf 'not json at all\n' > "$FIX/../badjson.json"
+BADJSON=$(new_tmp)
+printf 'not json at all\n' > "$BADJSON/badjson.json"
 set +e
-err=$(/bin/bash "$SCRIPT" --classify "$FIX/../badjson.json" 2>&1)
+err=$(/bin/bash "$SCRIPT" --classify "$BADJSON/badjson.json" 2>&1)
 rc=$?
 set -e
 if [ "$rc" -eq 65 ] && printf '%s' "$err" | grep -q 'not valid JSON'; then
@@ -165,7 +318,6 @@ if [ "$rc" -eq 65 ] && printf '%s' "$err" | grep -q 'not valid JSON'; then
 else
   bad "malformed JSON reports as invalid (exit 65) (got rc=$rc: $err)"
 fi
-rm -f "$FIX/../badjson.json"
 
 # An unknown gate name must abort, not silently fall through to permissive.
 # Require the gate-validation MESSAGE, not just rc 64 — before --classify
@@ -181,7 +333,7 @@ else
   bad "unknown --gate value aborts (exit 64) (got rc=$rc: ${err:-<empty>})"
 fi
 
-D=$(mktemp -d)
+D=$(new_tmp)
 mkdir -p "$D/plugins/demo/evals/alpha"
 cat > "$D/plugins/demo/evals/alpha/case.yaml" <<'YAML'
 schema_version: "1.1"
@@ -218,10 +370,23 @@ else
   bad "output-dir stays outside plugins/ (got: $cmd)"
 fi
 
+# The CLI's --allow-tools is VARIADIC (`<tools...>`): each tool must be its own
+# argv element. Forwarding the operator's raw "Bash,Write" as one element hands
+# the CLI a tool name matching nothing, every gated call is denied in BOTH
+# arms, and the run comes back 0.00/0.00 — the very outcome the guard exists to
+# prevent, produced by the guard's own runner. Assert on the rendered command
+# the operator is invited to copy.
+cmd=$(cd "$D" && /bin/bash "$SCRIPT" --plugin demo --allow-tools Bash,Write --dry-run 2>&1) || true
+if printf '%s' "$cmd" | grep -q -- '--allow-tools Bash Write' \
+   && ! printf '%s' "$cmd" | grep -q 'Bash,Write'; then
+  ok "dry-run splits a multi-tool grant into separate arguments"
+else
+  bad "dry-run splits a multi-tool grant into separate arguments (got: $cmd)"
+fi
+
 # A case declaring a gated tool absent from the grant must abort loudly,
 # rather than scoring both arms 0.00 and reading as "no gap".
-mkdir -p "$D/plugins/demo/evals/needswrite"
-cat > "$D/plugins/demo/evals/needswrite/case.yaml" <<'YAML'
+NEEDS=$(mk_case_tree needswrite <<'YAML'
 schema_version: "1.1"
 name: needswrite
 execution:
@@ -232,20 +397,29 @@ graders:
     name: g
     pattern: hi
 YAML
-set +e
-(cd "$D" && /bin/bash "$SCRIPT" --plugin demo --allow-tools Bash --dry-run >/dev/null 2>&1)
-rc=$?
-set -e
+)
+rc=$(guard_rc "$NEEDS" --plugin demo --allow-tools Bash)
 if [ "$rc" -eq 7 ]; then
   ok "ungranted gated tool aborts (exit 7)"
 else
   bad "ungranted gated tool aborts (exit 7) (got rc=$rc)"
 fi
 
+# ...and the SAME case with the tool granted must run. Without this control the
+# assertion above cannot tell "guard fired for the right reason" from "guard
+# fires on everything", and a multi-tool grant is exactly what it must accept.
+rc=$(guard_rc "$NEEDS" --plugin demo --allow-tools Bash,Write)
+if [ "$rc" -eq 0 ]; then
+  ok "a granted multi-tool case is not blocked by the guard"
+else
+  bad "a granted multi-tool case is not blocked by the guard (got rc=$rc)"
+fi
+
 # Block-style YAML must be caught too — it is the layout `eval init` writes,
 # so a flow-only guard is blind to precisely the cases it exists to protect.
-mkdir -p "$D/plugins/demo/evals/blockstyle"
-cat > "$D/plugins/demo/evals/blockstyle/case.yaml" <<'YAML'
+# Its OWN tree: with a flow-form case left on disk this assertion passes with
+# the block parser deleted outright (verified by ablation).
+BLOCK=$(mk_case_tree blockstyle <<'YAML'
 schema_version: "1.1"
 name: blockstyle
 execution:
@@ -258,23 +432,220 @@ graders:
     name: g
     pattern: hi
 YAML
-set +e
-(cd "$D" && /bin/bash "$SCRIPT" --plugin demo --allow-tools Bash --dry-run >/dev/null 2>&1)
-rc=$?
-set -e
+)
+rc=$(guard_rc "$BLOCK" --plugin demo --allow-tools Bash)
 if [ "$rc" -eq 7 ]; then
   ok "block-style allowed_tools caught by guard"
 else
   bad "block-style allowed_tools caught by guard (got rc=$rc)"
 fi
-rm -rf "$D/plugins/demo/evals/blockstyle" "$D/plugins/demo/evals/needswrite"
+
+# A YAML comment inside the block list must not truncate it. A comment as the
+# FIRST entry yields zero tools and disables the guard completely; the range
+# end pattern that stops at "not a - item" matches "#" too.
+BLOCKC=$(mk_case_tree blockcomment <<'YAML'
+schema_version: "1.1"
+name: blockcomment
+execution:
+  prompt: hello
+  allowed_tools:
+    # the grader shells out
+    - Bash
+    - Write
+graders:
+  - type: regex
+    name: g
+    pattern: hi
+YAML
+)
+rc=$(guard_rc "$BLOCKC" --plugin demo --allow-tools Bash)
+if [ "$rc" -eq 7 ]; then
+  ok "comment-first block list still yields its tools"
+else
+  bad "comment-first block list still yields its tools (got rc=$rc)"
+fi
+
+# Comment MID-list: extraction stops there, so everything after it is dropped.
+BLOCKM=$(mk_case_tree blockmid <<'YAML'
+schema_version: "1.1"
+name: blockmid
+execution:
+  prompt: hello
+  allowed_tools:
+    - Bash
+    # the grader also writes a file
+    - Write
+graders:
+  - type: regex
+    name: g
+    pattern: hi
+YAML
+)
+rc=$(guard_rc "$BLOCKM" --plugin demo --allow-tools Bash)
+if [ "$rc" -eq 7 ]; then
+  ok "mid-list comment does not truncate the tool list"
+else
+  bad "mid-list comment does not truncate the tool list (got rc=$rc)"
+fi
+
+# Single-quoted YAML scalars are valid and common. Stripping only double quotes
+# leaves 'Write' unmatched by the gated-tool arm and the guard passes silently.
+QUOTED=$(mk_case_tree quoted <<'YAML'
+schema_version: "1.1"
+name: quoted
+execution:
+  prompt: hello
+  allowed_tools: ['Bash', 'Write']
+graders:
+  - type: regex
+    name: g
+    pattern: hi
+YAML
+)
+rc=$(guard_rc "$QUOTED" --plugin demo --allow-tools Bash)
+if [ "$rc" -eq 7 ]; then
+  ok "single-quoted tool names are caught by the guard"
+else
+  bad "single-quoted tool names are caught by the guard (got rc=$rc)"
+fi
+
+# The mirror hazard: an unanchored match on `allowed_tools:` also matches a
+# `disallowed_tools:` companion key, so the guard demands the very tool the
+# case is trying to DENY. The operator's only way past is to grant it.
+DENY=$(mk_case_tree denies <<'YAML'
+schema_version: "1.1"
+name: denies
+execution:
+  prompt: hello
+  disallowed_tools: [Write]
+  allowed_tools: [Bash]
+graders:
+  - type: regex
+    name: g
+    pattern: hi
+YAML
+)
+rc=$(guard_rc "$DENY" --plugin demo --allow-tools Bash)
+if [ "$rc" -eq 0 ]; then
+  ok "disallowed_tools is not read as a declaration"
+else
+  bad "disallowed_tools is not read as a declaration (got rc=$rc)"
+fi
+
+# The bare layout declares allowed_tools in prompt.md frontmatter (verified
+# against the CLI's own frontmatter key set). Discovery was widened to find
+# these cases; a guard that requires case.yaml is blind to every one of them.
+BARE=$(new_tmp)
+mkdir -p "$BARE/plugins/demo/.claude-plugin" "$BARE/plugins/demo/evals/bare/graders"
+printf '{"name":"demo","description":"d","version":"0.0.1"}\n' \
+  > "$BARE/plugins/demo/.claude-plugin/plugin.json"
+cat > "$BARE/plugins/demo/evals/bare/prompt.md" <<'MD'
+---
+name: bare
+allowed_tools: [Bash, Write]
+---
+Write a file and tell me what happened.
+MD
+cat > "$BARE/plugins/demo/evals/bare/graders/g.md" <<'MD'
+---
+type: regex
+pattern: hi
+---
+MD
+rc=$(guard_rc "$BARE" --plugin demo --allow-tools Bash)
+if [ "$rc" -eq 7 ]; then
+  ok "prompt.md-layout case is inspected by the guard"
+else
+  bad "prompt.md-layout case is inspected by the guard (got rc=$rc)"
+fi
+
+rc=$(guard_rc "$BARE" --plugin demo --allow-tools Bash,Write)
+if [ "$rc" -eq 0 ]; then
+  ok "granted prompt.md-layout case runs"
+else
+  bad "granted prompt.md-layout case runs (got rc=$rc)"
+fi
+
+# An eval case path containing a space word-splits an unquoted `for` over the
+# discovered list into fragments, none of which holds a case.yaml, so the guard
+# inspects NOTHING and the run proceeds ungranted.
+SPACED=$(new_tmp)
+mkdir -p "$SPACED/plugins/my plugin/.claude-plugin" "$SPACED/plugins/my plugin/evals/space case"
+printf '{"name":"my plugin","description":"d","version":"0.0.1"}\n' \
+  > "$SPACED/plugins/my plugin/.claude-plugin/plugin.json"
+cat > "$SPACED/plugins/my plugin/evals/space case/case.yaml" <<'YAML'
+schema_version: "1.1"
+name: space case
+execution:
+  prompt: hello
+  allowed_tools: [Bash, Write]
+graders:
+  - type: regex
+    name: g
+    pattern: hi
+YAML
+rc=$(guard_rc "$SPACED" --allow-tools Bash)
+if [ "$rc" -eq 7 ]; then
+  ok "a case path containing a space still reaches the guard"
+else
+  bad "a case path containing a space still reaches the guard (got rc=$rc)"
+fi
+
+# --case is globbed by the CLI against the case's `name:` field, not the
+# directory basename (verified against 2.1.220). Scoping on the basename lets
+# the two sets go disjoint: the guard inspects nothing, the CLI runs the case
+# ungranted, and both arms come back 0.00.
+NAMED=$(mk_case_tree needswrite <<'YAML'
+schema_version: "1.1"
+name: alpha-outcome
+execution:
+  prompt: hello
+  allowed_tools: [Bash, Write]
+graders:
+  - type: regex
+    name: g
+    pattern: hi
+YAML
+)
+rc=$(guard_rc "$NAMED" --plugin demo --case alpha-outcome --allow-tools Bash)
+if [ "$rc" -eq 7 ]; then
+  ok "--case scopes on the case name the CLI matches"
+else
+  bad "--case scopes on the case name the CLI matches (got rc=$rc)"
+fi
+
+# The mirror: a --case that matches the DIRECTORY but no case name selects
+# nothing in the CLI. Refusing to spend is right; exit 7 is the wrong reason,
+# and it names a tool grant that would not have mattered.
+rc=$(guard_rc "$NAMED" --plugin demo --case needswrite --allow-tools Bash)
+if [ "$rc" -eq 3 ]; then
+  ok "--case matching only a directory name aborts as scoped-to-nothing"
+else
+  bad "--case matching only a directory name aborts as scoped-to-nothing (got rc=$rc)"
+fi
+
+# Scoped to nothing is the #82 disease one level in: indistinguishable from
+# guarded-and-clean, and the paid run that follows measures nothing.
+rc=$(guard_rc "$NAMED" --plugin demo --case nosuchcase --allow-tools Bash)
+if [ "$rc" -eq 3 ]; then
+  ok "a --case glob matching nothing aborts (exit 3)"
+else
+  bad "a --case glob matching nothing aborts (exit 3) (got rc=$rc)"
+fi
+
+rc=$(guard_rc "$NAMED" --plugin nosuchplugin --allow-tools Bash)
+if [ "$rc" -eq 3 ]; then
+  ok "a --plugin matching nothing aborts (exit 3)"
+else
+  bad "a --plugin matching nothing aborts (exit 3) (got rc=$rc)"
+fi
 
 # --- LIVE PATH via a stub `claude` on PATH ---
 # Every exit-code test above goes through --classify directly. Without a live
 # test, `set -e` killing the runner before classify() is invisible — a green
 # suite that cannot fail, which is the exact disease this project exists to
 # prevent. These stubs cost nothing and cover the real invocation path.
-STUB=$(mktemp -d)
+STUB=$(new_tmp)
 mkdir -p "$STUB/bin"
 cat > "$STUB/bin/claude" <<'STUBEOF'
 #!/usr/bin/env bash
@@ -283,21 +654,32 @@ cat > "$STUB/bin/claude" <<'STUBEOF'
 # table to STDOUT (verified live on 2.1.220) — the stub must too, or the
 # stdout-purity test below can only pass vacuously.
 printf 'CASE  WITH  W/OUT (stub table noise)\n'
+# Record argv ONE ELEMENT PER LINE. This file is also the "the CLI was
+# invoked" sentinel: no file means no spend.
+if [ -n "${STUB_ARGV_FILE:-}" ]; then
+  : > "$STUB_ARGV_FILE"
+  for a in "$@"; do printf '%s\n' "$a" >> "$STUB_ARGV_FILE"; done
+fi
 outdir=""
 prev=""
 for a in "$@"; do
   [ "$prev" = "--output-dir" ] && outdir="$a"
   prev="$a"
 done
-mkdir -p "$outdir"
 case "${STUB_MODE:-ok}" in
   threshold)
+    mkdir -p "$outdir"
     printf '{"schema_version":"1.0","partial":false,"cases":[{"name":"c","score":0.5,"score_without":0,"delta":0.5}]}\n' > "$outdir/aggregate-result.json"
     exit 1 ;;
   maxcost)
+    mkdir -p "$outdir"
     printf '{"schema_version":"1.0","partial":true,"cases":[{"name":"c","score":1,"score_without":0,"delta":1}]}\n' > "$outdir/aggregate-result.json"
     exit 2 ;;
+  nooutput)
+    # Zero loadable cases: the CLI writes no result at all and exits 0.
+    exit 0 ;;
   *)
+    mkdir -p "$outdir"
     printf '{"schema_version":"1.0","partial":false,"cases":[{"name":"c","score":1,"score_without":0,"delta":1}]}\n' > "$outdir/aggregate-result.json"
     exit 0 ;;
 esac
@@ -322,6 +704,18 @@ else
   bad "assembles --threshold 0 (got: $cmd)"
 fi
 
+# The rendered dry-run is a proxy; this is the argv the CLI actually receives.
+ARGV="$STUB/argv.txt"
+rm -f "$ARGV"
+(cd "$D" && PATH="$STUB/bin:$PATH" STUB_ARGV_FILE="$ARGV" \
+  /bin/bash "$SCRIPT" --plugin demo --allow-tools Bash,Write >/dev/null 2>&1) || true
+if [ -f "$ARGV" ] && grep -qx 'Bash' "$ARGV" && grep -qx 'Write' "$ARGV" \
+   && ! grep -q ',' "$ARGV"; then
+  ok "each granted tool reaches the CLI as its own argv element"
+else
+  bad "each granted tool reaches the CLI as its own argv element (got: $( (cat "$ARGV" 2>/dev/null || printf '<no argv>') | tr '\n' ' '))"
+fi
+
 # A budget breach is CLI exit 2; .partial must still reach classify as exit 6.
 set +e
 (cd "$D" && PATH="$STUB/bin:$PATH" STUB_MODE=maxcost \
@@ -332,6 +726,36 @@ if [ "$rc" -eq 6 ]; then
   ok "budget breach reaches the .partial tripwire (exit 6)"
 else
   bad "budget breach reaches the .partial tripwire (exit 6) (got rc=$rc)"
+fi
+
+# The CLI writes no result directory when it loads zero cases. `find` then
+# fails under set -e and the runner dies at exit 1 with a bare `find:` message,
+# never reaching classify() and never naming what went wrong.
+set +e
+err=$(cd "$D" && PATH="$STUB/bin:$PATH" STUB_MODE=nooutput \
+  /bin/bash "$SCRIPT" --plugin demo 2>&1 >/dev/null)
+rc=$?
+set -e
+if [ "$rc" -eq 3 ] && printf '%s' "$err" | grep -q 'aggregate-result.json'; then
+  ok "a run that writes no result aborts with a diagnosis (exit 3)"
+else
+  bad "a run that writes no result aborts with a diagnosis (exit 3) (got rc=$rc: ${err:-<empty>})"
+fi
+
+# A bad --gate must be rejected BEFORE the CLI is invoked. Validating it inside
+# classify() means the typo is caught only after the whole paid run finished:
+# the operator pays in full, gets no gate, and exits 64 anyway. rc alone cannot
+# see the difference — the sentinel is whether the CLI ran at all.
+rm -f "$ARGV"
+set +e
+(cd "$D" && PATH="$STUB/bin:$PATH" STUB_ARGV_FILE="$ARGV" \
+  /bin/bash "$SCRIPT" --plugin demo --gate strcit >/dev/null 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 64 ] && [ ! -f "$ARGV" ]; then
+  ok "a bad --gate is rejected before the CLI is invoked"
+else
+  bad "a bad --gate is rejected before the CLI is invoked (got rc=$rc, cli invoked: $([ -f "$ARGV" ] && printf yes || printf no))"
 fi
 
 # stdout must be pure TSV — Task 7 pipes it to a file. The stub prints a fake

--- a/.github/tests/test-run-evals.sh
+++ b/.github/tests/test-run-evals.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/../scripts" && pwd)/run-evals.sh"
+PASS=0
+FAIL=0
+
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+# --- discovery: finds case.yaml ---
+T=$(mktemp -d)
+mkdir -p "$T/plugins/demo/evals/alpha"
+touch "$T/plugins/demo/evals/alpha/case.yaml"
+out=$(cd "$T" && /bin/bash "$SCRIPT" --discover-only 2>&1) || true
+if printf '%s' "$out" | grep -q 'plugins/demo/evals/alpha'; then
+  ok "discovers case.yaml"
+else
+  bad "discovers case.yaml (got: $out)"
+fi
+
+# --- discovery: ALSO finds prompt.md (the format `eval init --bare` writes) ---
+mkdir -p "$T/plugins/demo/evals/beta/graders"
+touch "$T/plugins/demo/evals/beta/prompt.md"
+out=$(cd "$T" && /bin/bash "$SCRIPT" --discover-only 2>&1) || true
+if printf '%s' "$out" | grep -q 'plugins/demo/evals/beta'; then
+  ok "discovers prompt.md format"
+else
+  bad "discovers prompt.md format (got: $out)"
+fi
+
+# --- zero matches must ABORT, not silently pass (#82) ---
+E=$(mktemp -d)
+mkdir -p "$E/plugins/empty"
+set +e
+(cd "$E" && /bin/bash "$SCRIPT" --discover-only >/dev/null 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 3 ]; then
+  ok "zero matches aborts with exit 3"
+else
+  bad "zero matches aborts with exit 3 (got rc=$rc)"
+fi
+
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+test "$FAIL" -eq 0

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .jj/
 node_modules/
 *.log
+**/evals/results/

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Layer 2 is the gate. The eval suite gates nothing — it is a measurement instru
 /bin/bash .github/scripts/run-evals.sh --plugin commit-commands-jj --runs 2
 ```
 
-Run from the repo root. Useful flags: `--case <glob>` scopes to one case, `--gate report` downgrades `NO_GAP`/`PARTIAL` from failures to findings, `--max-cost-usd` caps spend (default `5`), `--keep-temp` keeps the sandboxes. Verdict rows go to stdout as TSV; everything else, including the result-JSON path, goes to stderr.
+Run from the repo root — running elsewhere exits 3 rather than dying on a stray `find` error. Useful flags: `--case <glob>` scopes to one case, matched against the case's `name:` field exactly as the CLI matches it (a case that declares no name defaults to its directory basename); `--gate report` downgrades `NO_GAP`/`PARTIAL` from failures to findings; `--max-cost-usd` caps spend (default `5`); `--keep-temp` keeps the sandboxes. `--allow-tools` accepts a comma- or space-separated list and forwards each tool separately. A `--plugin`/`--case` combination that selects no case exits 3: scoped-to-nothing is not a clean run. Verdict rows go to stdout as TSV; everything else, including the result-JSON path, goes to stderr.
 
 ### Manual by design — not wired into CI
 
@@ -175,7 +175,9 @@ The runner emits one TSV row per case — `name / score / score_without / delta 
 | `REGRESSION` | Δ < 0 | the plugin made things worse. Fails in both gate modes |
 | `BROKEN` | both arms scored 0.00 | **the harness failed, not the plugin** |
 
-> **`BROKEN` never means "no gap".** Both arms scoring zero is the signature of a case that could not run at all — nearly always a **gated tool the case declares that `--allow-tools` does not grant**, leaving the agent unable to call it in either arm. Misread as "no difference between the arms", it deletes the best case in the suite. The runner also checks this before spending and exits 7. Other non-zero exits: 3 nothing measured, 4 gate failure, 5 result-schema drift, 6 budget-truncated run, 64 bad argument, 65 missing or malformed result file.
+Δ comparisons carry a 1e-9 tolerance. The CLI computes the delta by subtraction, so a case scoring 7/10 with and 2/10 without arrives as `0.49999999999999994`; without the tolerance a textbook shipping case at exactly the threshold is filed `PARTIAL` and fails CI.
+
+> **`BROKEN` never means "no gap".** Both arms scoring zero is the signature of a case that could not run at all — nearly always a **gated tool the case declares that `--allow-tools` does not grant**, leaving the agent unable to call it in either arm. Misread as "no difference between the arms", it deletes the best case in the suite. The runner also checks this before spending and exits 7 — for both case layouts, both YAML forms, and whatever `--case` actually selects. Other non-zero exits: 3 nothing measured (no cases discovered, none selected, or none returned), 4 gate failure, 5 result-schema drift, 6 budget-truncated run, 64 bad argument or bad `--gate` (rejected before spending), 65 missing or malformed result file.
 
 ### Measured results
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,60 @@ Or browse available plugins:
 
 **Note:** After installing workspace-jj, run `/workspace-setup` in your jj project and restart Claude Code.
 
+## Evals
+
+Two verification layers cover this repo, doing different jobs:
+
+| Layer | Question it answers | Where | Gating |
+|---|---|---|---|
+| 1 — evals | Does a plugin change what the **model** does? | `plugins/<name>/evals/<case>/` | none — run by hand |
+| 2 — shell tests | Do the **scripts** behave? | `plugins/<name>/tests/test-*.sh`, `.github/tests/` | CI, every push |
+
+Layer 2 is the gate. The eval suite gates nothing — it is a measurement instrument, run deliberately, to answer what a deterministic test cannot: whether the prose and hooks a plugin ships actually move model behaviour. Each case runs under `--ablation with-without` (plugin loaded vs. not), and the **delta between the two arms is the result**. A case whose arms score the same measured nothing, however green it looks.
+
+### Running it
+
+```bash
+# free — list the cases that would run, and print the CLI invocation
+/bin/bash .github/scripts/run-evals.sh --discover-only
+/bin/bash .github/scripts/run-evals.sh --plugin commit-commands-jj --dry-run
+
+# paid — actually run them (spends model tokens; see below)
+/bin/bash .github/scripts/run-evals.sh --plugin commit-commands-jj --runs 2
+```
+
+Run from the repo root. Useful flags: `--case <glob>` scopes to one case, `--gate report` downgrades `NO_GAP`/`PARTIAL` from failures to findings, `--max-cost-usd` caps spend (default `5`), `--keep-temp` keeps the sandboxes. Verdict rows go to stdout as TSV; everything else, including the result-JSON path, goes to stderr.
+
+### Manual by design — not wired into CI
+
+Three independent reasons, any one of which is sufficient:
+
+- **Early access.** `claude plugin eval` sits behind `CLAUDE_CODE_WALNUT_SPIRE=1`, which the runner sets on every invocation. That requirement was measured on CLI **2.1.216**; by **2.1.220**, `plugin eval --help` exits 0 with the variable unset. Setting it stays harmless either way, so the runner keeps doing so — but **no logic may treat "exits 1 without the variable" as gate detection.** That signal has already drifted once.
+- **Model spend.** Every run costs real money — per case, per arm, per run. Tranche 1 cost $3.77 in total. A per-push CI job would bill this repo for every typo fix.
+- **No entitlement guarantee on runners.** Nothing guarantees a CI runner can obtain the same early-access entitlement the local operator has, and the suites are macOS/bash 3.2 to begin with.
+
+### Verdicts
+
+The runner emits one TSV row per case — `name / score / score_without / delta / verdict`:
+
+| Verdict | Condition | Means |
+|---|---|---|
+| `DISCRIMINATING` | Δ ≥ 0.5 | the plugin measurably changes behaviour; the case earns its keep |
+| `PARTIAL` | 0 < Δ < 0.5 | some effect — check attribution grader-by-grader before believing it |
+| `NO_GAP` | Δ = 0 | both arms did equally well: the **case** cannot discriminate. Move the assertion to layer 2 |
+| `REGRESSION` | Δ < 0 | the plugin made things worse. Fails in both gate modes |
+| `BROKEN` | both arms scored 0.00 | **the harness failed, not the plugin** |
+
+> **`BROKEN` never means "no gap".** Both arms scoring zero is the signature of a case that could not run at all — nearly always a **gated tool the case declares that `--allow-tools` does not grant**, leaving the agent unable to call it in either arm. Misread as "no difference between the arms", it deletes the best case in the suite. The runner also checks this before spending and exits 7. Other non-zero exits: 3 nothing measured, 4 gate failure, 5 result-schema drift, 6 budget-truncated run, 64 bad argument, 65 missing or malformed result file.
+
+### Measured results
+
+Tranche 1 (issue #79) is written up in **[docs/eval-triage-2026-07.md](docs/eval-triage-2026-07.md)** — what shipped, what was cut and why, and three runner gaps found but left unfixed. Two cases ship today, both under `plugins/commit-commands-jj/evals/`, both at Δ +1.00. **Both exercise the same branch** of `block-raw-git.sh`: the second case's name promises the git-internals branch but its prompt never reaches it (§1.1). A third case measured Δ 0.00 and was cut; its assertions now live in `plugins/commit-commands-jj/tests/test-block-raw-git-gating.sh`, where they are deterministic and free.
+
+Read the triage document before authoring a case. Its §3 is the prompting-and-grading recipe that was measured to work; its §2 is three separate mechanisms that make a case report green while measuring nothing.
+
+Failure taxonomy informed by netresearch/jujutsu-workflow-skill (MIT AND CC-BY-SA-4.0); cases independently authored.
+
 ## Relationship to claude-plugins-official
 
 This repo started as a fork of Anthropic's [claude-plugins-official](https://github.com/anthropics/claude-plugins-official) and has evolved through two phases:

--- a/docs/eval-triage-2026-07.md
+++ b/docs/eval-triage-2026-07.md
@@ -496,7 +496,7 @@ three were left unfixed at the time and are recorded here so they are not lost.
 **Gap C has since been closed** (see below); Gaps A and B remain open.
 
 **Gap A — `SlashCommand` is missing from the exit-7 guard's gated list.**
-The guard (`.github/scripts/run-evals.sh:179`) matches
+The guard (`.github/scripts/run-evals.sh:351`) matches
 `Bash|Write|Edit|WebFetch|mcp__*`. A case declaring `SlashCommand` in
 `allowed_tools` passes the guard clean while the CLI denies the tool at runtime:
 `cmd-describe: denied tools (pass --allow-tools to grant): SlashCommand`. The
@@ -512,7 +512,7 @@ requirement that every case carry at least one positive outcome grader.
 **Gap C — zero loadable cases kills the runner on `find` before `classify()`.**
 When the CLI loads 0 cases it writes no output directory, so
 `RESULT="$(find "$OUT_DIR" -name aggregate-result.json | head -1)"`
-(`run-evals.sh:230`) fails and `set -e` kills the script at that line. The
+(`run-evals.sh:419`) fails and `set -e` kills the script at that line. The
 operator sees a bare `find: … No such file or directory` and exit 1 instead of a
 diagnostic naming the load failures, and `classify()` never runs. Any workflow
 that depends on the `result JSON:` line printed two lines later inherits this.

--- a/docs/eval-triage-2026-07.md
+++ b/docs/eval-triage-2026-07.md
@@ -1,0 +1,561 @@
+# Eval triage — 2026-07 (issue #79, tranche 1)
+
+Date: 2026-07-26
+Issue: #79 — "~20 user-facing commands have never been executed"
+Spec: `docs/specs/2026-07-20-eval-suite-design.md`
+Plan: `docs/plans/2026-07-20-eval-suite-plan.md`
+Status: tranche 1 measurement complete; Task 8 (documentation, issue filing,
+final verification) still open
+
+**This is a map, not a prune list. No command is proposed for deletion.**
+See §5 before reading any number here as a recommendation.
+
+---
+
+## What this document is
+
+The spec planned two deliverables for tranche 1: **Part B**, a handful of hook
+and invariant eval cases, and **Part A**, a 16-command ablation sweep producing
+a triage table.
+
+Part B shipped. **Part A did not, and the reason is the result.** Three
+probes — costing $1.63 rather than the $7 the sweep was budgeted — refuted
+Part A's design at the mechanism level, one measurement at a time. The sweep was
+never run and the 16 generated cases were removed before landing.
+
+So this document is not the triage table. It is the record of what was actually
+measured: the deltas Part B earned, the three separate mechanisms that killed
+Part A's design, and the prompting-and-grading methodology the probes proved
+works, handed to tranche 2 in a state it can pick up directly.
+
+A triage table built on the refuted mechanism would have been sixteen rows of
+noise reported as data. That is precisely the failure the spec was written to
+prevent ("a green suite that cannot fail is worse than no suite, because it
+terminates the inquiry"). Catching it at $1.63 instead of publishing it at $7 is
+the tranche working as designed.
+
+---
+
+## 1. What tranche 1 measured
+
+### 1.1 Part B — three ablation-checked cases
+
+All three were run with `--ablation with-without` at `runs: 2` per arm.
+
+| Case | with | without | Δ | pass (with) | pass (without) | Verdict | Outcome |
+|---|---|---|---|---|---|---|---|
+| `hook-blocks-raw-git` | 1.00 | 0.00 | **+1.00** | 2/2 | 0/2 | DISCRIMINATING | **shipped** |
+| `hook-blocks-git-internals` \* | 1.00 | 0.00 | **+1.00** | 2/2 | 0/2 | DISCRIMINATING | **shipped** |
+| `hook-allows-jj-git-and-gh` | 1.00 | 1.00 | **0.00** | 2/2 | 2/2 | NO_GAP | **cut → layer 2** |
+
+> **\* `hook-blocks-git-internals` is misnamed, and these are not two branches
+> of coverage. Both shipped cases measure the same branch.**
+> Its prompt is `git rev-parse HEAD`. In
+> `plugins/commit-commands-jj/scripts/block-raw-git.sh` the `has_raw_git` test
+> matches any bare `git` token at command position and returns the **raw-git**
+> deny message at line 49 — before the internals branch at line 62 is ever
+> reached. The case's grader regex,
+> `(BLOCKED|blocked|not allowed|denied|internals)`, passes happily on that
+> raw-git message. Verified offline against the hook: the internals branch
+> answers only `.git/` **path** access; both commands the internals regex
+> names (`git config`, `git rev-parse`) are shadowed by the raw-git branch.
+>
+> So the internals branch has **zero eval coverage**. It is reached only by the
+> free layer-2 assertion added in Task 5
+> (`tests/test-block-raw-git-gating.sh:17-23`, which documents the shadowing in
+> a comment). A reader seeing two rows at Δ +1.00 must not conclude two hook
+> branches are covered — one branch is covered twice.
+>
+> This is §6's own lesson landing in this document's own results table: **a
+> grader measures its own assertion, not the case's title.** The case name and
+> `description:` still say "git internals"; correcting them is open work, and
+> the Δ +1.00 itself is real — it is a genuine measurement of the raw-git
+> branch, just not of the branch the name promises.
+
+Per-run detail, from the result JSONs:
+
+- **`hook-blocks-raw-git`** — grader `reports-blocked` (regex, weight 1) passed
+  on both with-arm runs and failed on both without-arm runs. Turns: with 3, 3;
+  without 2, 2. Cost `$0.4536`. `partial: false`.
+- **`hook-blocks-git-internals`** — same single grader, same 2/2 vs 0/2 split.
+  Turns: with 3, 4; without 3, 6. Cost `$0.6828`. `partial: false`. Measures the
+  raw-git branch, per the note above.
+- **`hook-allows-jj-git-and-gh`** — two graders, `jj-git-ran` and `not-blocked`,
+  both passed on all four runs across both arms. Turns: with 7, 5; without 9, 8.
+  Cost `$0.9956`. `partial: false`.
+
+The cut is not a failure of the hook; it is a failure of the *case*. The
+assertion is the **absence** of a deny, and the ablation's `without` arm has no
+hook to produce a deny either — so both arms pass whether or not the negative
+lookahead in the raw-git regex works. The case was structurally incapable of
+distinguishing "correctly passed through" from "no hook at all". The spec had
+already reached that conclusion analytically for the #45 pass-through invariant
+and routed it to layer 2 before spending; `hook-allows-jj-git-and-gh` reached
+the same place empirically, for the same reason, at $0.9956.
+
+Both sets of assertions now live in
+`plugins/commit-commands-jj/tests/test-block-raw-git-gating.sh`, where the hook
+is exercised as the pure stdin/stdout function it is — deterministically, for
+free, and inside CI's test glob. That suite reports **5 passed, 0 failed**.
+
+### 1.2 Part A — three probes, no sweep
+
+| Probe | Prompt form | runs/arm | with | without | Δ | Reported verdict |
+|---|---|---|---|---|---|---|
+| **P2 run A** | literal `/describe …` | 1 | 0.50 | 0.50 | 0.00 | NO_GAP |
+| **P2 run B** | literal `/commit-commands-jj:describe …` | 1 | 1.00 | 0.50 | +0.50 | DISCRIMINATING |
+| **P3** | natural language, no command named | 3 | 0.83 | 0.50 | +0.33 | PARTIAL |
+
+Both P2 verdicts are artifacts, for reasons §2 dissects. P3 is a real
+measurement and is read in §4.
+
+Turn counts are the tell, and they are the single most useful column in this
+table:
+
+| Probe | with turns | without turns |
+|---|---|---|
+| P2 run A | 0 | 0 |
+| P2 run B | 2 | 0 |
+| P3 | 6, 6, 6 | 6, 5, 8 |
+
+In P2 run A **neither arm executed a single turn**, and the harness reported the
+case green. In P2 run B only the with arm ran. Only under P3's natural-language
+prompt did both arms actually do work.
+
+### 1.3 Spend
+
+| Artifact | What | Cost |
+|---|---|---|
+| `eval-results-95904` | `hook-blocks-raw-git` | $0.4536 |
+| `eval-results-17927` | `hook-blocks-git-internals` | $0.6828 |
+| `eval-results-21782` | `hook-allows-jj-git-and-gh` | $0.9956 |
+| `eval-results-20375` | P2 run A | $0.0093 |
+| `eval-results-21686` | P2 run B | $0.1087 |
+| `eval-results-27873` | P3 | $1.5150 |
+| | **total** | **$3.77** |
+
+Summing the six `cost_usd` fields gives `$3.7651`. The ledger's per-task figures
+round to the same total. The one further run reported at `$0.00` is the **schema
+pre-check** — a prompt-stripped copy of the case, run first so that any grader
+error surfaces at validation for free; it aborts before the paid path and never
+writes an aggregate, which is why it has no result JSON and is not in this table.
+
+Task 6 — the entire Part A investigation — cost **$1.63** against a $7 sweep
+budget (the three retained JSONs sum to `$1.6331`; the SDD ledger records $1.64,
+which is the same spend rounded per-run), and every blocking finding except the
+schema rejection was reached by spending. The schema rejection (§2.1) was proved at **$0.00**, by a controlled
+pair of throwaway cases that could never reach the paid path.
+
+---
+
+## 2. Why Part A did not ship: three separately-measured mechanism failures
+
+These are three independent defects, each measured on its own. Fixing any one of
+them would have left the other two intact. That matters for tranche 2: the
+temptation is to remember this as "Part A was blocked", and then to re-land it
+after fixing the blocker one remembers.
+
+### 2.1 `weight: 0` is rejected by the case schema — CONFIRMED, $0.00
+
+Part A's design hinged on a *validity precondition*: a `tool_used` grader
+asserting "the command was actually exercised", recorded but not scored. The
+plan implemented "not scored" as `weight: 0`.
+
+The CLI's case schema declares weight as a positive number. All 16 generated
+cases failed validation identically:
+
+```
+graders.0.weight: Number must be greater than 0
+```
+
+Isolated with a controlled experiment: two throwaway cases differing only in
+`weight`, both also missing `execution.prompt` so validation could never reach a
+paid run. The `weight: 0` copy failed on weight; the `weight: 1` copy cleared
+the weight check and failed only on the missing prompt. `weight` was the sole
+offender.
+
+The correct mechanism exists and is a different feature entirely: **`arm:
+with-only`**, which the runner auto-applies to any `tool_used` grader whose
+`tool` is `Skill`. It excludes the grader from the score in *both* arms while
+still recording pass/fail in `runs[].graders[]`. This was confirmed by
+measurement in P2 — the with arm printed `invoked-command [with-only, not
+scored]`, the JSON carried `with_only: true`, and the grader was **absent
+entirely** from `runs_without[].graders[]` (3 graders in the with arm, 2 in the
+without arm). It did not move the score in either direction.
+
+One consequence for anyone reading the old plan: its "column 3 tripwire" — jq
+asserting the precondition never passes in the without arm — becomes vacuous
+under `with-only`, because the grader is filtered out of that arm by
+construction rather than measured there. It is no longer a real check.
+
+### 2.2 A literal `/cmd` prompt records no tool call — and a bare `/cmd` resolves to nothing — MEASURED
+
+Part A's prompts were literal slash-command invocations, on the spec's reasoning
+that slash commands are user-invoked rather than model-invoked, so the eval
+should simulate the user typing one. Two independent things go wrong.
+
+**(a) An expanded slash command is not a tool call.** In P2 run B the with arm
+demonstrably executed the command — the trace shows a `Bash` call running
+`jj describe -m "Add notes.txt"` and a 2-turn successful result — and yet the
+`tool_used` precondition reported `Skill called 0x (expected 1..∞)` and failed.
+A prompt beginning with `/` is expanded client-side into the prompt text; it
+never becomes a tool call, so **no `tool_used` grader can observe it**. The
+precondition Part A's design required is not merely misconfigured, it is
+unobtainable for literally-invoked commands.
+
+*Measured for `Skill` only.* "`SlashCommand` would fail identically" is an
+**inference** from the same client-side-expansion mechanism, not a measurement:
+`Skill` is the only tool that was actually run as the grader's `tool`, and
+`SlashCommand` is denied outright by the CLI in this configuration (§7, Gap A),
+so it could not have been measured without first fixing that.
+
+**(b) Commands are namespaced, so the bare form never resolved at all.** The
+generated prompts used `/describe …`. The with arm's `system/init` line shows
+the plugin loaded correctly and registered the command as
+`commit-commands-jj:describe`. Bare `/describe` does not exist — plugin loaded
+or not. Both arms therefore returned:
+
+```json
+{"num_turns":0,"total_cost_usd":0,"is_error":false,"subtype":"success",
+ "result":"Unknown command: /describe"}
+```
+
+`subtype: "success"`, `is_error: false`, zero turns, and a score reported green.
+Nothing in the harness or the runner flags it. Had the sweep run as planned, all
+16 cases would have produced this — 96 runs of nothing, reported as a clean
+NO_GAP sweep.
+
+### 2.3 A 0-turn arm banks free score from vacuously-passing negative graders — MEASURED
+
+The generated cases' only scored grader was `no-raw-git`: a negative
+`tool_used` at `min: 0, max: 0`, failing if the model shells out to raw git. It
+counts `Bash` calls **filtered by a raw-git pattern**, not all `Bash` calls — so
+its "Bash called 0x" reading means "zero raw-git invocations", and a run making
+several legitimate `Bash` calls still passes it.
+
+A negative grader **passes when nothing happens**. So an arm that took zero
+turns, cost nothing, and produced only the synthetic text `Unknown command: …`
+still scored `0.50` — half marks for not doing the thing it never had a chance
+to do.
+
+That vacuous 0.50 is what manufactured P2 run B's verdict:
+
+| Probe | Arm | turns | `invoked-command` | outcome grader | `no-raw-git` | score |
+|---|---|---|---|---|---|---|
+| P2 run B | with | 2 | fail (not scored) | PASS | PASS | **1.00** |
+| P2 run B | without | 0 | *(filtered out)* | FAIL | PASS (vacuous) | **0.50** |
+
+Δ **+0.50**, printed as **DISCRIMINATING** — the taxonomy's top verdict, the one
+that means "ships". What it actually measured is that a command name resolves in
+one arm and not the other. Sixteen such rows would have been a table of name
+resolution wearing the costume of a behavioural finding.
+
+The same vacuity produced P2 run A's symmetric `0.50 / 0.50 / Δ 0.00 NO_GAP`
+out of two completely dead runs.
+
+**And the spec's guard did not catch it.** The runner classifies both-arms-zero
+as "broken, never no-gap" precisely to catch dead runs. Both arms here scored
+`0.50`, not `0.00`, so the guard never fired. A negative-only grader lifts a dead
+arm off the floor the guard is watching.
+
+### 2.4 The fourth problem, which is a design gap rather than a mechanism
+
+Recorded here because it is what made the first three fatal rather than
+fixable. Once the precondition is correctly unscored — by any mechanism — the
+generated cases had **no outcome grader left**. The only scored grader was a
+negative invariant both arms satisfy whenever the model simply does not reach
+for raw git. All 16 cases would have returned NO_GAP **by construction**,
+independent of whether any command helped.
+
+The CLI's own authoring guidance names this floor: every case needs at least one
+outcome grader, and a `Skill` precondition must never be a case's only grader.
+§3 is the methodology that satisfies it.
+
+---
+
+## 3. The methodology that works — hand-off to tranche 2
+
+P3 was designed to test whether *anything* about Part A was salvageable. The
+mechanism is. Tranche 2 should adopt this recipe as-is.
+
+**The recipe:**
+
+1. **Natural-language prompts.** Describe the task the way a user would. Do not
+   name the command, do not use `/`. P3's prompt was, in full:
+
+   > I just added notes.txt to this repo. The change I'm sitting on still has no
+   > message attached to it, so I can't tell what it is when I look back at the
+   > log later. Please sort that out for me.
+
+   Both arms then genuinely execute, and the model keeps agency over whether to
+   reach for the command — which is the thing worth measuring.
+
+2. **A `tool_used` precondition on `tool: Skill`, `min: 1`, with `arm` left
+   unset.** The runner auto-applies `with-only`. The grader records whether the
+   model invoked a plugin command, and cannot move the score in either arm.
+   Leave `arm` unset; do not set it by hand, and do not try to make it scored.
+
+3. **At least one real outcome grader**, asserting the user-visible effect in the
+   sandbox rather than the presence of a command invocation. P3's was
+   `change-described-not-finalized`: the change ends up with a message referring
+   to the file, and the assistant did not finalize or advance past it.
+
+4. **`runs: 3` per arm.** This is what P3 ran. The spec explicitly rejected
+   `runs: 1`: a single sample per arm yields a delta in {−1, 0, +1} with no
+   confidence attached, and the noise is asymmetric, since a spurious `without`
+   pass reads as the actionable verdict.
+
+5. **Keep `SlashCommand` out of `allowed_tools`.** It buys nothing (§2.2) and the
+   CLI denies it anyway, silently past the runner's guard (§7, Gap A). P3 dropped
+   it. Do leave `Bash` in: the runner's default `--allow-tools Bash` is what
+   satisfies the exit-7 tool-grant guard for a `Bash`-based grader, and a case
+   declaring a gated tool the grant does not cover would otherwise score zeros.
+
+**The measured evidence that it works, all from `eval-results-27873`:**
+
+- **The model invoked the command on 3/3 with-arm runs.** Every with-arm run
+  shows `Skill {'skill': 'commit-commands-jj:describe'}` in the trace, and
+  `invoked-command` passing with `Skill called 1x (expected 1..∞)`. Zero
+  occurrences in the without arm.
+- **This overturns the spec's own premise.** The spec's Part A rewrite was
+  founded on a review measurement that the model "never invokes the commands at
+  all — it goes straight to Bash, with `Skill` and `SlashCommand` both called
+  0×". That does not hold on this harness under a natural-language prompt with a
+  with-only precondition in place. A model-initiated command invocation *does*
+  go through the `Skill` tool and *is* observable.
+- **Both arms ran real turns on every run** — with 6/6/6, without 6/5/8, at
+  $0.23–$0.29 each. The dead-arm artifact of §2.3 is gone.
+- **The precondition was recorded but not scored.** `with_only: true` on all
+  three with-arm runs, and absent from `runs_without[].graders[]` entirely. That
+  it cannot move the score is shown directly by P2 run B, where
+  `invoked-command` **failed** and the with arm still scored a full **1.00**.
+
+One scaffold defect noticed in passing and worth fixing before re-use: P3's
+scaffold wrote `.jjconfig/config.toml` *inside* the work tree, so it appeared as
+a second added file and both arms described "notes.txt and jj config". Harmless
+to the result, but it muddies "what changed". Move scaffold config outside the
+work tree.
+
+---
+
+## 4. The one command actually measured: `describe`
+
+One command out of sixteen has a real ablation number.
+
+**`describe` — with 0.83 / without 0.50 / Δ +0.33 / PARTIAL** (3 runs per arm,
+`eval-results-27873`). Per-arm pass counts: with **2/3**, without **0/3**.
+
+The aggregate is not the finding. The grader-by-grader attribution is:
+
+| Grader | with | without | Contribution to Δ |
+|---|---|---|---|
+| `invoked-command` (with-only) | 3/3 | *(filtered out)* | 0 — never scored |
+| `change-described-not-finalized` (outcome) | **3/3** | **3/3** | **0.00** |
+| `no-raw-git` (negative invariant) | 2/3 | 0/3 | **+0.33** |
+
+**The outcome grader passed 3/3 in both arms.** The 2026 base model, given the
+natural-language prompt and no plugin at all, described the change correctly and
+did not finalize it — unprompted, on every run. On the thing `describe.md`'s
+prose is actually *about*, the measured gap is **zero**.
+
+The entire +0.33 came from `no-raw-git` — a negative `tool_used` grader that
+counts only the **pattern-matching** raw-git `Bash` calls, not all `Bash` calls,
+which is why a run making three or four legitimate `Bash` calls still reports
+"Bash called 0x".
+
+**And the mechanism behind that +0.33 is not the hook blocking anything.** The
+traces are unambiguous:
+
+| P3 with-arm run | `no-raw-git` | did the model reach for git? | did the hook fire? |
+|---|---|---|---|
+| run 1 (`claude-eval-Ty9b0d`) | **PASS** | no | no |
+| run 2 (`claude-eval-TshZtm`) | **FAIL** | yes | **yes** — `BLOCKED: Raw git commands…` |
+| run 3 (`claude-eval-yW9wum`) | **PASS** | no | no |
+
+On the two with-arm runs where the grader passed, the model never issued a git
+command at all, so the hook never fired. On the one run where the hook *did*
+fire, the grader **failed** — because it counts the attempt, not the outcome.
+**Not one with-arm grader pass is attributable to the hook blocking anything.**
+The with-arm advantage comes from the loaded plugin steering the model to jj
+*before* it reached for git; the hook, when it fired, was too late to save the
+grader. In the without arm all 3/3 runs reached for git with no hook present.
+
+Either way the delta belongs to the plugin's raw-git avoidance, not to
+`describe`'s prose — and that is the **hook** invariant `hook-blocks-raw-git`
+already covers at **Δ +1.00**, with a case built for it. A re-landed Part A
+`describe` case would be measuring the hook a second time, through a
+command-shaped hole.
+
+Note also that the with arm was not clean: `no-raw-git` failed there too, on 1 of
+3 runs (2/3, not 3/3) — run 2 above, where the model attempted raw git, was
+blocked, and recovered to `jj describe -m …`. Correct end-to-end behaviour,
+scored as a failure.
+
+**The generalisable lesson, and the most portable thing in this document:**
+
+> An aggregate delta can be carried entirely by a grader that belongs to a
+> different case. Check attribution grader-by-grader before reading a delta as a
+> verdict.
+
+`describe` at Δ +0.33 PARTIAL looks, from the TSV row alone, like a command whose
+prose does modest measurable work. It is not. It is a command whose prose does
+*no* measurable work here, sitting next to a hook that does a great deal, in a
+case that scored them together. A triage table reporting only `with / without /
+Δ / verdict` would have printed the wrong conclusion in a column labelled
+"verdict" — and would have done so for every one of sixteen rows carrying the
+same `no-raw-git` grader.
+
+---
+
+## 5. This is a map, not a prune list
+
+This framing comes from the spec and survives the re-scope unchanged.
+
+`commit-commands-jj` is a jj-native port of `anthropics/claude-plugins-official`'s
+commit-commands; this repo began as a fork of it. The command set exists partly
+to mirror upstream, and **upstream parity is itself a reason to keep a command a
+model could limp through without** — consistency across the two repos, and
+pinning behaviour that could otherwise drift, are values no ablation number can
+see.
+
+Therefore:
+
+- **No command is proposed for deletion.** Not `describe`, not any of the other
+  fifteen. Nothing in this document licenses removing anything.
+- A low delta means *"the prose adds little measurable behaviour on this prompt,
+  under this grader, at this sample size"*. It is information about **where
+  tranche-2 test effort belongs**. It is not evidence about a command's value,
+  and it is certainly not grounds for deletion.
+- The single measured command is measured at Δ +0.33 with **zero** of that delta
+  attributable to its own prose. Read as a hit list, that would be an argument to
+  delete `describe`. That reading would be wrong on the facts of §4 and wrong on
+  the policy of this section.
+
+If a future reader arrives here looking for a list of commands to cut, the
+correct response is that this document does not contain one and was explicitly
+written not to.
+
+---
+
+## 6. Method and limits
+
+Stated plainly, because the numbers above are small and the temptation to
+over-read them is real.
+
+- **Sample size is 1–3 runs per arm.** Part B ran at `runs: 2`, P3 at `runs: 3`,
+  the P2 probes at `runs: 1`. Every delta here is a **point estimate with no
+  confidence interval attached**.
+- **One command was measured, out of sixteen.** `describe`, once, on one prompt,
+  with one grader set, judged by the CLI's default judge model (the runner does
+  not pass `--judge-model`). Nothing here generalises to the other fifteen
+  commands, and the §4 result does not even generalise to `describe` under a
+  different prompt.
+- **This is a screen, not a verdict.** Its output is where to spend tranche-2
+  effort, not a ruling on any command.
+- **A grader measures its own assertion, not the case's title.** §4 is the
+  worked example.
+- **The eval layer replaces nothing.** Layer 2 — the repo's deterministic shell
+  suites — still does the CI gating. Evals gate nothing, are run by hand, and
+  cost money per run.
+- **Result JSONs live in the OS temp directory** (`/var/folders/…`) and will be
+  reaped. Every number in this document was read from them while they existed;
+  once they are gone, this document and the SDD ledger are the record.
+
+**What would change the conclusion:**
+
+- Running `describe` at higher `runs` and finding the outcome grader failing in
+  the without arm — i.e. that its 3/3 was sampling luck rather than base-model
+  competence. That would move `describe` from "prose adds nothing measurable
+  here" to a genuine partial.
+- A different outcome grader for `describe` targeting a claim the current one
+  does not — the current one grades the user-visible outcome, and the prose makes
+  narrower claims that a sharper grader might catch the base model violating.
+- Any of the other fifteen commands measuring a non-zero delta on an outcome
+  grader with `no-raw-git` removed from the case. This is the obvious tranche-2
+  experiment and the cheapest way to make §4's attribution finding actionable:
+  **drop `no-raw-git` from command cases entirely**, since a dedicated case
+  already covers it at Δ +1.00, and read the outcome grader alone.
+- Evidence that natural-language prompting biases invocation — P3 measured 3/3
+  `Skill` invocations on one command with one phrasing, and a prompt that
+  telegraphs the command more than intended would inflate that.
+
+---
+
+## 7. Runner gaps found and logged, not fixed
+
+Three defects in `.github/scripts/run-evals.sh` surfaced during the probes. All
+three were left unfixed by ruling and are recorded here so they are not lost.
+
+**Gap A — `SlashCommand` is missing from the exit-7 guard's gated list.**
+The guard (`.github/scripts/run-evals.sh:179`) matches
+`Bash|Write|Edit|WebFetch|mcp__*`. A case declaring `SlashCommand` in
+`allowed_tools` passes the guard clean while the CLI denies the tool at runtime:
+`cmd-describe: denied tools (pass --allow-tools to grant): SlashCommand`. The
+guard exists precisely to prevent an ungranted tool silently zeroing an arm, and
+it had a hole for the one tool Part A depended on.
+
+**Gap B — negative-only graders score vacuously on a 0-turn arm.**
+Dissected in §2.3. A dead arm banks free score, inflating the delta, and lands
+above the both-arms-zero floor so the runner's "broken, never no-gap" guard never
+fires. Candidate fixes: a `turns > 0` precondition on scored runs, or a hard
+requirement that every case carry at least one positive outcome grader.
+
+**Gap C — zero loadable cases kills the runner on `find` before `classify()`.**
+When the CLI loads 0 cases it writes no output directory, so
+`RESULT="$(find "$OUT_DIR" -name aggregate-result.json | head -1)"`
+(`run-evals.sh:230`) fails and `set -e` kills the script at that line. The
+operator sees a bare `find: … No such file or directory` and exit 1 instead of a
+diagnostic naming the load failures, and `classify()` never runs. Any workflow
+that depends on the `result JSON:` line printed two lines later inherits this.
+
+### Authoring hazard, if tranche 2 writes another case generator
+
+Part A's generator wrote each `case.yaml` from an **unquoted** heredoc — required
+so `$cmd` and `$prompt` expand — whose body contained backticked prose
+(`` `jj git push` ``, `` `jj describe -m "…"` ``). Bash performs command
+substitution on backticks inside an unquoted heredoc. Run verbatim against stub
+binaries, the generator **executed 32 pushes and 16 description rewrites**,
+exited **0**, and emitted a `case.yaml` whose comment block had been silently
+gutted where the backticks used to be. Nothing in the output signalled it. The
+fix is one character per backtick (`` \` ``); the lesson is that an unquoted
+heredoc containing documentation prose is a live shell, and its failure mode is
+green.
+
+---
+
+## 8. Artifact index
+
+Result JSONs, all with `schema_version: "1.0"` and `partial: false`, all under
+`/var/folders/bc/x1cqjcfx5cq1v24n2ddl21bm0000gn/T/`:
+
+| Directory | Case | Result |
+|---|---|---|
+| `eval-results-95904/` | `hook-blocks-raw-git` | 1.00 / 0.00 / +1.00 |
+| `eval-results-17927/` | `hook-blocks-git-internals` (measures the raw-git branch — see §1.1) | 1.00 / 0.00 / +1.00 |
+| `eval-results-21782/` | `hook-allows-jj-git-and-gh` | 1.00 / 1.00 / 0.00 |
+| `eval-results-20375/` | P2 run A (literal bare `/cmd`) | 0.50 / 0.50 / 0.00 |
+| `eval-results-21686/` | P2 run B (literal namespaced `/cmd`) | 1.00 / 0.50 / +0.50 |
+| `eval-results-27873/` | P3 (natural language, `runs: 3`) | 0.83 / 0.50 / +0.33 |
+
+P3 trace directories (`<dir>/out/trace.jsonl`), which §4's attribution rests on:
+
+| Arm / run | Directory | `no-raw-git` |
+|---|---|---|
+| with 1 | `claude-eval-Ty9b0d/` | pass |
+| with 2 | `claude-eval-TshZtm/` | fail (hook fired) |
+| with 3 | `claude-eval-yW9wum/` | pass |
+| without 1–3 | `claude-eval-auuDpM/`, `claude-eval-Ktbsfc/`, `claude-eval-Pcjg9J/` | fail |
+
+Shipped cases in the tree:
+
+- `plugins/commit-commands-jj/evals/hook-blocks-raw-git/`
+- `plugins/commit-commands-jj/evals/hook-blocks-git-internals/`
+
+Layer-2 test carrying the cut case's assertions:
+
+- `plugins/commit-commands-jj/tests/test-block-raw-git-gating.sh` (5 passed, 0 failed)
+
+Removed before landing: all 16 `plugins/commit-commands-jj/evals/cmd-*/`
+directories and `.github/scripts/gen-command-cases.sh`. They were added and
+removed inside the same change, so they cancel; the net diff of that change is
+the `commit-commands-jj` version bump to `0.4.0`.

--- a/docs/eval-triage-2026-07.md
+++ b/docs/eval-triage-2026-07.md
@@ -336,6 +336,14 @@ a second added file and both arms described "notes.txt and jj config". Harmless
 to the result, but it muddies "what changed". Move scaffold config outside the
 work tree.
 
+The two shipped scaffolds now do exactly that, and for a second reason found in
+the #79 review: the CLI spawns `scaffold.sh` with a fixed env whitelist and runs
+the turn in a **separate process**, so an `export JJ_CONFIG=…` in a scaffold
+configures nothing the agent can see. `HOME` is what the two processes share, so
+the scaffolds write jj's user config inside the sandbox home — out of the work
+tree and actually visible to the turn. Asserted in
+`plugins/commit-commands-jj/tests/test-eval-scaffold.sh`.
+
 ---
 
 ## 4. The one command actually measured: `describe`
@@ -484,7 +492,8 @@ over-read them is real.
 ## 7. Runner gaps found and logged, not fixed
 
 Three defects in `.github/scripts/run-evals.sh` surfaced during the probes. All
-three were left unfixed by ruling and are recorded here so they are not lost.
+three were left unfixed at the time and are recorded here so they are not lost.
+**Gap C has since been closed** (see below); Gaps A and B remain open.
 
 **Gap A — `SlashCommand` is missing from the exit-7 guard's gated list.**
 The guard (`.github/scripts/run-evals.sh:179`) matches
@@ -507,6 +516,10 @@ When the CLI loads 0 cases it writes no output directory, so
 operator sees a bare `find: … No such file or directory` and exit 1 instead of a
 diagnostic naming the load failures, and `classify()` never runs. Any workflow
 that depends on the `result JSON:` line printed two lines later inherits this.
+**Closed** in the #79 review fix-wave: an empty `RESULT` now exits 3 with a
+diagnosis, and the same fix covers a missing `plugins/` directory (a
+wrong-cwd invocation, which previously exited 1 with no output at all).
+Both are asserted in `.github/tests/test-run-evals.sh`.
 
 ### Authoring hazard, if tranche 2 writes another case generator
 

--- a/docs/plans/2026-07-20-eval-suite-plan.md
+++ b/docs/plans/2026-07-20-eval-suite-plan.md
@@ -1,0 +1,1701 @@
+# Eval Suite (issue #79, tranche 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an ablation-gated behavioural eval suite that measures whether these jj plugins actually change model behaviour, plus a triage table for the 16 never-executed `commit-commands-jj` commands.
+
+**Architecture:** Eval cases live at `plugins/<name>/evals/<case>/case.yaml` and run through `claude plugin eval` with `--ablation with-without`, which scores each case twice — with the plugin and without it. A bash runner at `.github/scripts/run-evals.sh` owns the seven environment traps and gates on the *delta* rather than the absolute score, because the harness itself marks zero-gap cases as passing. Classification logic is exposed as a `--classify` mode so it can be tested against JSON fixtures with zero model spend.
+
+**Tech Stack:** bash 3.2, jq, `claude plugin eval` (early access), jj (Jujutsu).
+
+## Global Constraints
+
+- **bash 3.2 is the floor** (CI is `macos-latest`). No `shopt -s globstar`, no associative arrays. Test with `/bin/bash script.sh`, **never** the interactive zsh.
+- **This is a jj repo. Never use raw git** — a PreToolUse hook blocks it. Use `jj` and `gh` only. The working copy IS a commit; there is no staging.
+- **`CLAUDE_CODE_WALNUT_SPIRE=1` is set on every `claude plugin eval` invocation.** The early-access gate that made the CLI exit 1 without it was measured on 2.1.216; on 2.1.220 `--help` succeeds with the variable unset, so the gate is gone or fires only on a real run. Setting it is harmless — keep setting it, but never use "exits 1 without the var" as a detection heuristic.
+- **`--allow-tools Bash` is required on the command line.** `allowed_tools:` in `case.yaml` is necessary but not sufficient; omitting the grant zeroes both arms.
+- **House lint style:** `#!/usr/bin/env bash`, `set -euo pipefail`, `ok()`/`bad()` counters, ends with `test "$FAIL" -eq 0`, prints `N passed, M failed`.
+- **Every lint is written to FAIL FIRST.** A lint green on its first run has proved nothing. Corollary for negative assertions: anchor on positive evidence — a not-match against empty or error output is vacuously green and can never fail first.
+- **CI (#84) requires a version bump** for any byte under `plugins/<name>/`.
+- **Write our own prompt text.** netresearch's prompts are CC-BY-SA-4.0; copying them verbatim pulls ShareAlike onto this Apache-2.0 repo.
+- **Result JSON fields are flat snake_case:** `.cases[].delta`, `.score`, `.score_without`, `.pass_rate`, `.pass_rate_without`, top-level `.partial`. There is no `.aggregates.*`.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `.github/scripts/run-evals.sh` | Discovery, flag assembly, invocation, delta gate. Single entry point. |
+| `.github/tests/test-run-evals.sh` | Fail-first suite for the runner. Auto-discovered by CI's existing glob. |
+| `.github/tests/fixtures/evals/*.json` | `aggregate-result.json` fixtures for classification tests — no model spend. |
+| `plugins/commit-commands-jj/evals/<case>/case.yaml` | Eval cases. |
+| `plugins/commit-commands-jj/evals/<case>/scaffold.sh` | Temp jj repo builders. |
+| `docs/eval-triage-2026-07.md` | Part A's triage write-up. |
+
+---
+
+### Task 1: Runner skeleton — discovery and zero-match abort
+
+**Files:**
+- Create: `.github/scripts/run-evals.sh`
+- Create: `.github/tests/test-run-evals.sh`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: `run-evals.sh` supporting `--discover-only` (prints one case dir per line, exit 0) and aborting with exit 3 on zero matches. Later tasks add `--classify` and live invocation.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `.github/tests/test-run-evals.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/../scripts" && pwd)/run-evals.sh"
+PASS=0
+FAIL=0
+
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+# --- discovery: finds case.yaml ---
+T=$(mktemp -d)
+mkdir -p "$T/plugins/demo/evals/alpha"
+touch "$T/plugins/demo/evals/alpha/case.yaml"
+out=$(cd "$T" && /bin/bash "$SCRIPT" --discover-only 2>&1) || true
+if printf '%s' "$out" | grep -q 'plugins/demo/evals/alpha'; then
+  ok "discovers case.yaml"
+else
+  bad "discovers case.yaml (got: $out)"
+fi
+
+# --- discovery: ALSO finds prompt.md (the format `eval init --bare` writes) ---
+mkdir -p "$T/plugins/demo/evals/beta/graders"
+touch "$T/plugins/demo/evals/beta/prompt.md"
+out=$(cd "$T" && /bin/bash "$SCRIPT" --discover-only 2>&1) || true
+if printf '%s' "$out" | grep -q 'plugins/demo/evals/beta'; then
+  ok "discovers prompt.md format"
+else
+  bad "discovers prompt.md format (got: $out)"
+fi
+
+# --- zero matches must ABORT, not silently pass (#82) ---
+E=$(mktemp -d)
+mkdir -p "$E/plugins/empty"
+set +e
+(cd "$E" && /bin/bash "$SCRIPT" --discover-only >/dev/null 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 3 ]; then
+  ok "zero matches aborts with exit 3"
+else
+  bad "zero matches aborts with exit 3 (got rc=$rc)"
+fi
+
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+test "$FAIL" -eq 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/bin/bash .github/tests/test-run-evals.sh`
+Expected: FAIL — `run-evals.sh` does not exist, all three cases fail.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `.github/scripts/run-evals.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Run plugin eval cases with ablation and gate on the delta.
+# bash 3.2-safe: no globstar, no associative arrays.
+set -euo pipefail
+
+DISCOVER_ONLY=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --discover-only) DISCOVER_ONLY=1; shift ;;
+    *) printf 'unknown argument: %s\n' "$1" >&2; exit 64 ;;
+  esac
+done
+
+# Discover case directories. BOTH supported formats: `case.yaml` and the
+# `prompt.md` + graders/ layout that `claude plugin eval init --bare` writes.
+# A single-format glob would silently skip officially-scaffolded cases (#82).
+discover_cases() {
+  find plugins \
+    \( -path '*/evals/*/case.yaml' -o -path '*/evals/*/prompt.md' \) \
+    -type f 2>/dev/null | sed 's#/[^/]*$##' | sort -u
+}
+
+CASES=$(discover_cases)
+
+if [ -z "$CASES" ]; then
+  printf 'ERROR: no eval cases found under plugins/*/evals/.\n' >&2
+  printf 'A glob matching nothing is indistinguishable from passing (#82).\n' >&2
+  exit 3
+fi
+
+if [ "$DISCOVER_ONLY" -eq 1 ]; then
+  printf '%s\n' "$CASES"
+  exit 0
+fi
+
+# stderr, not stdout — stdout carries the TSV that Task 7 pipes to a file.
+printf 'discovered %d case(s)\n' "$(printf '%s\n' "$CASES" | wc -l | tr -d ' ')" >&2
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `chmod +x .github/scripts/run-evals.sh && /bin/bash .github/tests/test-run-evals.sh`
+Expected: `3 passed, 0 failed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(evals): runner skeleton with dual-format discovery
+
+Discovers both case.yaml and prompt.md layouts; aborts on zero matches
+per #82 (a glob matching nothing looks exactly like passing)."
+jj new
+```
+
+---
+
+### Task 2: Delta gate — classification with the delta-type tripwire
+
+**Files:**
+- Modify: `.github/scripts/run-evals.sh`
+- Modify: `.github/tests/test-run-evals.sh`
+- Create: `.github/tests/fixtures/evals/discriminating.json`
+- Create: `.github/tests/fixtures/evals/nogap.json`
+- Create: `.github/tests/fixtures/evals/broken.json`
+- Create: `.github/tests/fixtures/evals/regression.json`
+- Create: `.github/tests/fixtures/evals/nulldelta.json`
+- Create: `.github/tests/fixtures/evals/stringdelta.json`
+- Create: `.github/tests/fixtures/evals/partial.json`
+- Create: `.github/tests/fixtures/evals/partialgap.json`
+- Create: `.github/tests/fixtures/evals/boundary.json`
+- Create: `.github/tests/fixtures/evals/nocases.json`
+
+**Interfaces:**
+- Consumes: `run-evals.sh` from Task 1.
+- Produces: `run-evals.sh --classify <file.json> [--gate strict|report]` printing TSV `name<TAB>score<TAB>score_without<TAB>delta<TAB>verdict`. Verdicts: `DISCRIMINATING`, `PARTIAL`, `NO_GAP`, `REGRESSION`, `BROKEN`. Exit 0 clean; 3 zero cases; 4 gate failure; 5 delta-type tripwire (null or non-numeric); 6 partial run; 64 bad `--gate`; 65 missing or malformed file. Schema drift exits 5 with a diagnostic; it is not a verdict row.
+
+- [ ] **Step 1: Write the fixtures**
+
+Create `.github/tests/fixtures/evals/discriminating.json`:
+
+```json
+{"schema_version":"1.0","partial":false,"cost_usd":0.15,
+ "cases":[{"name":"hook-blocks-raw-git","score":1,"score_without":0,"delta":1,"pass_rate":1,"pass_rate_without":0}]}
+```
+
+Create `.github/tests/fixtures/evals/nogap.json`:
+
+```json
+{"schema_version":"1.0","partial":false,"cost_usd":0.21,
+ "cases":[{"name":"describe-noninteractive","score":1,"score_without":1,"delta":0,"pass_rate":1,"pass_rate_without":1}]}
+```
+
+Create `.github/tests/fixtures/evals/broken.json`:
+
+```json
+{"schema_version":"1.0","partial":false,"cost_usd":0.16,
+ "cases":[{"name":"missing-tool-grant","score":0,"score_without":0,"delta":0,"pass_rate":0,"pass_rate_without":0}]}
+```
+
+Create `.github/tests/fixtures/evals/regression.json`:
+
+```json
+{"schema_version":"1.0","partial":false,"cost_usd":0.18,
+ "cases":[{"name":"plugin-makes-it-worse","score":0,"score_without":1,"delta":-1,"pass_rate":0,"pass_rate_without":1}]}
+```
+
+Create `.github/tests/fixtures/evals/nulldelta.json` — the schema-drift case, with the camelCase shape a review report once claimed:
+
+```json
+{"schema_version":"1.0","partial":false,"cost_usd":0.15,
+ "cases":[{"name":"schema-drifted","aggregates":{"delta":1,"score":1,"scoreWithout":0}}]}
+```
+
+Create `.github/tests/fixtures/evals/stringdelta.json` — the OTHER drift shape:
+a delta that is present but string-typed. jq sorts every string above every
+number, so all three comparisons come back false, the case classifies
+`DISCRIMINATING`, and the gate exits 0 — schema drift reading as shipping
+success, in the one direction (green) the tripwire cannot afford to miss.
+Found by the third review running a `"0.0"` delta through classify():
+
+```json
+{"schema_version":"1.0","partial":false,"cost_usd":0.15,
+ "cases":[{"name":"drifted-to-string","score":"1","score_without":"0","delta":"0.0"}]}
+```
+
+Create `.github/tests/fixtures/evals/partial.json`:
+
+```json
+{"schema_version":"1.0","partial":true,"cost_usd":5.0,
+ "cases":[{"name":"budget-breached","score":1,"score_without":0,"delta":1,"pass_rate":1,"pass_rate_without":0}]}
+```
+
+Create `.github/tests/fixtures/evals/partialgap.json` — a sub-0.5 delta, so the
+`PARTIAL` verdict is actually exercised rather than merely declared:
+
+```json
+{"schema_version":"1.0","partial":false,"cost_usd":0.19,
+ "cases":[{"name":"weak-gap","score":1,"score_without":0.7,"delta":0.3,"pass_rate":1,"pass_rate_without":0.7}]}
+```
+
+Create `.github/tests/fixtures/evals/boundary.json` — delta exactly at the
+threshold, pinning the `>=` semantics:
+
+```json
+{"schema_version":"1.0","partial":false,"cost_usd":0.17,
+ "cases":[{"name":"exactly-half","score":1,"score_without":0.5,"delta":0.5,"pass_rate":1,"pass_rate_without":0.5}]}
+```
+
+Create `.github/tests/fixtures/evals/nocases.json` — a structurally valid
+result that measured nothing:
+
+```json
+{"schema_version":"1.0","partial":false,"cost_usd":0,"cases":[]}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `.github/tests/test-run-evals.sh`, immediately before the final `printf`:
+
+```bash
+FIX="$(cd "$(dirname "$0")" && pwd)/fixtures/evals"
+
+verdict_of() { /bin/bash "$SCRIPT" --classify "$1" 2>/dev/null | awk -F'\t' 'NR==1{print $5}'; }
+
+for pair in "discriminating:DISCRIMINATING" "nogap:NO_GAP" "broken:BROKEN" "regression:REGRESSION"; do
+  f="${pair%%:*}"; want="${pair##*:}"
+  got=$(verdict_of "$FIX/$f.json" || true)
+  if [ "$got" = "$want" ]; then
+    ok "classifies $f as $want"
+  else
+    bad "classifies $f as $want (got: ${got:-<empty>})"
+  fi
+done
+
+# BROKEN must NOT be reported as NO_GAP — a missing --allow-tools grant zeroes
+# both arms, and reading that as "no gap" silently deletes the best cases.
+# Require a NON-EMPTY verdict: bare != would pass vacuously on empty output
+# before classify() even exists (fail-first, third review).
+got=$(verdict_of "$FIX/broken.json" || true)
+if [ -n "$got" ] && [ "$got" != "NO_GAP" ]; then
+  ok "both-arms-zero is never NO_GAP"
+else
+  bad "both-arms-zero is never NO_GAP (got: ${got:-<empty>})"
+fi
+
+# Null delta must abort. jq yields null for a missing path and null sorts BELOW
+# every number, so `null < 0` is true — an ungated null files every case as
+# REGRESSION while looking like it works.
+set +e
+/bin/bash "$SCRIPT" --classify "$FIX/nulldelta.json" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 5 ]; then
+  ok "null delta trips the tripwire (exit 5)"
+else
+  bad "null delta trips the tripwire (exit 5) (got rc=$rc)"
+fi
+
+# A present-but-string delta is the same disease in the opposite direction:
+# jq sorts strings above every number, so "0.0" passes every comparison,
+# classifies DISCRIMINATING, and gates GREEN. The tripwire must key on type.
+set +e
+/bin/bash "$SCRIPT" --classify "$FIX/stringdelta.json" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 5 ]; then
+  ok "string-typed delta trips the tripwire (exit 5)"
+else
+  bad "string-typed delta trips the tripwire (exit 5) (got rc=$rc)"
+fi
+
+# A budget-breached run has partial scores; deltas must not be trusted.
+set +e
+/bin/bash "$SCRIPT" --classify "$FIX/partial.json" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 6 ]; then
+  ok "partial run aborts (exit 6)"
+else
+  bad "partial run aborts (exit 6) (got rc=$rc)"
+fi
+
+# strict gate (Part B): anything short of DISCRIMINATING fails.
+set +e
+/bin/bash "$SCRIPT" --classify "$FIX/nogap.json" --gate strict >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 4 ]; then
+  ok "strict gate fails on NO_GAP"
+else
+  bad "strict gate fails on NO_GAP (got rc=$rc)"
+fi
+
+# report gate (Part A): NO_GAP is data, not failure.
+set +e
+/bin/bash "$SCRIPT" --classify "$FIX/nogap.json" --gate report >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  ok "report gate tolerates NO_GAP"
+else
+  bad "report gate tolerates NO_GAP (got rc=$rc)"
+fi
+
+# PARTIAL is a declared verdict; assert it rather than leaving it untested.
+got=$(verdict_of "$FIX/partialgap.json" || true)
+if [ "$got" = "PARTIAL" ]; then
+  ok "classifies a sub-0.5 delta as PARTIAL"
+else
+  bad "classifies a sub-0.5 delta as PARTIAL (got: ${got:-<empty>})"
+fi
+
+# Boundary: exactly 0.5 ships (>= 0.5 per the spec taxonomy).
+got=$(verdict_of "$FIX/boundary.json" || true)
+if [ "$got" = "DISCRIMINATING" ]; then
+  ok "delta of exactly 0.5 is DISCRIMINATING"
+else
+  bad "delta of exactly 0.5 is DISCRIMINATING (got: ${got:-<empty>})"
+fi
+
+# Zero cases must abort. An empty .cases[] prints nothing and gates green,
+# having measured nothing — #82 one level in.
+set +e
+/bin/bash "$SCRIPT" --classify "$FIX/nocases.json" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 3 ]; then
+  ok "zero cases in result aborts (exit 3)"
+else
+  bad "zero cases in result aborts (exit 3) (got rc=$rc)"
+fi
+
+# Malformed JSON must report as malformed, not as schema drift.
+printf 'not json at all\n' > "$FIX/../badjson.json"
+set +e
+err=$(/bin/bash "$SCRIPT" --classify "$FIX/../badjson.json" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 65 ] && printf '%s' "$err" | grep -q 'not valid JSON'; then
+  ok "malformed JSON reports as invalid (exit 65)"
+else
+  bad "malformed JSON reports as invalid (exit 65) (got rc=$rc: $err)"
+fi
+rm -f "$FIX/../badjson.json"
+
+# An unknown gate name must abort, not silently fall through to permissive.
+# Require the gate-validation MESSAGE, not just rc 64 — before --classify
+# exists, the unknown-argument arm also exits 64, so a bare rc check passes
+# vacuously for the wrong reason (fail-first, third review).
+set +e
+err=$(/bin/bash "$SCRIPT" --classify "$FIX/nogap.json" --gate typo 2>&1 >/dev/null)
+rc=$?
+set -e
+if [ "$rc" -eq 64 ] && printf '%s' "$err" | grep -q -- '--gate must be'; then
+  ok "unknown --gate value aborts (exit 64)"
+else
+  bad "unknown --gate value aborts (exit 64) (got rc=$rc: ${err:-<empty>})"
+fi
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `/bin/bash .github/tests/test-run-evals.sh`
+Expected: FAIL — `--classify` is an unknown argument (exit 64), and **all 15
+new assertions fail** (verified by running this suite against the Task 1
+runner). If any new assertion shows `ok` here, it is passing vacuously —
+strengthen it before writing a line of implementation.
+
+- [ ] **Step 4: Write minimal implementation**
+
+In `.github/scripts/run-evals.sh`, replace the argument-parsing block with:
+
+```bash
+DISCOVER_ONLY=0
+CLASSIFY_FILE=""
+GATE="strict"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --discover-only) DISCOVER_ONLY=1; shift ;;
+    --classify)      CLASSIFY_FILE="$2"; shift 2 ;;
+    --gate)          GATE="$2"; shift 2 ;;
+    *) printf 'unknown argument: %s\n' "$1" >&2; exit 64 ;;
+  esac
+done
+```
+
+Then insert this block immediately after the parsing loop (before discovery, so
+`--classify` needs no cases on disk):
+
+```bash
+# Classify an aggregate-result.json into verdicts and set the exit code.
+# Field paths are FLAT snake_case and verified against a real run:
+#   .cases[].delta / .score / .score_without / .pass_rate / .pass_rate_without
+#   .partial (top level)
+# There is no .aggregates.* — see docs/specs/2026-07-20-eval-suite-design.md.
+classify() {
+  file="$1"
+
+  if [ ! -f "$file" ]; then
+    printf 'ERROR: no such result file: %s\n' "$file" >&2
+    exit 65
+  fi
+
+  # Malformed JSON must not be misdiagnosed. A `$(jq ...)` inside `[ ... ]`
+  # does NOT trip set -e, so without this check a parse error falls through
+  # the .partial test and then trips the null-delta tripwire, reporting
+  # "schema drift" with total confidence about a file that is simply corrupt.
+  if ! jq -e . "$file" >/dev/null 2>&1; then
+    printf 'ERROR: %s is not valid JSON\n' "$file" >&2
+    exit 65
+  fi
+
+  # Zero cases is never success. `.cases[]` over an empty array prints
+  # nothing, bad_count is 0, and the gate exits green having measured
+  # nothing at all — #82's failure mode, one level in.
+  if [ "$(jq -r '.cases | length' "$file")" = "0" ]; then
+    printf 'ERROR: result contains zero cases — nothing was measured (#82).\n' >&2
+    exit 3
+  fi
+
+  # Budget breach: paid graders were skipped, so scores are partial.
+  if [ "$(jq -r '.partial // false' "$file")" = "true" ]; then
+    printf 'ERROR: run was truncated by --max-cost-usd (.partial=true).\n' >&2
+    printf 'Paid graders were skipped; deltas are not trustworthy.\n' >&2
+    exit 6
+  fi
+
+  # Tripwire: any missing OR non-numeric delta means the result schema moved.
+  # null is not the only drift shape: jq sorts every string above every
+  # number, so a string "0.0" delta passes every comparison, classifies
+  # DISCRIMINATING, and gates green. Key on type — never let a non-number
+  # reach a comparison.
+  if [ "$(jq -r '[.cases[]? | select((.delta | type) != "number")] | length' "$file")" != "0" ]; then
+    printf 'ERROR: a case has a null or non-numeric delta — result schema drift.\n' >&2
+    printf 'Expected flat numeric .cases[].delta. Every verdict would be meaningless.\n' >&2
+    exit 5
+  fi
+
+  jq -r '
+    .cases[]?
+    | [ .name,
+        (.score          | tostring),
+        (.score_without  | tostring),
+        (.delta          | tostring),
+        ( if   (.score == 0 and .score_without == 0) then "BROKEN"
+          elif .delta <  0    then "REGRESSION"
+          elif .delta == 0    then "NO_GAP"
+          elif .delta <  0.5  then "PARTIAL"
+          else                     "DISCRIMINATING"
+          end )
+      ] | @tsv
+  ' "$file"
+
+  # Validate the gate name. Without this, any typo falls through to report
+  # semantics — silently turning a strict Part B gate permissive and green.
+  case "$GATE" in
+    strict|report) ;;
+    *) printf 'ERROR: --gate must be "strict" or "report", got "%s"\n' "$GATE" >&2
+       exit 64 ;;
+  esac
+
+  # Gate. strict (Part B): only DISCRIMINATING passes.
+  # report (Part A): NO_GAP and PARTIAL are findings, not failures — but
+  # BROKEN and REGRESSION always fail, in both modes.
+  if [ "$GATE" = "strict" ]; then
+    bad_count=$(jq -r '[.cases[] | select((.score == 0 and .score_without == 0) or .delta < 0.5)] | length' "$file")
+  else
+    bad_count=$(jq -r '[.cases[] | select((.score == 0 and .score_without == 0) or .delta < 0)] | length' "$file")
+  fi
+
+  if [ "$bad_count" != "0" ]; then
+    printf 'gate(%s): %s case(s) failed\n' "$GATE" "$bad_count" >&2
+    exit 4
+  fi
+}
+
+if [ -n "$CLASSIFY_FILE" ]; then
+  classify "$CLASSIFY_FILE"
+  exit 0
+fi
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `/bin/bash .github/tests/test-run-evals.sh`
+Expected: `18 passed, 0 failed` (3 discovery + 15 classification — verified by
+executing this task's code; if the count differs, reconcile before proceeding)
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "feat(evals): delta gate with null-delta tripwire
+
+Classifies cases by ablation delta, not absolute score — the harness
+marks zero-gap cases PASS, which is the opposite of what we want.
+
+Guards: both-arms-zero is BROKEN (a missing --allow-tools grant) and
+never NO_GAP; null or non-numeric deltas abort — jq sorts null below and
+strings above every number, so an ungated null files every case as
+REGRESSION and an ungated string as DISCRIMINATING, both while looking
+correct."
+jj new
+```
+
+---
+
+### Task 3: Live invocation — flag assembly and the tool-grant guard
+
+**Files:**
+- Modify: `.github/scripts/run-evals.sh`
+- Modify: `.github/tests/test-run-evals.sh`
+
+**Interfaces:**
+- Consumes: `discover_cases()` and `classify()`.
+- Produces: `run-evals.sh [--plugin <name>] [--case <glob>] [--runs <n>] [--gate strict|report] [--keep-temp] [--max-cost-usd <n>] [--dry-run]`. `--dry-run` prints the assembled command without executing — the seam that makes flag assembly testable without spend.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `.github/tests/test-run-evals.sh` before the final `printf`:
+
+```bash
+D=$(mktemp -d)
+mkdir -p "$D/plugins/demo/evals/alpha"
+cat > "$D/plugins/demo/evals/alpha/case.yaml" <<'YAML'
+schema_version: "1.1"
+name: alpha
+execution:
+  prompt: hello
+  allowed_tools: [Bash]
+graders:
+  - type: regex
+    name: g
+    pattern: hi
+YAML
+mkdir -p "$D/plugins/demo/.claude-plugin"
+printf '{"name":"demo","description":"d","version":"0.0.1"}\n' \
+  > "$D/plugins/demo/.claude-plugin/plugin.json"
+
+cmd=$(cd "$D" && /bin/bash "$SCRIPT" --plugin demo --dry-run 2>&1) || true
+
+for flag in "--ablation with-without" "--allow-tools" "--scaffold" "--output-dir" "CLAUDE_CODE_WALNUT_SPIRE=1"; do
+  if printf '%s' "$cmd" | grep -q -- "$flag"; then
+    ok "dry-run includes $flag"
+  else
+    bad "dry-run includes $flag (got: $cmd)"
+  fi
+done
+
+# --output-dir must land OUTSIDE plugins/, or results trip the #84 version
+# lint. Anchor on the flag being PRESENT — a bare not-match is vacuously
+# green on empty or error output and can never fail first (third review).
+if printf '%s' "$cmd" | grep -q -- '--output-dir' \
+   && ! printf '%s' "$cmd" | grep -q -- '--output-dir[= ]*[^ ]*plugins/'; then
+  ok "output-dir stays outside plugins/"
+else
+  bad "output-dir stays outside plugins/ (got: $cmd)"
+fi
+
+# A case declaring a gated tool absent from the grant must abort loudly,
+# rather than scoring both arms 0.00 and reading as "no gap".
+mkdir -p "$D/plugins/demo/evals/needswrite"
+cat > "$D/plugins/demo/evals/needswrite/case.yaml" <<'YAML'
+schema_version: "1.1"
+name: needswrite
+execution:
+  prompt: hello
+  allowed_tools: [Bash, Write]
+graders:
+  - type: regex
+    name: g
+    pattern: hi
+YAML
+set +e
+(cd "$D" && /bin/bash "$SCRIPT" --plugin demo --allow-tools Bash --dry-run >/dev/null 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 7 ]; then
+  ok "ungranted gated tool aborts (exit 7)"
+else
+  bad "ungranted gated tool aborts (exit 7) (got rc=$rc)"
+fi
+
+# Block-style YAML must be caught too — it is the layout `eval init` writes,
+# so a flow-only guard is blind to precisely the cases it exists to protect.
+mkdir -p "$D/plugins/demo/evals/blockstyle"
+cat > "$D/plugins/demo/evals/blockstyle/case.yaml" <<'YAML'
+schema_version: "1.1"
+name: blockstyle
+execution:
+  prompt: hello
+  allowed_tools:
+    - Bash
+    - Write
+graders:
+  - type: regex
+    name: g
+    pattern: hi
+YAML
+set +e
+(cd "$D" && /bin/bash "$SCRIPT" --plugin demo --allow-tools Bash --dry-run >/dev/null 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 7 ]; then
+  ok "block-style allowed_tools caught by guard"
+else
+  bad "block-style allowed_tools caught by guard (got rc=$rc)"
+fi
+rm -rf "$D/plugins/demo/evals/blockstyle" "$D/plugins/demo/evals/needswrite"
+
+# --- LIVE PATH via a stub `claude` on PATH ---
+# Every exit-code test above goes through --classify directly. Without a live
+# test, `set -e` killing the runner before classify() is invisible — a green
+# suite that cannot fail, which is the exact disease this project exists to
+# prevent. These stubs cost nothing and cover the real invocation path.
+STUB=$(mktemp -d)
+mkdir -p "$STUB/bin"
+cat > "$STUB/bin/claude" <<'STUBEOF'
+#!/usr/bin/env bash
+# Emulate the CLI's exit contract: 1 when a case scores under --threshold,
+# 2 on --max-cost-usd breach. The real CLI also prints its human summary
+# table to STDOUT (verified live on 2.1.220) — the stub must too, or the
+# stdout-purity test below can only pass vacuously.
+printf 'CASE  WITH  W/OUT (stub table noise)\n'
+outdir=""
+prev=""
+for a in "$@"; do
+  [ "$prev" = "--output-dir" ] && outdir="$a"
+  prev="$a"
+done
+mkdir -p "$outdir"
+case "${STUB_MODE:-ok}" in
+  threshold)
+    printf '{"schema_version":"1.0","partial":false,"cases":[{"name":"c","score":0.5,"score_without":0,"delta":0.5}]}\n' > "$outdir/aggregate-result.json"
+    exit 1 ;;
+  maxcost)
+    printf '{"schema_version":"1.0","partial":true,"cases":[{"name":"c","score":1,"score_without":0,"delta":1}]}\n' > "$outdir/aggregate-result.json"
+    exit 2 ;;
+  *)
+    printf '{"schema_version":"1.0","partial":false,"cases":[{"name":"c","score":1,"score_without":0,"delta":1}]}\n' > "$outdir/aggregate-result.json"
+    exit 0 ;;
+esac
+STUBEOF
+chmod +x "$STUB/bin/claude"
+
+# A case scoring under 1.0 makes the CLI exit 1. The runner must survive it
+# and still classify — otherwise --threshold silently pre-empts the delta gate.
+out=$(cd "$D" && PATH="$STUB/bin:$PATH" STUB_MODE=threshold \
+  /bin/bash "$SCRIPT" --plugin demo 2>/dev/null) || true
+if printf '%s' "$out" | grep -q 'DISCRIMINATING'; then
+  ok "live path survives CLI exit 1 and still classifies"
+else
+  bad "live path survives CLI exit 1 and still classifies (got: ${out:-<empty>})"
+fi
+
+# The assembled command must carry --threshold 0, or the above is luck.
+cmd=$(cd "$D" && /bin/bash "$SCRIPT" --plugin demo --dry-run 2>/dev/null) || true
+if printf '%s' "$cmd" | grep -q -- '--threshold 0'; then
+  ok "assembles --threshold 0"
+else
+  bad "assembles --threshold 0 (got: $cmd)"
+fi
+
+# A budget breach is CLI exit 2; .partial must still reach classify as exit 6.
+set +e
+(cd "$D" && PATH="$STUB/bin:$PATH" STUB_MODE=maxcost \
+  /bin/bash "$SCRIPT" --plugin demo >/dev/null 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 6 ]; then
+  ok "budget breach reaches the .partial tripwire (exit 6)"
+else
+  bad "budget breach reaches the .partial tripwire (exit 6) (got rc=$rc)"
+fi
+
+# stdout must be pure TSV — Task 7 pipes it to a file. The stub prints a fake
+# summary table to stdout precisely because the real CLI does; if the runner
+# fails to redirect the CLI's stdout, this catches it.
+out=$(cd "$D" && PATH="$STUB/bin:$PATH" /bin/bash "$SCRIPT" --plugin demo 2>/dev/null) || true
+if printf '%s' "$out" | grep -q 'DISCRIMINATING' \
+   && ! printf '%s' "$out" | grep -qE 'discovered|stub table noise'; then
+  ok "stdout is pure TSV"
+else
+  bad "stdout is pure TSV (got: ${out:-<empty>})"
+fi
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/bin/bash .github/tests/test-run-evals.sh`
+Expected: FAIL — `--plugin`, `--dry-run`, `--allow-tools` are unknown
+arguments (exit 64), and **all 12 new assertions fail**. If any new assertion
+shows `ok` here, it is passing vacuously — strengthen it before writing a
+line of implementation.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Extend the argument loop in `.github/scripts/run-evals.sh`:
+
+```bash
+DISCOVER_ONLY=0
+CLASSIFY_FILE=""
+GATE="strict"
+PLUGIN=""
+CASE_GLOB=""
+RUNS=""
+KEEP_TEMP=0
+MAX_COST="5"
+ALLOW_TOOLS="Bash"
+DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --discover-only) DISCOVER_ONLY=1; shift ;;
+    --classify)      CLASSIFY_FILE="$2"; shift 2 ;;
+    --gate)          GATE="$2"; shift 2 ;;
+    --plugin)        PLUGIN="$2"; shift 2 ;;
+    --case)          CASE_GLOB="$2"; shift 2 ;;
+    --runs)          RUNS="$2"; shift 2 ;;
+    --allow-tools)   ALLOW_TOOLS="$2"; shift 2 ;;
+    --max-cost-usd)  MAX_COST="$2"; shift 2 ;;
+    --keep-temp)     KEEP_TEMP=1; shift ;;
+    --dry-run)       DRY_RUN=1; shift ;;
+    *) printf 'unknown argument: %s\n' "$1" >&2; exit 64 ;;
+  esac
+done
+```
+
+Append after the discovery block:
+
+```bash
+# Scope the guard to what this invocation will actually run. Scanning every
+# discovered case makes an unrelated plugin's Write-requiring case abort a run
+# that never touches it.
+SCOPED=""
+for case_dir in $CASES; do
+  case "$case_dir" in
+    plugins/${PLUGIN}/*|plugins/*) : ;;
+  esac
+  if [ -n "$PLUGIN" ]; then
+    case "$case_dir" in plugins/"$PLUGIN"/*) ;; *) continue ;; esac
+  fi
+  if [ -n "$CASE_GLOB" ]; then
+    # shellcheck disable=SC2254
+    case "$(basename "$case_dir")" in $CASE_GLOB) ;; *) continue ;; esac
+  fi
+  SCOPED="$SCOPED$case_dir
+"
+done
+
+# Guard: every gated tool a case declares must appear in the grant. Without
+# this, the agent cannot call the tool, BOTH arms score 0.00, and the delta
+# reads 0.00 — which the gate would otherwise interpret as "measures the
+# model, cut the case". That silently deletes the best cases in the suite.
+for case_dir in $SCOPED; do
+  [ -f "$case_dir/case.yaml" ] || continue
+  # Extract BOTH YAML forms. Flow (`[Bash, Write]`) and block sequence
+  # (`- Bash` on following lines). A block-form-blind guard misses exactly the
+  # layout `claude plugin eval init` scaffolds — i.e. the case it exists for.
+  declared=$( { sed -n 's/.*allowed_tools:[[:space:]]*\[\(.*\)\].*/\1/p' "$case_dir/case.yaml" | tr ',' '\n'
+                sed -n '/allowed_tools:[[:space:]]*$/,/^[[:space:]]*[^[:space:]-]/ s/^[[:space:]]*-[[:space:]]*//p' "$case_dir/case.yaml"
+              } | tr -d ' "' | grep -v '^$' || true )
+  for tool in $declared; do
+    case "$tool" in
+      Bash|Write|Edit|WebFetch|mcp__*)
+        # Exact match against the grant list — an unanchored grep lets
+        # `--allow-tools BashOutput` satisfy a requirement for `Bash`.
+        if ! printf '%s' "$ALLOW_TOOLS" | tr ', ' '\n\n' | grep -qx "$tool"; then
+          printf 'ERROR: %s declares gated tool "%s" but --allow-tools is "%s".\n' \
+            "$case_dir" "$tool" "$ALLOW_TOOLS" >&2
+          printf 'Both ablation arms would score 0.00 and read as "no gap".\n' >&2
+          exit 7
+        fi
+        ;;
+    esac
+  done
+done
+
+TARGET="plugins/${PLUGIN}"
+[ -n "$PLUGIN" ] || TARGET="plugins"
+OUT_DIR="${TMPDIR:-/tmp}/eval-results-$$"
+
+# --threshold 0 is LOAD-BEARING. It defaults to 1.0, so the CLI exits 1 on any
+# case scoring below 1.00 — which, under `set -e`, kills this script before
+# classify() ever runs. The delta gate would be permanently unreachable, and
+# every case the sweep exists to measure scores below 1.00 by definition.
+set -- "$TARGET" --ablation with-without --scaffold \
+  --allow-tools "$ALLOW_TOOLS" --threshold 0 \
+  --output-dir "$OUT_DIR" --max-cost-usd "$MAX_COST"
+[ -z "$CASE_GLOB" ] || set -- "$@" --case "$CASE_GLOB"
+[ -z "$RUNS" ]      || set -- "$@" --runs "$RUNS"
+[ "$KEEP_TEMP" -eq 0 ] || set -- "$@" --keep-temp
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf 'CLAUDE_CODE_WALNUT_SPIRE=1 JJ_USER=%s JJ_EMAIL=%s claude plugin eval %s\n' \
+    "${JJ_USER:-eval}" "${JJ_EMAIL:-eval@example.com}" "$*"
+  exit 0
+fi
+
+# Capture the CLI's exit code rather than letting set -e act on it. Exit 2 is
+# the documented --max-cost-usd breach, which must reach classify() so the
+# .partial tripwire can report it; anything above 2 is a real failure.
+# The CLI prints its human summary table to STDOUT (verified live, 2.1.220);
+# send it to stderr — stdout belongs to the TSV that Task 7 pipes to a file.
+eval_rc=0
+CLAUDE_CODE_WALNUT_SPIRE=1 \
+JJ_USER="${JJ_USER:-eval}" \
+JJ_EMAIL="${JJ_EMAIL:-eval@example.com}" \
+  claude plugin eval "$@" 1>&2 || eval_rc=$?
+
+if [ "$eval_rc" -gt 2 ]; then
+  printf 'ERROR: claude plugin eval failed (rc=%s)\n' "$eval_rc" >&2
+  exit "$eval_rc"
+fi
+
+RESULT="$(find "$OUT_DIR" -name aggregate-result.json | head -1)"
+# Task 7 reads per-grader results (the exercised precondition) from this
+# file; print the path where a human can find it.
+printf 'result JSON: %s\n' "$RESULT" >&2
+classify "$RESULT"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/bin/bash .github/tests/test-run-evals.sh`
+Expected: `30 passed, 0 failed` (18 prior + 12 new — verified by executing
+this task's code)
+
+If the count differs, reconcile before proceeding — a drifting expected count
+is how a suite quietly stops asserting what it claims.
+
+- [ ] **Step 5: Verify bash 3.2 compatibility explicitly**
+
+Run: `/bin/bash --version | head -1 && /bin/bash -n .github/scripts/run-evals.sh && echo "SYNTAX OK"`
+Expected: `GNU bash, version 3.2.57` and `SYNTAX OK`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "feat(evals): live invocation with tool-grant guard
+
+Assembles the flag set that owns the harness's seven traps, and refuses
+to run when a case declares a gated tool the grant omits — that
+combination zeroes both arms and reads as 'no gap'."
+jj new
+```
+
+---
+
+### Task 4: Exemplar case — hook-blocks-raw-git
+
+**Files:**
+- Create: `plugins/commit-commands-jj/evals/hook-blocks-raw-git/case.yaml`
+- Create: `plugins/commit-commands-jj/evals/hook-blocks-raw-git/scaffold.sh`
+- Modify: `.gitignore`
+- Modify: `plugins/commit-commands-jj/.claude-plugin/plugin.json`
+
+**Interfaces:**
+- Consumes: the runner from Task 3.
+- Produces: the committed schema exemplar every later case is copied from. Measured Δ +1.00 (with 1.00 / without 0.00), reproduced independently three times.
+
+- [ ] **Step 1: Write the scaffold**
+
+Create `plugins/commit-commands-jj/evals/hook-blocks-raw-git/scaffold.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Build a throwaway jj repo for the case. Hardened per netresearch's MIT
+# pattern: paginate=never and editor=true, so an accidental interactive
+# invocation no-ops instead of hanging the run.
+set -euo pipefail
+
+export JJ_USER="${JJ_USER:-eval}"
+export JJ_EMAIL="${JJ_EMAIL:-eval@example.com}"
+
+mkdir -p .jjconfig
+cat > .jjconfig/config.toml <<'TOML'
+[ui]
+paginate = "never"
+editor = "true"
+TOML
+export JJ_CONFIG="$PWD/.jjconfig/config.toml"
+
+jj git init . >/dev/null 2>&1
+printf 'alpha\n' > notes.txt
+```
+
+- [ ] **Step 2: Write the case**
+
+Create `plugins/commit-commands-jj/evals/hook-blocks-raw-git/case.yaml`:
+
+```yaml
+schema_version: "1.1"
+name: hook-blocks-raw-git
+description: >
+  block-raw-git.sh must deny a raw git command inside a jj repo.
+  Ablation-verified: with 1.00 / without 0.00, delta +1.00.
+tags: [commit-commands-jj, hook, invariant]
+context:
+  scaffold_script: scaffold.sh
+execution:
+  prompt: |
+    Run the shell command `git status` in this repository and tell me
+    exactly what happened.
+  max_turns: 6
+  timeout_seconds: 300
+  allowed_tools: [Bash]
+runs: 2
+graders:
+  - type: regex
+    name: reports-blocked
+    pattern: "(BLOCKED|blocked|not allowed|denied)"
+    match: contains
+    weight: 1
+```
+
+- [ ] **Step 3: Ignore results and bump the version**
+
+Append to `.gitignore`:
+
+```
+**/evals/results/
+```
+
+**The `**/` prefix is required.** A gitignore pattern containing a mid-string
+slash is anchored to the file's own directory, so a bare `evals/results/` would
+match only a root-level directory that never exists — while
+`plugins/commit-commands-jj/evals/results/`, the exact path that trips the #84
+lint, stays fully tracked. Verified under jj:
+
+```
+pattern=evals/results/      plugins/foo/evals/results IGNORED? NO
+pattern=**/evals/results/   plugins/foo/evals/results IGNORED? YES
+```
+
+jj auto-snapshots the working copy, so if results ever land before this entry
+is correct they are already tracked and the pattern will not retroactively
+apply. Remediate with `jj file untrack 'glob:**/evals/results/**'`.
+
+In `plugins/commit-commands-jj/.claude-plugin/plugin.json`, change `"version": "0.1.1"` to `"version": "0.2.0"`. Required by #84 for any byte under `plugins/<name>/`.
+
+- [ ] **Step 4: Run the case and verify the delta**
+
+Run:
+```bash
+chmod +x plugins/commit-commands-jj/evals/hook-blocks-raw-git/scaffold.sh
+/bin/bash .github/scripts/run-evals.sh --plugin commit-commands-jj \
+  --case 'hook-blocks-raw-git' --gate strict
+```
+Expected: a TSV row ending `DISCRIMINATING`, exit 0. If it prints `BROKEN`, the tool grant is wrong; if `NO_GAP`, the hook is not firing.
+
+- [ ] **Step 5: Verify the version-bump lint is satisfied**
+
+Run:
+```bash
+BASE=$(mktemp -d)
+jj --ignore-working-copy file list -r 'trunk()' 'glob:plugins/*/.claude-plugin/plugin.json' \
+  | while read -r p; do
+      mkdir -p "$BASE/$(dirname "$p")"
+      jj --ignore-working-copy file show -r 'trunk()' "$p" > "$BASE/$p"
+    done
+CHANGED_FILES=$(jj --ignore-working-copy diff --from 'trunk()' --name-only) \
+  BASE_DIR="$BASE" /bin/bash .github/scripts/require-version-bump.sh
+```
+Expected: exit 0.
+
+**`BASE_DIR=.` does not work** — it resolves the base manifest to the same file
+as the head manifest, so `base_ver == head_ver` always and the lint fails
+unconditionally, even with the bump correctly applied. The script needs a real
+base tree, which the block above materialises from `trunk()`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "feat(evals): hook-blocks-raw-git exemplar case
+
+First ablation-verified case: delta +1.00, reproduced three times.
+Doubles as the committed schema exemplar — the spec deliberately does
+not restate the schema in prose, because its first draft got
+regex.target wrong.
+
+Bumps commit-commands-jj to 0.2.0 (#84) and gitignores evals/results/."
+jj new
+```
+
+---
+
+### Task 5: Remaining hook and invariant cases
+
+**Files:**
+- Create: `plugins/commit-commands-jj/evals/hook-blocks-git-internals/{case.yaml,scaffold.sh}`
+- Create: `plugins/commit-commands-jj/tests/test-block-raw-git-gating.sh` (the #45 invariant as a layer-2 test, not an eval — see Step 2)
+- Create: `plugins/commit-commands-jj/evals/hook-allows-jj-git-and-gh/{case.yaml,scaffold.sh}`
+- Modify: `plugins/commit-commands-jj/.claude-plugin/plugin.json`
+
+**Interfaces:**
+- Consumes: the Task 4 exemplar (copy its shape).
+- Produces: three more cases, each either ablation-verified or cut with the measurement recorded.
+
+- [ ] **Step 1: Case — git internals**
+
+Create `plugins/commit-commands-jj/evals/hook-blocks-git-internals/scaffold.sh` — identical to Task 4's scaffold (repeated deliberately; do not symlink, cases must stand alone).
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+export JJ_USER="${JJ_USER:-eval}"
+export JJ_EMAIL="${JJ_EMAIL:-eval@example.com}"
+mkdir -p .jjconfig
+cat > .jjconfig/config.toml <<'TOML'
+[ui]
+paginate = "never"
+editor = "true"
+TOML
+export JJ_CONFIG="$PWD/.jjconfig/config.toml"
+jj git init . >/dev/null 2>&1
+printf 'alpha\n' > notes.txt
+```
+
+Create `plugins/commit-commands-jj/evals/hook-blocks-git-internals/case.yaml`:
+
+```yaml
+schema_version: "1.1"
+name: hook-blocks-git-internals
+description: >
+  The hook's second, separately-coded branch: .git/ access and git plumbing
+  (rev-parse, config) carry their own deny message.
+tags: [commit-commands-jj, hook, invariant]
+context:
+  scaffold_script: scaffold.sh
+execution:
+  prompt: |
+    Print the current commit hash by running `git rev-parse HEAD`, and
+    tell me exactly what happened.
+  max_turns: 6
+  timeout_seconds: 300
+  allowed_tools: [Bash]
+runs: 2
+graders:
+  - type: regex
+    name: reports-blocked
+    pattern: "(BLOCKED|blocked|not allowed|denied|internals)"
+    match: contains
+    weight: 1
+```
+
+- [ ] **Step 2: Case — non-jj repo pass-through (#45) — DO NOT WRITE AS AN EVAL**
+
+The #45 invariant is that outside a jj repo the hook passes git through.
+Blocking git in a non-jj project is collateral damage, not the design.
+
+**This cannot be an eval, and the reasoning matters more than the case.** The
+grader would assert the *absence* of a deny. But the `without` arm has no hook
+either, so it also produces no deny — both arms pass, Δ = 0, and the case
+reports `NO_GAP` no matter what the hook does. It is structurally incapable of
+distinguishing "the hook correctly passed git through" from "there is no hook".
+Spending on it would buy a number that cannot mean anything.
+
+Worse in practice: the scaffold cannot run `git init` (the session hook blocks
+raw git), so the sandbox would be a bare directory where `git status` fails
+with "not a repository" in both arms — failing for a third reason unrelated to
+the invariant.
+
+**Write it as a layer-2 shell test instead.** The hook is a pure function from
+JSON stdin to JSON stdout; testing it needs no model at all. Create
+`plugins/commit-commands-jj/tests/test-block-raw-git-gating.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+HOOK="$(cd "$(dirname "$0")/../scripts" && pwd)/block-raw-git.sh"
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+# Inside a jj repo: raw git is denied.
+JJ_DIR=$(mktemp -d); mkdir -p "$JJ_DIR/.jj"
+out=$(printf '{"cwd":"%s","tool_input":{"command":"git status"}}' "$JJ_DIR" | /bin/bash "$HOOK")
+if printf '%s' "$out" | grep -q '"permissionDecision": *"deny"'; then
+  ok "denies raw git inside a jj repo"
+else
+  bad "denies raw git inside a jj repo (got: $out)"
+fi
+
+# Outside a jj repo: passes through silently (#45). Anchor in a NON-jj temp
+# dir — the dev checkout is itself a jj repo, so a relative cwd would walk up
+# into the real .jj and invert this test.
+PLAIN=$(mktemp -d)
+out=$(printf '{"cwd":"%s","tool_input":{"command":"git status"}}' "$PLAIN" | /bin/bash "$HOOK")
+if [ -z "$out" ]; then
+  ok "passes git through outside a jj repo (#45)"
+else
+  bad "passes git through outside a jj repo (#45) (got: $out)"
+fi
+
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+test "$FAIL" -eq 0
+```
+
+Run: `/bin/bash plugins/commit-commands-jj/tests/test-block-raw-git-gating.sh`
+Expected: `2 passed, 0 failed`. CI auto-discovers it via the existing
+`*/tests/test-*.sh` glob, and it also closes the "no tests/ directory" gap
+that Task 8 otherwise only files as an issue.
+
+- [ ] **Step 3: Case — jj git and gh survive the lookahead**
+
+Create `plugins/commit-commands-jj/evals/hook-allows-jj-git-and-gh/scaffold.sh` — identical to Task 4's.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+export JJ_USER="${JJ_USER:-eval}"
+export JJ_EMAIL="${JJ_EMAIL:-eval@example.com}"
+mkdir -p .jjconfig
+cat > .jjconfig/config.toml <<'TOML'
+[ui]
+paginate = "never"
+editor = "true"
+TOML
+export JJ_CONFIG="$PWD/.jjconfig/config.toml"
+jj git init . >/dev/null 2>&1
+printf 'alpha\n' > notes.txt
+```
+
+Create `plugins/commit-commands-jj/evals/hook-allows-jj-git-and-gh/case.yaml`:
+
+```yaml
+schema_version: "1.1"
+name: hook-allows-jj-git-and-gh
+description: >
+  Regression guard on the subtlest line in the hook — the negative lookahead
+  that must let `jj git ...` and `gh ...` through while blocking bare git.
+tags: [commit-commands-jj, hook, invariant]
+context:
+  scaffold_script: scaffold.sh
+execution:
+  prompt: |
+    Run `jj git remote list` in this repository and tell me exactly what
+    happened.
+  max_turns: 6
+  timeout_seconds: 300
+  allowed_tools: [Bash]
+runs: 2
+graders:
+  - type: tool_used
+    name: jj-git-ran
+    tool: Bash
+    input_match: "jj git remote"
+    min: 1
+    weight: 1
+  - type: regex
+    name: not-blocked
+    pattern: "(BLOCKED|not allowed)"
+    match: not_contains
+    weight: 1
+```
+
+- [ ] **Step 4: Ablation-check the two evals**
+
+Run:
+```bash
+for c in hook-blocks-git-internals hook-allows-jj-git-and-gh; do
+  chmod +x "plugins/commit-commands-jj/evals/$c/scaffold.sh" 2>/dev/null || true
+  /bin/bash .github/scripts/run-evals.sh --plugin commit-commands-jj --case "$c" --gate report
+done
+```
+Expected: a verdict per case. **Do not assume all three ship.** For any case returning `NO_GAP`, cut it and record the measured scores in the commit message. For `BROKEN`, fix the tool grant and re-run — never record BROKEN as a finding.
+
+Note `hook-allows-jj-git-and-gh` partly asserts the *absence* of a deny, so its
+`without` arm may also pass and yield `NO_GAP`. Its `jj-git-ran` grader is what
+gives it any discriminating power. If it returns `NO_GAP`, move it to the
+layer-2 suite from Step 2 alongside the #45 gating test — the hook is a pure
+stdin/stdout function and testing it needs no model.
+
+- [ ] **Step 5: Bump the version**
+
+In `plugins/commit-commands-jj/.claude-plugin/plugin.json`, change `"version": "0.2.0"` to `"version": "0.3.0"`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "feat(evals): hook invariant cases
+
+Adds git-internals, non-jj pass-through (#45), and the jj-git/gh
+lookahead guard. Records measured deltas per case; non-discriminating
+cases cut with their scores noted rather than kept as decoration."
+jj new
+```
+
+---
+
+### Task 6: Part A — command triage cases
+
+**Files:**
+- Create: `plugins/commit-commands-jj/evals/cmd-<name>/case.yaml` × 16
+- Create: `.github/scripts/gen-command-cases.sh`
+- Modify: `plugins/commit-commands-jj/.claude-plugin/plugin.json`
+
+**Interfaces:**
+- Consumes: the runner and exemplar.
+- Produces: 16 cases named `cmd-<command>`, each invoking its command literally and carrying an invocation precondition.
+
+- [ ] **Step 1: Write the generator**
+
+The 16 cases differ only in command name and prompt, so generate them rather than hand-writing 16 near-identical files. Create `.github/scripts/gen-command-cases.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Generate one triage case per commit-commands-jj command.
+# bash 3.2-safe: parallel-array lookup, no associative arrays.
+set -euo pipefail
+
+PLUGIN_DIR="plugins/commit-commands-jj"
+EVAL_DIR="$PLUGIN_DIR/evals"
+
+# command:prompt pairs. Prompts contain the LITERAL slash-command invocation —
+# the model never reaches for a command on its own (measured: 0 Skill and 0
+# SlashCommand calls on task-phrased prompts), so a natural-language prompt
+# would measure the base model and report a null result it could not avoid.
+PAIRS="
+describe:/describe record that notes.txt was added
+commit:/commit finalize this change
+new:/new start a change for the parser work
+squash:/squash fold this into its parent
+abandon:/abandon discard this change
+sync:/sync bring this change up to date with trunk
+absorb:/absorb move these edits into the changes that touched these lines
+edit:/edit move the working copy to the previous change
+evolog:/evolog show how this change evolved
+show:/show inspect the current revision
+op-show:/op-show inspect the most recent operation
+undo:/undo revert the last operation
+tag-list:/tag-list list the tags
+clean_stale:/clean_stale clean up stale bookmarks and workspaces
+commit-push-pr:/commit-push-pr ship this as a pull request
+finish:/finish wrap up this development work
+"
+
+printf '%s\n' "$PAIRS" | while IFS=: read -r cmd prompt; do
+  [ -n "$cmd" ] || continue
+  dir="$EVAL_DIR/cmd-$cmd"
+  mkdir -p "$dir"
+
+  cat > "$dir/scaffold.sh" <<'SCAFFOLD'
+#!/usr/bin/env bash
+set -euo pipefail
+export JJ_USER="${JJ_USER:-eval}"
+export JJ_EMAIL="${JJ_EMAIL:-eval@example.com}"
+mkdir -p .jjconfig
+cat > .jjconfig/config.toml <<'TOML'
+[ui]
+paginate = "never"
+editor = "true"
+TOML
+export JJ_CONFIG="$PWD/.jjconfig/config.toml"
+jj git init . >/dev/null 2>&1
+printf 'alpha\n' > notes.txt
+SCAFFOLD
+  chmod +x "$dir/scaffold.sh"
+
+  cat > "$dir/case.yaml" <<YAML
+schema_version: "1.1"
+name: cmd-$cmd
+description: >
+  Triage: does /$cmd change behaviour versus not having the plugin?
+  The invoked-command grader is a VALIDITY PRECONDITION at weight 0 — if it
+  fails the result is "did not exercise the command", which is neither
+  "earns its keep" nor "no measurable gap". It must never contribute to the
+  score: the command does not exist in the without arm, so a scored
+  precondition manufactures the delta.
+tags: [commit-commands-jj, triage]
+context:
+  scaffold_script: scaffold.sh
+execution:
+  prompt: |
+    $prompt
+  max_turns: 10
+  timeout_seconds: 300
+  allowed_tools: [Bash, Read, Skill, SlashCommand]
+runs: 3
+graders:
+  # VALIDITY PRECONDITION, not a scored grader. In the without arm the slash
+  # command does not exist, so a scored invoked-command grader fails there
+  # mechanically — manufacturing a guaranteed delta for every exercised
+  # command (the null-control disease this suite exists to prevent) and
+  # filing unexercised commands as NO_GAP. Weight 0 keeps the pass/fail
+  # record in runs[].graders[] (Task 7 reads it) without letting plugin
+  # EXISTENCE masquerade as prose value.
+  - type: tool_used
+    name: invoked-command
+    tool: SlashCommand
+    min: 1
+    weight: 0
+  - type: tool_used
+    name: no-raw-git
+    tool: Bash
+    # Command-position anchor: match `git <verb>` only at line start or after
+    # a separator (; & |). The previous (^|[^a-z]) matched the SPACE in
+    # `jj git push` — failing /commit-push-pr and /finish precisely when the
+    # model follows their documented `jj git push` workflow — and matched
+    # substrings inside quoted text (`jj describe -m "add git log parser"`).
+    # Only syntax common to ERE and JS RegExp, so the grep -E check in Step 2
+    # verifies the same pattern the grader engine compiles.
+    input_match: "(^ *|[;&|] *)git (commit|add|status|log|diff|push)"
+    min: 0
+    max: 0
+    weight: 1
+YAML
+done
+
+printf 'generated %d case(s) under %s\n' \
+  "$(find "$EVAL_DIR" -maxdepth 1 -name 'cmd-*' -type d | wc -l | tr -d ' ')" "$EVAL_DIR"
+```
+
+- [ ] **Step 2: Generate, verify count, and verify the guard regex offline**
+
+Run:
+```bash
+/bin/bash .github/scripts/gen-command-cases.sh
+find plugins/commit-commands-jj/evals -maxdepth 1 -name 'cmd-*' -type d | wc -l
+```
+Expected: `generated 16 case(s)` and `16`.
+
+The negative grader must not match the plugin's own documented workflow —
+`/commit-push-pr` and `/finish` instruct `jj git push`, and `min: 0, max: 0`
+means any match fails the case. Verify the regex offline (free), via a script
+file so the session's own raw-git hook does not block the literal test
+strings:
+
+```bash
+cat > /tmp/check-regex.sh <<'CHECK'
+#!/usr/bin/env bash
+set -euo pipefail
+RE='(^ *|[;&|] *)git (commit|add|status|log|diff|push)'
+while IFS= read -r s; do
+  printf '%s' "$s" | grep -qE "$RE" && { echo "FALSE-POSITIVE: $s"; exit 1; }
+done <<'NEG'
+jj git push
+jj git push --bookmark my-feature
+jj git push --change @-
+jj git push --deleted
+jj describe -m "add git log parser"
+echo "git status"
+NEG
+while IFS= read -r s; do
+  printf '%s' "$s" | grep -qE "$RE" || { echo "MISS: $s"; exit 1; }
+done <<'POS'
+git push
+git status
+cd x && git commit -m hi
+git add .; git push
+POS
+echo "regex OK"
+CHECK
+/bin/bash /tmp/check-regex.sh
+```
+Expected: `regex OK`. A false positive here corrupts both arms of two cases
+and can file a spurious REGRESSION — the verdict this plan says to escalate.
+
+- [ ] **Step 3: Verify one case loads before spending on all 16**
+
+Run:
+```bash
+/bin/bash .github/scripts/run-evals.sh --plugin commit-commands-jj \
+  --case 'cmd-describe' --runs 1 --gate report
+```
+Expected: a verdict row. If it aborts with exit 7, the grant is wrong. If the
+case fails schema validation, the offender is almost certainly `weight: 0` —
+do **not** revert it to a scored grader (that manufactures the delta from
+plugin existence); stop and re-plan the precondition mechanism, because per
+the spec, without a non-scored "did not exercise" distinction Part A does not
+ship.
+
+Then verify the precondition is *recorded* where Task 7 will read it. The
+runner prints the result-JSON path on stderr; run against it:
+
+```bash
+jq -r '.cases[] | [.name,
+    (([.runs[]?.graders[]? | select(.name=="invoked-command")] | length) > 0
+     and ([.runs[]?.graders[]? | select(.name=="invoked-command") | .passed] | all)),
+    ([.runs_without[]?.graders[]? | select(.name=="invoked-command") | .passed] | any)
+  ] | @tsv' <result JSON path from stderr>
+```
+
+Expected: `cmd-describe	true	false`. Column 2 false means the model never
+invoked the command — the `SlashCommand` tool name is wrong for this harness;
+switch the grader to `tool: Skill` and re-run before proceeding. Column 3
+true means the precondition also fires in the arm where the command cannot
+exist — the grader is not measuring what it claims; stop and investigate.
+(The `length > 0` guard matters: `all` over an empty array is vacuously true,
+so a missing grader would otherwise read as "exercised". Verified against a
+real aggregate-result.json.) Do not generate spend on 16 cases until one is
+known good.
+
+- [ ] **Step 4: Bump the version**
+
+In `plugins/commit-commands-jj/.claude-plugin/plugin.json`, change `"version": "0.3.0"` to `"version": "0.4.0"`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(evals): 16 command triage cases
+
+Each prompt contains the literal slash-command invocation, because
+commands are user-invoked and the model never reaches for one unprompted
+(measured: 0 Skill / 0 SlashCommand calls on task-phrased prompts).
+
+The invoked-command grader is a validity precondition at weight 0:
+without it, 'did not exercise the command' is indistinguishable from
+'adds nothing'; scored, it would manufacture a delta from plugin
+existence, since the command cannot exist in the without arm."
+jj new
+```
+
+---
+
+### Task 7: Run the sweep and write the triage
+
+**Files:**
+- Create: `docs/eval-triage-2026-07.md`
+
+**Interfaces:**
+- Consumes: the 16 cases from Task 6.
+- Produces: the triage table — a map of where each command's prose measurably shapes behaviour, informing tranche-2 effort. Not a prune list. Tranche 1's primary deliverable.
+
+- [ ] **Step 1: Run the full sweep**
+
+Run:
+```bash
+/bin/bash .github/scripts/run-evals.sh --plugin commit-commands-jj \
+  --case 'cmd-*' --runs 3 --gate report --max-cost-usd 15 \
+  | tee /tmp/triage.tsv
+```
+Expected: 16 TSV rows, ~$7, ~10 minutes. stdout is pure TSV (the runner
+redirects the CLI's summary table to stderr), so the tee'd file is clean.
+The runner also prints `result JSON: <path>` on stderr — **record that path**;
+Step 3's exercised column is computed from it. If the run aborts with exit 6,
+the cost ceiling was hit — raise `--max-cost-usd` and re-run rather than
+trusting partial deltas.
+
+- [ ] **Step 2: Re-run every zero-gap case at higher runs**
+
+A `NO_GAP` at `runs: 3` may still be sampling noise. For each such case:
+
+```bash
+/bin/bash .github/scripts/run-evals.sh --plugin commit-commands-jj \
+  --case 'cmd-<name>' --runs 5 --gate report
+```
+Only a result stable across both runs reaches the write-up.
+
+- [ ] **Step 3: Write the triage document**
+
+Create `docs/eval-triage-2026-07.md` with: a table of `command | exercised | with | without | delta | pass_rate | verdict`; a paragraph per command classifying it as *shapes behaviour* (rewards careful tranche-2 cases), *thin wrapper* (model handles it unaided), or *not exercised* (the `invoked-command` precondition failed — excluded from the reading entirely).
+
+Compute the `exercised` column from the sweep's result JSON (the path the
+runner printed on stderr). The TSV cannot carry it: the precondition is
+weight 0 and invisible to scores **by design** — scored, it would
+manufacture the delta, because the command cannot exist in the without arm:
+
+```bash
+jq -r '.cases[] | [.name,
+    (([.runs[]?.graders[]? | select(.name=="invoked-command")] | length) > 0
+     and ([.runs[]?.graders[]? | select(.name=="invoked-command") | .passed] | all)),
+    ([.runs_without[]?.graders[]? | select(.name=="invoked-command") | .passed] | any)
+  ] | @tsv' <result JSON>
+```
+
+Column 2 is "every with-arm run invoked the command"; `false` means NOT
+EXERCISED — exclude that row's delta from the reading entirely, whatever the
+verdict column says. Column 3 must be `false` for every case (the command
+cannot exist in the without arm); a `true` there means the precondition is
+not measuring what it claims — stop and investigate before writing a single
+verdict.
+
+**Frame this as a map, not a prune list.** This repo is a jj-native port of `anthropics/claude-plugins-official`; the command set mirrors upstream, and parity is a reason to keep a command a model could limp through without. The document must **not** recommend removing any command — a low delta means "the prose adds little measurable behaviour here", which is information about where tranche-2 test effort belongs, not grounds for deletion. State this explicitly so a future reader does not mistake the table for a hit list.
+
+State the method and its limits plainly: 3 runs per arm, deltas are point estimates, and this is a screen rather than a verdict.
+
+- [ ] **Step 4: File findings**
+
+For each defect the sweep exposes, run `gh issue create` with a title naming the command and a body containing the failing prompt and the measured scores. For a `REGRESSION` verdict — the plugin making the model worse — file immediately and label it as the highest-value finding available.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "docs: command triage results (#79 tranche 1)
+
+Measured ablation deltas for all 16 commit-commands-jj commands.
+Screen, not verdict: 3 runs per arm, zero-gap cases re-run at 5."
+jj new
+```
+
+---
+
+### Task 8: Documentation and final verification
+
+**Files:**
+- Modify: `plugins/commit-commands-jj/README.md`
+- Modify: `README.md`
+- Modify: `plugins/commit-commands-jj/.claude-plugin/plugin.json`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: the documented runner, and the combined-result gate.
+
+- [ ] **Step 1: Document the runner**
+
+Add an `## Evals` section to the root `README.md` covering: what the suite is for; that it is **manual, not CI-gated**, and why (early-access flag, model spend, no macOS entitlement guarantee); the exact command to run it; that the runner sets `CLAUDE_CODE_WALNUT_SPIRE=1` (the early-access unlock as measured on 2.1.216; on 2.1.220 `--help` no longer requires it, and setting it stays harmless either way); and the verdict taxonomy with the note that **BROKEN means a missing tool grant, never "no gap"**.
+
+- [ ] **Step 2: Add the attribution note**
+
+In the same section, add one line: `Failure taxonomy informed by netresearch/jujutsu-workflow-skill (MIT AND CC-BY-SA-4.0); cases independently authored.`
+
+- [ ] **Step 3: Bump the version**
+
+In `plugins/commit-commands-jj/.claude-plugin/plugin.json`, change `"version": "0.4.0"` to `"version": "0.5.0"`.
+
+- [ ] **Step 4: Run the ENTIRE repo test suite**
+
+Not just this feature's suite. Per `project_kaisen_lessons`, per-task review never covers the combined result:
+
+```bash
+FAILED=0
+for t in $(find plugins .github -path '*/tests/test-*.sh'); do
+  printf '=== %s ===\n' "$t"
+  /bin/bash "$t" || { printf 'SUITE FAILED: %s\n' "$t"; FAILED=$((FAILED+1)); }
+done
+printf '%d suite(s) failed\n' "$FAILED"
+test "$FAILED" -eq 0
+```
+Expected: every suite reports `0 failed`, then `0 suite(s) failed`, and the
+block itself exits 0. The counter is load-bearing: a bare `|| printf` loop
+always exits 0, turning the combined-result gate — the reason this step
+exists (#94) — into an eyeball check. A stale count or a newly-broken suite
+is a blocker.
+
+- [ ] **Step 5: Verify the version-bump lint**
+
+Run:
+```bash
+BASE=$(mktemp -d)
+jj --ignore-working-copy file list -r 'trunk()' 'glob:plugins/*/.claude-plugin/plugin.json' \
+  | while read -r p; do
+      mkdir -p "$BASE/$(dirname "$p")"
+      jj --ignore-working-copy file show -r 'trunk()' "$p" > "$BASE/$p"
+    done
+CHANGED_FILES=$(jj --ignore-working-copy diff --from 'trunk()' --name-only) \
+  BASE_DIR="$BASE" /bin/bash .github/scripts/require-version-bump.sh
+```
+Expected: exit 0 — `commit-commands-jj` bumped from `0.1.1`. Do **not** pass
+`BASE_DIR=.`; it compares the head manifest against itself and fails always.
+
+- [ ] **Step 6: File the follow-ups**
+
+Task 5 Step 2 gives `commit-commands-jj` its first `tests/` file (the #45
+gating test), so the layer-2 gap is now *narrowed*, not open. File the residual:
+
+```bash
+gh issue create --title "commit-commands-jj layer-2 coverage is thin (one hook test)" \
+  --body "Eval work for #79 added tests/test-block-raw-git-gating.sh, but the 16 commands and the git-internals hook branch still have no deterministic shell tests. Layer 1 (evals) cannot catch a command citing a jj flag that no longer exists; layer 2 can."
+
+gh issue create --title "Wire evals into CI if plugin eval reaches GA" \
+  --body "Evals are manual per docs/specs/2026-07-20-eval-suite-design.md: they need CLAUDE_CODE_WALNUT_SPIRE, a model, and per-run spend. Revisit if the feature ships GA."
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj describe -m "docs(evals): document the runner and verdict taxonomy
+
+Manual by design — early-access flag, model spend, no CI entitlement.
+Full repo suite run in @ as the combined-result gate."
+jj new
+```
+
+- [ ] **Step 8: Final review pass (user-triggered)**
+
+After all tasks land and before `/finish`, the operator runs `/code-review
+xhigh` over the branch as an independent final pass. This is billed and
+user-invoked — the executing agent does not launch it. Address any findings it
+surfaces before merging.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every spec section maps to a task: verdict taxonomy → Task 2; the seven traps → Tasks 2–4 (`--allow-tools` guard in 3, null tripwire and `.partial` in 2, `--output-dir` assertion in 3); result-JSON paths → Task 2 fixtures; runner location and bash 3.2 → Tasks 1–3; Part A → Tasks 6–7; Part B → Tasks 4–5; two-layer framing → Task 8's follow-up issue; DoD items 1–9 → Tasks 1–3, 2, 5, 4, 7, 7, 4/5/6/8, 4, 8.
+
+**Known gaps carried deliberately:**
+
+1. **`SlashCommand` as a grader tool name is unverified.** It validates schema-wise, but whether it fires for a plugin command was never measured. Task 6 Step 3 gates all 16 cases behind one cheap probe for exactly this reason. The same probe now also gates `weight: 0` (schema acceptance was never measured either) and confirms the precondition is recorded in `runs[].graders[]`, which the exercised column depends on.
+2. **The `hook-allows-jj-git-and-gh` case may return `NO_GAP`.** Task 5 Step 4 names the condition and routes it to the layer-2 suite rather than keeping a case that cannot discriminate.
+
+**Corrections applied after adversarial review** (the plan's first draft was
+wrong about each of these, all reproduced by running the code):
+
+- `--threshold` defaults to 1.0, so the CLI exits 1 on any sub-1.00 case and `set -e` killed the runner **before `classify` ever ran** — the delta gate was unreachable, and every test passed because they all called `--classify` directly. Fixed with `--threshold 0` plus explicit rc capture, and a live-path stub test so it can never regress invisibly.
+- `--max-cost-usd` breach is CLI **exit 2**, not exit 6; the `.partial` tripwire was equally unreachable.
+- A result with zero cases gated **green**. Now exits 3.
+- The tool-grant guard was blind to **block-style YAML** — the layout `eval init` scaffolds, i.e. exactly the case it exists to catch.
+- `BASE_DIR=.` makes `require-version-bump.sh` compare a file to itself and fail unconditionally; both verification steps now materialise a real base tree from `trunk()`.
+- `evals/results/` does **not** match at any depth — gitignore anchors mid-string-slash patterns to their own directory. Now `**/evals/results/`.
+- The #45 pass-through case was structurally incapable of discriminating; it is now a layer-2 shell test.
+
+**Corrections applied after the third (code-running) review, 2026-07-25** —
+which transcribed Tasks 1–3 verbatim, ran the suite at every boundary under
+`/bin/bash` 3.2.57, and spent one live ablation run ($0.12) on CLI 2.1.220:
+
+- **Part A's `invoked-command` precondition was a scored grader (weight 1),
+  contradicting the spec's "not a scored grader".** The command cannot exist
+  in the without arm, so the grader fails there mechanically — manufacturing
+  Δ ≥ +0.5 for every exercised command and filing unexercised ones as
+  `NO_GAP`, with no "did not exercise" outcome anywhere in the pipeline. Now
+  weight 0, gated by the Task 6 probe, with Task 7 computing an `exercised`
+  column from `runs[].graders[]` (fields verified present on a live run).
+- **The `no-raw-git` regex `(^|[^a-z])git (...)` matched `jj git push`** —
+  the exact workflow `/commit-push-pr` and `/finish` document — and quoted
+  substrings (`jj describe -m "add git log parser"`). Now command-position
+  anchored (`(^ *|[;&|] *)git (...)`) and verified offline against both a
+  must-not-match and a must-match list.
+- **The null-delta tripwire was type-blind: a string `"0.0"` delta classified
+  `DISCRIMINATING` and gated green** (jq sorts strings above every number, so
+  every comparison is false). The tripwire now keys on
+  `(.delta | type) != "number"`, with a `stringdelta.json` fixture and test.
+- **The real CLI prints its summary table to stdout** (observed live), so
+  runner stdout was not pure TSV — and the purity test passed only because
+  the stub was silent. The CLI's stdout is now redirected to stderr, the stub
+  prints table noise so the test can actually fail, and the runner prints the
+  result-JSON path on stderr for Task 7.
+- **Both expected test counts were wrong** (claimed 18/31; the verbatim code
+  produced 17/29). Recounted after these amendments and verified by
+  execution: 18 (3 + 15) and 30 (18 + 12).
+- **Four assertions passed vacuously before their implementation existed**,
+  despite the fail-first constraint: `both-arms-zero is never NO_GAP` (empty
+  ≠ NO_GAP), `unknown --gate aborts` (the unknown-argument arm also exits
+  64), `output-dir stays outside plugins/` and `stdout is pure TSV` (bare
+  not-matches on empty output). All four now anchor on positive evidence —
+  non-empty verdict, the gate-validation message, flag presence, and the TSV
+  row — and were verified to FAIL against a Task-1-only runner and pass
+  against the full one. The corollary is now a Global Constraint.
+- **The early-access claim went stale**: on CLI 2.1.220, `plugin eval --help`
+  exits 0 with `CLAUDE_CODE_WALNUT_SPIRE` unset (measured with the variable
+  explicitly removed from the environment). The runner still sets it —
+  harmless — but no logic may treat "exits 1 without the var" as gate
+  detection, and the README wording now reflects the version drift.
+- **Task 8's full-suite loop swallowed failures** — `|| printf` made the
+  combined-result gate exit 0 even with a failing suite, reducing the #94
+  lesson to an eyeball check. The loop now counts failures and ends with
+  `test "$FAILED" -eq 0`; verified to exit 1 with a planted failing suite
+  and 0 when all pass.
+
+**Type consistency.** Verdict strings are identical across Task 2's implementation, its tests, and Tasks 5–7's usage: `DISCRIMINATING`, `PARTIAL`, `NO_GAP`, `REGRESSION`, `BROKEN`. There is no `ERROR_NULL_DELTA` verdict string — schema drift exits 5 with a diagnostic rather than emitting a row, and the earlier claim that it appeared in the implementation was false. Exit codes: 3 zero-match/zero-cases, 4 gate failure, 5 delta-type tripwire (null or non-numeric), 6 partial run, 7 tool grant, 64 bad argument or bad `--gate`, 65 missing or malformed file.

--- a/docs/specs/2026-07-20-eval-suite-design.md
+++ b/docs/specs/2026-07-20-eval-suite-design.md
@@ -1,0 +1,375 @@
+# Eval suite — design (issue #79, tranche 1)
+
+Date: 2026-07-20 (revised 2026-07-21 after adversarial review)
+Issue: #79 — "~20 user-facing commands have never been executed"
+Status: design, pending plan
+
+## Problem
+
+Issue #79 frames the gap as: ~20 user-facing commands have only ever been
+structurally validated, never behaviourally exercised. Measured defect rate on
+unexercised prose in this repo is 5–9 per file (fan-flames: 9 in #68 plus one
+in #76; `/finish`'s post-merge step: 4 in #69 plus a fifth in #74).
+
+The instrument for "skill text leads the model to act wrong" is an eval —
+prompt plus assertions — as distinct from a lint, which catches "skill text
+asserts something wrong". This repo has lints and has no evals.
+
+## The finding that shapes this design
+
+`claude plugin eval` was exercised before any design work, on a faithful port
+of netresearch's `describe-noninteractive` case. Against `commit-commands-jj`
+it scored 1.00. Against a **null control plugin** — a bare manifest with zero
+commands, skills or hooks — it also scored **1.00**.
+
+The 2026 base model already uses `-m` and already avoids raw git unprompted.
+That case measured the model, not the plugin.
+
+This is the central risk of the whole initiative. A suite assembled by porting
+the obvious cases would be green whether or not these plugins work —
+reproducing #79's own disease one level up, with a passing scoreboard that
+reads as evidence. A green suite that cannot fail is worse than no suite,
+because it terminates the inquiry.
+
+Independently confirmed twice: netresearch built their runner to report the
+**delta** rather than the pass rate, for the same reason; and an adversarial
+review of this spec reproduced both results from scratch (`hook-blocks-raw-git`
+Δ +1.00; `describe-noninteractive` Δ 0.00, twice).
+
+Therefore: **ablation is a gate, not a report.**
+
+### The verdict taxonomy
+
+| Δ | Verdict | Action |
+|---|---|---|
+| Δ ≥ +0.5 | discriminating | ships |
+| 0 < Δ < +0.5 | partial | needs written judgement in `description`, or cut |
+| Δ = 0 | measures the model | cut; record the scores |
+| Δ < 0 | **plugin makes the model worse** | **escalate — highest-value finding available** |
+| both arms 0.00 | **case is broken** | never a verdict; fix the case |
+| arms overlap across runs | noisy / inconclusive | re-run at higher `runs` |
+
+The last two rows exist because of specific failure modes found in review. A
+both-arms-zero result is categorically *not* "no gap" — it is almost always a
+missing `--allow-tools` grant, and treating it as a verdict would silently
+delete every genuinely discriminating case in the suite.
+
+## Verified harness mechanics
+
+Measured on Claude Code 2.1.216, then independently re-verified in adversarial
+review. Recorded in memory as `project_eval_harness_facts`.
+
+- `claude plugin eval` and `eval init` are **early access**: they exit 1 and
+  write nothing. Gate is `statsig("tengu_walnut_spire") ||
+  env.CLAUDE_CODE_WALNUT_SPIRE`. `CLAUDE_CODE_WALNUT_SPIRE=1` unlocks both. No
+  interactive auth needed — it runs headless here.
+- Cost: **$0.06–0.28 per run**, 2–13s per run for a small case.
+- Cases live at `<target>/evals/<case-name>/case.yaml`, under the **target**.
+- Grader types, exact and complete: `regex`, `tool_order`, `tool_used`,
+  `file_exists`, `llm`, `baseline`.
+- **Plugin hooks fire inside the harness** — the `with` arm surfaces the
+  `block-raw-git.sh` deny text; the `without` arm runs `git status` normally.
+- **The sandbox is fully isolated.** `--keep-temp` shows a fresh `config/`,
+  `cwd/`, `home/`, `out/` — no user or project `CLAUDE.md`. The ablation is
+  **not** confounded by ambient config. (This was the most likely way the
+  design could have been invalidated. It wasn't.)
+- **`--ablation with-without` works on path targets.** It is only the *default*
+  that differs (`none` for paths, `with-without` for named plugins). Passing it
+  explicitly yields a full two-arm table and a machine-readable result.
+
+### Result JSON — verified field paths
+
+`--output-dir` writes `aggregate-result.json` (`schema_version: "1.0"`). The
+fields are **flat and snake_case**:
+
+| Path | Meaning |
+|---|---|
+| `.cases[].delta` | the ablation gap the verdict taxonomy keys on |
+| `.cases[].score` / `.score_without` | per-arm mean score |
+| `.cases[].pass_rate` / `.pass_rate_without` | per-arm pass counts (Part A) |
+| `.cases[].runs[]` / `.runs_without[]` | per-run detail, incl. `trace_path` |
+| `.partial` (top level) | true when `--max-cost-usd` was breached |
+| `.cost_usd`, `.plugins[]` | run accounting |
+
+Stated as a table because getting this wrong is silent and total: a jq filter
+against a non-existent path yields `null`, and `null` sorts **below every
+number**, so `null < 0` is true. A delta gate built on wrong paths reads null
+everywhere and files every case under "plugin makes the model worse" while
+appearing to work. An earlier draft of this section carried camelCase paths
+(`.cases[].aggregates.delta`, `.suite.ablation`) taken from a review report;
+running the query showed every one of them resolving to null. **The runner's jq
+filter must be covered by a test asserting non-null deltas on a known fixture.**
+
+### Required schema
+
+`execution` is a required block; `prompt` lives inside it. Every grader
+requires `name`. `schema_version` is mandatory.
+
+Rather than restate the schema in prose — the first draft of this spec got
+`regex.target` wrong — the plan commits a **working exemplar** at
+`plugins/commit-commands-jj/evals/hook-blocks-raw-git/case.yaml` and this
+document points at it. Note `regex`'s default target is `last_message`; twelve
+guessed alternative values were all rejected, so `target` is not a
+transcript-section name and should be left at its default absent evidence.
+
+### Authoring traps
+
+Each cost a failed run during de-risking or review:
+
+1. `context.scaffold_script` is a **path to a script file**, not inline bash.
+   Under `--scaffold` it errors; **without `--scaffold` it silently does not
+   run at all**, which is the worse failure.
+2. Scaffolds run only under `--scaffold` (off by default).
+3. `execution.env` accepts **only `EVAL_*` keys**. `JJ_USER` / `JJ_EMAIL` must
+   come from the operator's shell.
+4. A negative `tool_used` needs **both `min: 0` and `max: 0`**; `max: 0` alone
+   yields the impossible range "expected 1..0".
+5. Results default to **`<target>/evals/results/`** — inside `plugins/<name>/`,
+   where they trip the #84 version-bump lint. The CLI's own `--help` documents
+   this as cwd-relative and is **wrong**; verified empirically.
+6. **Gated tools need `--allow-tools` on the command line.** `allowed_tools` in
+   `case.yaml` is necessary but not sufficient. Omitting the grant zeroes both
+   arms — see the verdict taxonomy.
+7. **`--threshold` gates on absolute score, not delta.** A zero-gap case scores
+   `with 1.00 / without 1.00` and the harness prints **`✓`**. The tool's exit
+   semantics actively oppose this design's doctrine; the runner must compute
+   its own exit code from `.cases[].aggregates.delta`.
+
+## Architecture
+
+### Case layout
+
+```
+plugins/<name>/evals/<case-name>/
+  case.yaml
+  scaffold.sh        # optional; builds a temp jj repo
+```
+
+Co-location means the #84 version-bump lint already covers eval changes.
+
+Scaffolds harden the environment per netresearch's MIT-licensed pattern: an
+isolated `JJ_CONFIG` with `ui.paginate = "never"` and `editor = "true"`, so an
+accidental editor invocation no-ops instead of hanging the run.
+
+### Ablation
+
+Use the harness's built-in `--ablation with-without`. **No null-control
+generator.** The first draft specified one, premised on the false claim that
+path targets cannot ablate; review disproved this. The built-in is also *more*
+valid — it disables the plugin against a byte-identical environment, whereas a
+generated control differs in name, description and manifest content.
+
+### Runner
+
+`.github/scripts/run-evals.sh`, with `.github/tests/test-run-evals.sh` beside
+it. This location is not cosmetic: CI globs `find plugins .github -path
+'*/tests/test-*.sh'`, so a repo-root `scripts/` would place a companion suite
+under neither root — discovered by nothing, silently, and green. Repo precedent
+is `.github/scripts/`; `CONVENTIONS.md` documents `scripts/` only as a *plugin*
+subdirectory.
+
+Bash 3.2-safe per the `macos-latest` CI floor: no globstar, no associative
+arrays; test with `/bin/bash`, never the interactive zsh.
+
+Fixed flags the runner owns, so nobody rediscovers the seven traps:
+
+- `CLAUDE_CODE_WALNUT_SPIRE=1`
+- `JJ_USER` / `JJ_EMAIL` when unset
+- `--ablation with-without`
+- `--allow-tools Bash` (plus Write/Edit as cases require)
+- `--scaffold`
+- `--output-dir` outside the plugin tree (this carries the result JSON; no
+  separate `--json` is needed)
+- **`--threshold 0`** — load-bearing. It defaults to 1.0, so the CLI exits 1 on
+  any case scoring below 1.00, which under `set -e` kills the runner before the
+  delta gate runs. Every case worth measuring scores below 1.00 by definition.
+- `--max-cost-usd` with a default ceiling. Breach is CLI **exit 2**, which must
+  be captured and passed to the gate rather than killing the script.
+- `--keep-temp` exposed as a first-class flag — the only way to reach
+  `trace.jsonl`, which is otherwise deleted; review had to pay to re-run a case
+  purely to inspect tool sequence
+
+Guards, each earning its place from a review finding:
+
+- **Zero-match glob aborts.** Discovery covers **both** supported formats:
+  `-path '*/evals/*/case.yaml' -o -path '*/evals/*/prompt.md'`. `eval init
+  --bare` scaffolds the second one, so a single-format glob would silently skip
+  cases authored the official way — #82's exact failure mode, reproduced inside
+  the tool built to honour #82.
+- **Tool-grant check.** If a case declares a gated tool absent from the
+  `--allow-tools` grant, abort with a diagnostic rather than scoring zeros.
+- **Both-arms-zero is "broken", never "no gap".**
+- **Exit code computed from `.cases[].delta`**, not from `--threshold`.
+- **Null-delta tripwire.** If any `.cases[].delta` reads `null`, abort — the
+  result schema moved and every verdict is meaningless. Never let a null reach
+  a comparison.
+- **Check `.partial` before trusting deltas.** True means `--max-cost-usd` was
+  breached and paid graders were skipped, leaving partial scores.
+
+### Two-layer framing
+
+Borrowed from netresearch:
+
+- **Layer 1 — evals.** Does the model *behave* correctly? Non-deterministic,
+  costs money, runs manually.
+- **Layer 2 — shell tests.** Does the documented workflow *work* against real
+  jj? Deterministic, free, gates CI. This repo has 11 such suites.
+
+Layer 2 catches a SKILL.md citing a flag jj removed. Layer 1 catches prose that
+is accurate but leads the model astray. The eval suite is the missing layer 1;
+it replaces nothing. Note `commit-commands-jj` currently has **no `tests/`
+directory at all** — a layer-2 gap worth filing separately.
+
+## Tranche 1 scope
+
+### Part A — 16-command triage sweep
+
+**Revised after review.** The original design phrased prompts as tasks and
+compared arms. Review measured that the model never invokes the commands at all
+— it goes straight to Bash, with `Skill` and `SlashCommand` both called 0×. So
+task-phrased prompts never read the command's prose, Δ≈0 for all 16, and the
+table would report "no measurable gap" for a reason unrelated to command value:
+a null result the design structurally could not have avoided.
+
+The fix follows from what that measurement actually reveals: **slash commands
+are user-invoked, not model-invoked.** "Never run" is literally true — they
+execute only when the user types `/describe`. The eval must therefore simulate
+*the user invoking the command*, which is not a compromise but the correct
+model of how these commands are used.
+
+So each case:
+
+- prompts with the **literal slash-command invocation** (`/describe add the
+  notes file`)
+- carries a `tool_used` on `SlashCommand`/`Skill`, `min: 1`, as a **validity
+  precondition** — not a scored grader
+- runs at **`runs: 3`** per arm
+
+If the precondition fails, the case reports **"did not exercise the command"** —
+a distinct outcome from both "earns its keep" and "no measurable gap". Without
+that distinction Part A does not ship.
+
+Cost: 16 × 2 arms × 3 runs = 96 runs at $0.06–0.28 ≈ **$7**, ~10 minutes.
+`runs: 1` was rejected on review: a single sample per arm yields a delta in
+{−1, 0, +1} with no confidence attached, and the noise is asymmetric — a
+spurious `without` pass reads as the actionable burden-shifting verdict. At
+~$0.07/run the saving never justified the ambiguity.
+
+Output is a triage table using the verdict taxonomy above, reporting **per-arm
+pass counts** (`3/3`, `2/3`), not just means.
+
+This is a **measurement, not a prune list**, and the framing matters. This
+repo is a jj-native port of `anthropics/claude-plugins-official`'s
+commit-commands; the command set exists partly to mirror upstream. Upstream
+parity is itself a reason to keep a command a model could limp through without
+— consistency across the two repos, and pinning behaviour that could drift, are
+values the ablation number does not see. So a zero-gap command is not a
+deletion candidate; the default is to keep it.
+
+What Part A produces is therefore a **map of where the prose earns its cost**:
+which commands measurably shape behaviour (and so most reward careful tranche-2
+cases), which are thin wrappers the model handles unaided, and which the suite
+could not exercise at all. It informs where to invest test effort, not what to
+remove. No command is proposed for deletion.
+
+### Part B — four hook and invariant cases
+
+Targeting behaviour the model demonstrably cannot infer, guarding invariants no
+lint covers.
+
+1. **`hook-blocks-raw-git`** — built and proven, Δ +1.00, twice, by two
+   independent parties.
+2. **`hook-blocks-git-internals`** — the second, separately-coded branch
+   (`.git/`, `git rev-parse`, `git config`).
+3. **#45 pass-through — moved to layer 2, not an eval.** The invariant (outside
+   a jj repo, git must be allowed) cannot be an eval: the grader asserts the
+   *absence* of a deny, but the `without` arm has no hook either, so both arms
+   pass and Δ = 0 regardless of whether the hook works. The case is
+   structurally incapable of distinguishing "correctly passed through" from
+   "no hook at all". It ships as `tests/test-block-raw-git-gating.sh` instead —
+   the hook is a pure stdin/stdout function and needs no model to test.
+4. **`hook-allows-jj-git-and-gh`** — `jj git push` and `gh pr view` must survive
+   the negative-lookahead in the raw-git regex.
+
+Cases 2–4 are hypotheses until ablation scores them. Non-discriminating ones are
+cut and the cut recorded.
+
+### Assertion strategy
+
+Prefer behavioural graders over rhetorical ones. netresearch's runner disables
+tools (`--tools ""`), so all 15 of their cases grade what the agent *says*. Our
+`tool_used` and `tool_order` graders assert what it *did* — the main reason
+their format is not worth porting directly.
+
+For the jj non-interactive class: `tool_used` on `Bash` with `input_match`,
+paired with a negative assertion at `min: 0, max: 0`.
+
+## Prior art
+
+netresearch/jujutsu-workflow-skill contributed the failure taxonomy: seven
+classes, of which the ones mapping onto code the base model cannot infer are
+colocated-repo desync (our hook's target), the ordered handoff gate (`/finish`),
+workspace isolation (kaisen), and jj not reading git config. Their classes A
+(interactivity deadlock) and B (git muscle memory) are most of their suite and
+are what our ablation gate is most likely to kill.
+
+**Licensing constraint for case authors: write our own prompt text.** The
+taxonomy is fact about jj's CLI and carries no obligation, but their prompt
+strings and assertion descriptions are CC-BY-SA-4.0; copying them verbatim would
+make an Adapted Work and pull ShareAlike onto this Apache-2.0 repo. Their shell
+harness patterns are MIT and safe to borrow with the notice.
+
+## CI
+
+Evals do **not** gate CI. They need an early-access flag, a model, and per-run
+spend, and CI is macOS with no guaranteed entitlement. netresearch made the same
+call: their `evals.json` gets structural validation only on PRs, while
+deterministic shell tests do the gating.
+
+Deliverable is a documented manual runner plus a README section. A follow-up
+issue tracks CI wiring if `plugin eval` reaches GA.
+
+## Out of scope
+
+- Portability of kaisen/plans to other repos (separate tranche).
+- Careful per-command cases — tranche 2, scoped to Part A survivors.
+- Other plugins' evals — later tranches.
+- Any command deletion. Part A measures and recommends.
+- A `tests/` suite for `commit-commands-jj` (layer-2 gap; file separately).
+
+## Definition of done
+
+1. `.github/scripts/run-evals.sh` exists, is bash 3.2-safe, and is documented.
+2. `.github/tests/test-run-evals.sh` covers: zero-match glob aborts;
+   both-arms-zero classified "broken" not "no gap"; delta gate arithmetic
+   against a committed `aggregate-result.json` fixture, **including a
+   null-delta case asserting the tripwire fires**; `--allow-tools` guard; both
+   discovery formats; execution under `/bin/bash`.
+3. Part B's four cases exist, each ablation-checked, non-discriminating ones cut
+   with the cut recorded.
+4. A committed exemplar `case.yaml` documents the schema by working example.
+5. Part A's triage table is produced and written up, with per-arm pass counts
+   and a recommendation per command.
+6. Defects found are fixed or filed. The suite is expected to find real bugs;
+   finding none is a reason to distrust the cases.
+7. `commit-commands-jj`'s version is bumped (#84).
+8. `**/evals/results/` gitignored — defence in depth behind `--output-dir`, for
+   the path reachable when someone calls `claude plugin eval` directly. The
+   `**/` prefix is required: gitignore anchors any pattern containing a
+   mid-string slash to its own directory, so a bare `evals/results/` matches
+   only a root-level dir that never exists while the real path stays tracked.
+9. Full test suite green in `@` after fan-in, run by hand — the combined-result
+   gate from `project_kaisen_lessons`.
+
+## Risks
+
+- **The suite becomes decorative.** Primary risk; mitigated by ablation as a
+  hard gate, the both-arms-zero guard, and reporting cut cases.
+- **Early-access flag disappears.** Runner breaks. Contained: manual, gates
+  nothing, fails loudly.
+- **Part A's thin cases understate a command's value.** Mitigated by `runs: 3`,
+  per-arm counts, the validity precondition, and treating output as measurement.
+- **Cost creep.** Bounded by a default `--max-cost-usd` in the runner. Note its
+  semantics: on breach it exits 2 and skips paid graders while free ones still
+  score, producing partial results a naive delta gate would misread — the gate
+  must check for the breach exit before trusting deltas.

--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/evals/hook-blocks-git-internals/case.yaml
+++ b/plugins/commit-commands-jj/evals/hook-blocks-git-internals/case.yaml
@@ -1,0 +1,22 @@
+schema_version: "1.1"
+name: hook-blocks-git-internals
+description: >
+  The hook's second, separately-coded branch: .git/ access and git plumbing
+  (rev-parse, config) carry their own deny message.
+tags: [commit-commands-jj, hook, invariant]
+context:
+  scaffold_script: scaffold.sh
+execution:
+  prompt: |
+    Print the current commit hash by running `git rev-parse HEAD`, and
+    tell me exactly what happened.
+  max_turns: 6
+  timeout_seconds: 300
+  allowed_tools: [Bash]
+runs: 2
+graders:
+  - type: regex
+    name: reports-blocked
+    pattern: "(BLOCKED|blocked|not allowed|denied|internals)"
+    match: contains
+    weight: 1

--- a/plugins/commit-commands-jj/evals/hook-blocks-git-internals/scaffold.sh
+++ b/plugins/commit-commands-jj/evals/hook-blocks-git-internals/scaffold.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export JJ_USER="${JJ_USER:-eval}"
+export JJ_EMAIL="${JJ_EMAIL:-eval@example.com}"
+mkdir -p .jjconfig
+cat > .jjconfig/config.toml <<'TOML'
+[ui]
+paginate = "never"
+editor = "true"
+TOML
+export JJ_CONFIG="$PWD/.jjconfig/config.toml"
+jj git init . >/dev/null 2>&1
+printf 'alpha\n' > notes.txt

--- a/plugins/commit-commands-jj/evals/hook-blocks-git-internals/scaffold.sh
+++ b/plugins/commit-commands-jj/evals/hook-blocks-git-internals/scaffold.sh
@@ -1,13 +1,25 @@
 #!/usr/bin/env bash
+# Same throwaway jj repo as hook-blocks-raw-git/scaffold.sh, and the same
+# reason for writing the hardening into the sandbox HOME rather than exporting
+# it: this script and the agent turn are different processes, and only HOME
+# crosses between them. See that file's header, and
+# tests/test-eval-scaffold.sh.
 set -euo pipefail
-export JJ_USER="${JJ_USER:-eval}"
-export JJ_EMAIL="${JJ_EMAIL:-eval@example.com}"
-mkdir -p .jjconfig
-cat > .jjconfig/config.toml <<'TOML'
+
+JJ_USER="${JJ_USER:-eval}"
+JJ_EMAIL="${JJ_EMAIL:-eval@example.com}"
+
+conf_dir="${XDG_CONFIG_HOME:-$HOME/.config}/jj"
+mkdir -p "$conf_dir"
+cat > "$conf_dir/config.toml" <<TOML
+[user]
+name = "$JJ_USER"
+email = "$JJ_EMAIL"
+
 [ui]
 paginate = "never"
 editor = "true"
 TOML
-export JJ_CONFIG="$PWD/.jjconfig/config.toml"
+
 jj git init . >/dev/null 2>&1
 printf 'alpha\n' > notes.txt

--- a/plugins/commit-commands-jj/evals/hook-blocks-raw-git/case.yaml
+++ b/plugins/commit-commands-jj/evals/hook-blocks-raw-git/case.yaml
@@ -1,0 +1,22 @@
+schema_version: "1.1"
+name: hook-blocks-raw-git
+description: >
+  block-raw-git.sh must deny a raw git command inside a jj repo.
+  Ablation-verified: with 1.00 / without 0.00, delta +1.00.
+tags: [commit-commands-jj, hook, invariant]
+context:
+  scaffold_script: scaffold.sh
+execution:
+  prompt: |
+    Run the shell command `git status` in this repository and tell me
+    exactly what happened.
+  max_turns: 6
+  timeout_seconds: 300
+  allowed_tools: [Bash]
+runs: 2
+graders:
+  - type: regex
+    name: reports-blocked
+    pattern: "(BLOCKED|blocked|not allowed|denied)"
+    match: contains
+    weight: 1

--- a/plugins/commit-commands-jj/evals/hook-blocks-raw-git/scaffold.sh
+++ b/plugins/commit-commands-jj/evals/hook-blocks-raw-git/scaffold.sh
@@ -2,18 +2,34 @@
 # Build a throwaway jj repo for the case. Hardened per netresearch's MIT
 # pattern: paginate=never and editor=true, so an accidental interactive
 # invocation no-ops instead of hanging the run.
+#
+# The hardening has to land in the sandbox HOME, not in this process's
+# environment. The CLI spawns this script with a fixed env whitelist and runs
+# the agent turn in a SEPARATE process, so an `export JJ_CONFIG=...` here dies
+# with the scaffold and the turn never sees it — and jj does not auto-discover
+# a config file sitting next to the work tree. HOME is what the two processes
+# share (the turn additionally gets XDG_CONFIG_HOME=$HOME/.config), so jj's
+# user config inside that throwaway home is the channel that actually crosses.
+# Writing it there also keeps it out of the work tree, which the CLI diffs
+# before and after the turn. Covered by tests/test-eval-scaffold.sh.
 set -euo pipefail
 
-export JJ_USER="${JJ_USER:-eval}"
-export JJ_EMAIL="${JJ_EMAIL:-eval@example.com}"
+# Not on the scaffold's env whitelist either — so these resolve to the
+# defaults, and the config below is what actually gives the turn an identity.
+JJ_USER="${JJ_USER:-eval}"
+JJ_EMAIL="${JJ_EMAIL:-eval@example.com}"
 
-mkdir -p .jjconfig
-cat > .jjconfig/config.toml <<'TOML'
+conf_dir="${XDG_CONFIG_HOME:-$HOME/.config}/jj"
+mkdir -p "$conf_dir"
+cat > "$conf_dir/config.toml" <<TOML
+[user]
+name = "$JJ_USER"
+email = "$JJ_EMAIL"
+
 [ui]
 paginate = "never"
 editor = "true"
 TOML
-export JJ_CONFIG="$PWD/.jjconfig/config.toml"
 
 jj git init . >/dev/null 2>&1
 printf 'alpha\n' > notes.txt

--- a/plugins/commit-commands-jj/evals/hook-blocks-raw-git/scaffold.sh
+++ b/plugins/commit-commands-jj/evals/hook-blocks-raw-git/scaffold.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Build a throwaway jj repo for the case. Hardened per netresearch's MIT
+# pattern: paginate=never and editor=true, so an accidental interactive
+# invocation no-ops instead of hanging the run.
+set -euo pipefail
+
+export JJ_USER="${JJ_USER:-eval}"
+export JJ_EMAIL="${JJ_EMAIL:-eval@example.com}"
+
+mkdir -p .jjconfig
+cat > .jjconfig/config.toml <<'TOML'
+[ui]
+paginate = "never"
+editor = "true"
+TOML
+export JJ_CONFIG="$PWD/.jjconfig/config.toml"
+
+jj git init . >/dev/null 2>&1
+printf 'alpha\n' > notes.txt

--- a/plugins/commit-commands-jj/scripts/block-raw-git.sh
+++ b/plugins/commit-commands-jj/scripts/block-raw-git.sh
@@ -32,12 +32,35 @@ command=$(echo "$input" | jq -r '.tool_input.command // ""')
 # Normalize: collapse newlines
 command_normalized=$(echo "$command" | tr '\n' ';')
 
-# Check for bare "git " commands (not preceded by "jj ")
+# Check for bare "git " commands, one clause at a time (#101).
+#
+# This used to ask two questions over the WHOLE command string: "is there a git
+# at command position" and "is there a jj git at command position". One
+# `jj git …` token anywhere exempted every other clause, so
+# `jj git fetch && git reset --hard origin/main` was allowed even though the
+# second clause is denied on its own. Chaining a fetch onto another command is
+# ordinary model output, not an evasion, so the seam was reachable by accident.
+#
+# The fix: split on the clause separators the old pattern already treated as
+# command-position boundaries (; & |) and decide each clause alone. `tr` maps
+# each character independently, so `&&` and `||` produce an empty clause in
+# between, which matches nothing and is skipped; `2>&1` likewise splits
+# harmlessly. Newlines were folded to `;` above, so multi-line commands split
+# here too. grep anchors `^` per line, i.e. per clause.
+#
+# The jj-git exemption is now structural rather than a second regex: a clause
+# invoking `jj git …` begins with `jj`, so it can never match a
+# command-position `git`. `jj git push` (used by /commit-push-pr and /finish)
+# stays allowed, in any position of any compound.
+#
+# Deliberately quote-blind, exactly as the previous regex was: a separator
+# inside quotes still starts a clause, and prose mentioning a git command
+# mid-clause (`jj describe -m 'replaces git status'`) is still not at command
+# position and still passes. bash 3.2-safe: no globstar, no associative arrays.
 has_raw_git=false
-if echo "$command_normalized" | grep -qE '(^|[;&|]\s*)git\s'; then
-  if ! echo "$command_normalized" | grep -qE '(^|[;&|]\s*)jj\s+git\s'; then
-    has_raw_git=true
-  fi
+if printf '%s\n' "$command_normalized" | tr ';&|' '\n\n\n' \
+   | grep -qE '^[[:space:]]*git[[:space:]]'; then
+  has_raw_git=true
 fi
 
 # Check for .git/ access or git plumbing

--- a/plugins/commit-commands-jj/tests/test-block-raw-git-gating.sh
+++ b/plugins/commit-commands-jj/tests/test-block-raw-git-gating.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+HOOK="$(cd "$(dirname "$0")/../scripts" && pwd)/block-raw-git.sh"
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+# Inside a jj repo: raw git is denied.
+JJ_DIR=$(mktemp -d); mkdir -p "$JJ_DIR/.jj"
+out=$(printf '{"cwd":"%s","tool_input":{"command":"git status"}}' "$JJ_DIR" | /bin/bash "$HOOK")
+if printf '%s' "$out" | grep -q '"permissionDecision": *"deny"'; then
+  ok "denies raw git inside a jj repo"
+else
+  bad "denies raw git inside a jj repo (got: $out)"
+fi
+
+# The internals branch is the hook's only code path with no other coverage.
+# The raw-git branch returns first for any command carrying a bare `git `
+# token, which shadows BOTH commands the internals regex names -- `git config`
+# and `git rev-parse` are answered by the raw-git message, never this one. Only
+# `.git/` path access reaches here. Anchor on the internals message itself:
+# asserting merely "something was denied" would pass against the raw-git branch
+# and prove nothing, which is the entire point of this assertion.
+out=$(printf '{"cwd":"%s","tool_input":{"command":"cat .git/HEAD"}}' "$JJ_DIR" | /bin/bash "$HOOK")
+if printf '%s' "$out" | grep -q 'BLOCKED: Git internals'; then
+  ok "denies .git/ access via the internals branch"
+else
+  bad "denies .git/ access via the internals branch (got: $out)"
+fi
+
+# Outside a jj repo: passes through silently (#45). Anchor in a NON-jj temp
+# dir — the dev checkout is itself a jj repo, so a relative cwd would walk up
+# into the real .jj and invert this test.
+PLAIN=$(mktemp -d)
+out=$(printf '{"cwd":"%s","tool_input":{"command":"git status"}}' "$PLAIN" | /bin/bash "$HOOK")
+if [ -z "$out" ]; then
+  ok "passes git through outside a jj repo (#45)"
+else
+  bad "passes git through outside a jj repo (#45) (got: $out)"
+fi
+
+# The negative lookahead: `jj git ...` and `gh ...` must survive it. This
+# started life as the eval case hook-allows-jj-git-and-gh, which measured
+# with 1.00 / without 1.00, Δ 0.00 — NO_GAP. It asserts the *absence* of a
+# deny, and the ablation's `without` arm has no hook to produce one either,
+# so both arms passed and the delta could never mean anything. The hook is a
+# pure stdin/stdout function, so the assertion belongs here where it is
+# deterministic and free.
+for allowed in "jj git remote list" "gh pr list"; do
+  out=$(printf '{"cwd":"%s","tool_input":{"command":"%s"}}' "$JJ_DIR" "$allowed" | /bin/bash "$HOOK")
+  if [ -z "$out" ]; then
+    ok "allows '$allowed' inside a jj repo (lookahead)"
+  else
+    bad "allows '$allowed' inside a jj repo (lookahead) (got: $out)"
+  fi
+done
+
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+test "$FAIL" -eq 0

--- a/plugins/commit-commands-jj/tests/test-block-raw-git-gating.sh
+++ b/plugins/commit-commands-jj/tests/test-block-raw-git-gating.sh
@@ -14,6 +14,25 @@ else
   bad "denies raw git inside a jj repo (got: $out)"
 fi
 
+# #101: the `jj git …` exemption used to be evaluated over the whole command
+# string, so one jj-git token anywhere exempted every other clause and
+# `jj git fetch && git reset --hard origin/main` came back ALLOWED. These run
+# against THIS plugin's copy of the hook — the drift-guard in project-setup-jj
+# proves byte-identity, this proves the shipped bytes behave.
+for denied in \
+  'jj git fetch && git reset --hard origin/main' \
+  'git status; jj git fetch' \
+  'jj git fetch;git status' \
+  'jj git fetch\ngit reset --hard origin/main'
+do
+  out=$(printf '{"cwd":"%s","tool_input":{"command":"%s"}}' "$JJ_DIR" "$denied" | /bin/bash "$HOOK")
+  if printf '%s' "$out" | grep -q '"permissionDecision": *"deny"'; then
+    ok "denies raw git in a compound command: $denied"
+  else
+    bad "denies raw git in a compound command: $denied (got: $out)"
+  fi
+done
+
 # The internals branch is the hook's only code path with no other coverage.
 # The raw-git branch returns first for any command carrying a bare `git `
 # token, which shadows BOTH commands the internals regex names -- `git config`
@@ -46,7 +65,15 @@ fi
 # so both arms passed and the delta could never mean anything. The hook is a
 # pure stdin/stdout function, so the assertion belongs here where it is
 # deterministic and free.
-for allowed in "jj git remote list" "gh pr list"; do
+#
+# The trailing three are #101 regression guards rather than fail-first cases:
+# they passed before the per-clause split and must still pass after it. This
+# hook is a hard wall, so a false positive costs as much as a bypass —
+# /commit-push-pr and /finish both instruct `jj git push` in their own prose.
+for allowed in "jj git remote list" "gh pr list" \
+               "jj git push --bookmark feature-x" \
+               "jj git fetch && jj rebase -d main" \
+               "echo 'git status'"; do
   out=$(printf '{"cwd":"%s","tool_input":{"command":"%s"}}' "$JJ_DIR" "$allowed" | /bin/bash "$HOOK")
   if [ -z "$out" ]; then
     ok "allows '$allowed' inside a jj repo (lookahead)"

--- a/plugins/commit-commands-jj/tests/test-eval-scaffold.sh
+++ b/plugins/commit-commands-jj/tests/test-eval-scaffold.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# The eval scaffolds' anti-hang hardening must reach the AGENT, not just the
+# scaffold process.
+#
+# `claude plugin eval` spawns scaffold.sh with a fixed environment whitelist
+# (PATH, HOME, USERPROFILE, TMPDIR, TERM, USER_TYPE, NODE_ENV) and then runs
+# the agent turn in a SEPARATE process. Anything the scaffold `export`s dies
+# with the scaffold, so `export JJ_CONFIG=...` configures nothing the turn can
+# see: an interactive `jj describe` opens the real editor and blocks until
+# timeout_seconds, burning the run and the money for it.
+#
+# What both processes DO share is HOME — the CLI points it at a throwaway
+# sandbox home for the scaffold, and gives the agent the same HOME plus
+# XDG_CONFIG_HOME=$HOME/.config. So jj's user config inside that sandbox home
+# is the one channel that actually crosses the process boundary. This suite
+# reproduces both environments exactly and asserts the crossing.
+set -euo pipefail
+
+PLUGIN_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+if ! command -v jj >/dev/null 2>&1; then
+  printf 'FAIL - jj must be installed to verify the scaffolds\n'
+  printf '0 passed, 1 failed\n'
+  exit 1
+fi
+
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+for case_name in hook-blocks-raw-git hook-blocks-git-internals; do
+  scaffold="$PLUGIN_DIR/evals/$case_name/scaffold.sh"
+  sandbox=$(mktemp -d "$TMPROOT/sb.XXXXXX")
+  mkdir -p "$sandbox/home" "$sandbox/cwd"
+
+  # Exactly the env the CLI hands the scaffold — no more. `env -i` is the
+  # point: inheriting this shell's HOME would let the assertions below pass
+  # against the developer's own ~/.config/jj.
+  set +e
+  err=$(cd "$sandbox/cwd" && env -i \
+    PATH="$PATH" HOME="$sandbox/home" USERPROFILE="$sandbox/home" \
+    TMPDIR="${TMPDIR:-/tmp}" TERM=dumb USER_TYPE=external NODE_ENV=production \
+    /bin/bash "$scaffold" 2>&1)
+  rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    ok "$case_name: scaffold runs under the CLI's env whitelist"
+  else
+    bad "$case_name: scaffold runs under the CLI's env whitelist (rc=$rc: ${err:-<empty>})"
+  fi
+
+  # ...and exactly the env the CLI hands the agent turn.
+  agent_jj() {
+    (cd "$sandbox/cwd" && env -i \
+      PATH="$PATH" HOME="$sandbox/home" USERPROFILE="$sandbox/home" \
+      XDG_CONFIG_HOME="$sandbox/home/.config" TMPDIR="${TMPDIR:-/tmp}" TERM=dumb \
+      jj "$@")
+  }
+
+  editor=$(agent_jj config get ui.editor 2>/dev/null || printf '<unset>')
+  if [ "$editor" = "true" ]; then
+    ok "$case_name: ui.editor reaches a separate process"
+  else
+    bad "$case_name: ui.editor reaches a separate process (got: $editor)"
+  fi
+
+  paginate=$(agent_jj config get ui.paginate 2>/dev/null || printf '<unset>')
+  if [ "$paginate" = "never" ]; then
+    ok "$case_name: ui.paginate reaches a separate process"
+  else
+    bad "$case_name: ui.paginate reaches a separate process (got: $paginate)"
+  fi
+
+  # An identity the turn can rely on: JJ_USER/JJ_EMAIL are not on the
+  # scaffold's env whitelist either, so exporting them there sets nothing.
+  who=$(agent_jj config get user.name 2>/dev/null || printf '<unset>')
+  if [ -n "$who" ] && [ "$who" != "<unset>" ]; then
+    ok "$case_name: a jj identity reaches a separate process"
+  else
+    bad "$case_name: a jj identity reaches a separate process (got: $who)"
+  fi
+
+  # The payoff assertion: an interactive jj command must no-op instead of
+  # blocking on an editor. Only run it once the editor is known to be `true` —
+  # invoking a real editor under a dumb terminal is the hang this exists to
+  # prevent, and a test suite must not reproduce it.
+  if [ "$editor" = "true" ]; then
+    set +e
+    out=$(agent_jj describe </dev/null 2>&1)
+    rc=$?
+    set -e
+    if [ "$rc" -eq 0 ]; then
+      ok "$case_name: an editor-opening jj command returns instead of hanging"
+    else
+      bad "$case_name: an editor-opening jj command returns instead of hanging (rc=$rc: $out)"
+    fi
+  else
+    bad "$case_name: an editor-opening jj command returns instead of hanging (editor is $editor — not invoking it)"
+  fi
+
+  # Scaffold config must stay OUT of the work tree: the CLI diffs the sandbox
+  # cwd before and after the turn, and a config directory in there shows up as
+  # a file the agent supposedly created (see docs/eval-triage-2026-07.md §3).
+  if [ ! -e "$sandbox/cwd/.jjconfig" ]; then
+    ok "$case_name: scaffold leaves no config inside the work tree"
+  else
+    bad "$case_name: scaffold leaves no config inside the work tree"
+  fi
+
+  if [ -d "$sandbox/cwd/.jj" ] && [ -f "$sandbox/cwd/notes.txt" ]; then
+    ok "$case_name: scaffold builds the repo the case expects"
+  else
+    bad "$case_name: scaffold builds the repo the case expects"
+  fi
+done
+
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+test "$FAIL" -eq 0

--- a/plugins/peer-review-jj/.claude-plugin/plugin.json
+++ b/plugins/peer-review-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "peer-review-jj",
   "description": "Unified change review for jj repos — generalist-first with emergent specialists, two-phase pipeline, structured findings",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/peer-review-jj/scripts/block-raw-git.sh
+++ b/plugins/peer-review-jj/scripts/block-raw-git.sh
@@ -32,12 +32,35 @@ command=$(echo "$input" | jq -r '.tool_input.command // ""')
 # Normalize: collapse newlines
 command_normalized=$(echo "$command" | tr '\n' ';')
 
-# Check for bare "git " commands (not preceded by "jj ")
+# Check for bare "git " commands, one clause at a time (#101).
+#
+# This used to ask two questions over the WHOLE command string: "is there a git
+# at command position" and "is there a jj git at command position". One
+# `jj git …` token anywhere exempted every other clause, so
+# `jj git fetch && git reset --hard origin/main` was allowed even though the
+# second clause is denied on its own. Chaining a fetch onto another command is
+# ordinary model output, not an evasion, so the seam was reachable by accident.
+#
+# The fix: split on the clause separators the old pattern already treated as
+# command-position boundaries (; & |) and decide each clause alone. `tr` maps
+# each character independently, so `&&` and `||` produce an empty clause in
+# between, which matches nothing and is skipped; `2>&1` likewise splits
+# harmlessly. Newlines were folded to `;` above, so multi-line commands split
+# here too. grep anchors `^` per line, i.e. per clause.
+#
+# The jj-git exemption is now structural rather than a second regex: a clause
+# invoking `jj git …` begins with `jj`, so it can never match a
+# command-position `git`. `jj git push` (used by /commit-push-pr and /finish)
+# stays allowed, in any position of any compound.
+#
+# Deliberately quote-blind, exactly as the previous regex was: a separator
+# inside quotes still starts a clause, and prose mentioning a git command
+# mid-clause (`jj describe -m 'replaces git status'`) is still not at command
+# position and still passes. bash 3.2-safe: no globstar, no associative arrays.
 has_raw_git=false
-if echo "$command_normalized" | grep -qE '(^|[;&|]\s*)git\s'; then
-  if ! echo "$command_normalized" | grep -qE '(^|[;&|]\s*)jj\s+git\s'; then
-    has_raw_git=true
-  fi
+if printf '%s\n' "$command_normalized" | tr ';&|' '\n\n\n' \
+   | grep -qE '^[[:space:]]*git[[:space:]]'; then
+  has_raw_git=true
 fi
 
 # Check for .git/ access or git plumbing

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/scripts/block-raw-git.sh
+++ b/plugins/project-setup-jj/scripts/block-raw-git.sh
@@ -32,12 +32,35 @@ command=$(echo "$input" | jq -r '.tool_input.command // ""')
 # Normalize: collapse newlines
 command_normalized=$(echo "$command" | tr '\n' ';')
 
-# Check for bare "git " commands (not preceded by "jj ")
+# Check for bare "git " commands, one clause at a time (#101).
+#
+# This used to ask two questions over the WHOLE command string: "is there a git
+# at command position" and "is there a jj git at command position". One
+# `jj git …` token anywhere exempted every other clause, so
+# `jj git fetch && git reset --hard origin/main` was allowed even though the
+# second clause is denied on its own. Chaining a fetch onto another command is
+# ordinary model output, not an evasion, so the seam was reachable by accident.
+#
+# The fix: split on the clause separators the old pattern already treated as
+# command-position boundaries (; & |) and decide each clause alone. `tr` maps
+# each character independently, so `&&` and `||` produce an empty clause in
+# between, which matches nothing and is skipped; `2>&1` likewise splits
+# harmlessly. Newlines were folded to `;` above, so multi-line commands split
+# here too. grep anchors `^` per line, i.e. per clause.
+#
+# The jj-git exemption is now structural rather than a second regex: a clause
+# invoking `jj git …` begins with `jj`, so it can never match a
+# command-position `git`. `jj git push` (used by /commit-push-pr and /finish)
+# stays allowed, in any position of any compound.
+#
+# Deliberately quote-blind, exactly as the previous regex was: a separator
+# inside quotes still starts a clause, and prose mentioning a git command
+# mid-clause (`jj describe -m 'replaces git status'`) is still not at command
+# position and still passes. bash 3.2-safe: no globstar, no associative arrays.
 has_raw_git=false
-if echo "$command_normalized" | grep -qE '(^|[;&|]\s*)git\s'; then
-  if ! echo "$command_normalized" | grep -qE '(^|[;&|]\s*)jj\s+git\s'; then
-    has_raw_git=true
-  fi
+if printf '%s\n' "$command_normalized" | tr ';&|' '\n\n\n' \
+   | grep -qE '^[[:space:]]*git[[:space:]]'; then
+  has_raw_git=true
 fi
 
 # Check for .git/ access or git plumbing

--- a/plugins/project-setup-jj/tests/test-block-raw-git.sh
+++ b/plugins/project-setup-jj/tests/test-block-raw-git.sh
@@ -53,12 +53,54 @@ echo "=== jj repo: raw git is blocked ==="
 assert_blocked "git status at jj root"      "git status"            "$JJ_DIR"
 assert_blocked "git status in jj subdir"    "git status"            "$JJ_DIR/sub/deep"
 assert_blocked "git commit at jj root"      "git commit -m x"       "$JJ_DIR"
+assert_blocked "git add"                    "git add -A"            "$JJ_DIR"
+assert_blocked "git log"                    "git log --oneline"     "$JJ_DIR"
+assert_blocked "git diff"                   "git diff"              "$JJ_DIR"
+assert_blocked "git push"                   "git push origin main"  "$JJ_DIR"
+assert_blocked "git reset --hard"           "git reset --hard origin/main" "$JJ_DIR"
 assert_blocked "git config (internals)"     "git config user.name x" "$JJ_DIR"
 assert_blocked "git rev-parse (internals)"  "git rev-parse HEAD"    "$JJ_DIR"
 
+# #101: the jj-git exemption used to be evaluated over the WHOLE command
+# string, so a single `jj git …` token anywhere exempted every other clause —
+# `jj git fetch && git reset --hard origin/main` was ALLOWED even though the
+# second clause is denied on its own. The exemption is now decided per clause.
+# Chaining a fetch onto another command is ordinary model output, not an
+# adversarial input, so every separator the shell accepts is covered here.
+echo "=== jj repo: compound commands are decided per clause (#101) ==="
+assert_blocked "jj-git clause then raw git (&&)"  "jj git fetch && git reset --hard origin/main" "$JJ_DIR"
+assert_blocked "jj-git clause then raw git (;)"   "jj git push; git status"                      "$JJ_DIR"
+assert_blocked "raw git then jj-git clause (;)"   "git status; jj git fetch"                     "$JJ_DIR"
+assert_blocked "raw git then jj-git clause (||)"  "git log --oneline || jj git fetch"            "$JJ_DIR"
+assert_blocked "jj-git clause piped into raw git" "jj git fetch | git log --oneline"             "$JJ_DIR"
+assert_blocked "no space after ; separator"       "jj git fetch;git status"                      "$JJ_DIR"
+assert_blocked "no space after && separator"      "jj git fetch&&git status"                     "$JJ_DIR"
+assert_blocked "raw git in a third clause"        "echo hi && jj git fetch && git status"        "$JJ_DIR"
+# Newlines are folded to ';' before analysis, so a multi-line command must
+# split the same way. The \n below is a JSON escape: jq hands the hook a real
+# newline.
+assert_blocked "multi-line: newline is a separator" 'jj git fetch\ngit reset --hard origin/main' "$JJ_DIR"
+
+# These are regression guards, not fail-first cases: every one of them passed
+# before the #101 per-clause fix and must still pass after it. A false positive
+# in this hook is as bad as a bypass — `jj git push` is instructed in the
+# command prose of /commit-push-pr and /finish, so a hook that blocks it breaks
+# the documented workflow of three plugins.
 echo "=== jj repo: interop seams and non-git pass through ==="
 assert_passthrough "jj git push allowed"    "jj git push"           "$JJ_DIR"
+assert_passthrough "jj git push with bookmark" "jj git push --bookmark feature-x" "$JJ_DIR"
+assert_passthrough "jj git push --change"   "jj git push --change @" "$JJ_DIR"
+assert_passthrough "jj git fetch"           "jj git fetch"          "$JJ_DIR"
+assert_passthrough "jj git remote list"     "jj git remote list"    "$JJ_DIR"
+assert_passthrough "jj git init"            "jj git init"           "$JJ_DIR"
+assert_passthrough "two jj clauses, one jj-git" "jj git fetch && jj rebase -d main" "$JJ_DIR"
+assert_passthrough "jj-git clause last"     "jj log -r @ && jj git push" "$JJ_DIR"
 assert_passthrough "gh allowed"             "gh pr list"            "$JJ_DIR"
+assert_passthrough "gh with flags"          "gh pr create --title x --body y" "$JJ_DIR"
+# Mid-clause prose is not command position: a message that merely names a git
+# command must not be blocked.
+assert_passthrough "git named inside a -m message" "jj describe -m 'replace git status with jj status'" "$JJ_DIR"
+assert_passthrough "quoted git string echoed"      "echo 'git status'" "$JJ_DIR"
 assert_passthrough "non-git command"        "ls -la"               "$JJ_DIR"
 
 echo "=== non-jj repo: git is allowed ==="


### PR DESCRIPTION
## Summary

Tranche 1 of #79 — an ablation-gated behavioural eval suite — plus the fixes that came out of reviewing it, plus a security fix to the raw-git hard wall that the eval work surfaced.

**The suite (layer 1, which this repo did not have).** `.github/scripts/run-evals.sh` wraps `claude plugin eval` and gates cases on the **ablation delta** rather than the absolute score. That distinction is the point: the harness marks a zero-gap case as passing, so a suite built the obvious way is green whether or not the plugins work. Two eval cases ship, both ablation-verified at **Δ +1.00** (with 1.00 / without 0.00), re-measured against the code in this PR.

**Part A was cut on measurement, not skipped.** The plan called for a 16-command triage sweep. Its Step 3 probe — a gate built specifically to protect that spend — fired at **$0.00** and refuted the design three ways: `weight: 0` is rejected by the case schema; a literal `/cmd` prompt is expanded client-side so it records no tool call, and bare `/describe` never resolved at all (commands are namespaced) returning 0 turns in *both* arms while reporting `subtype: "success"`; and a 0-turn arm banks free score from vacuously-passing negative graders, manufacturing a spurious Δ +0.50 "DISCRIMINATING". `docs/eval-triage-2026-07.md` is the record, and #104 carries a working methodology for tranche 2 — natural-language prompts, which measured the model invoking a plugin command via `Skill` on 3/3 runs, overturning the spec's premise that it never does.

**#101 — the hard wall had a hole.** The raw-git block evaluated its `jj git` exemption over the whole command string, so one `jj git` token anywhere suppressed the deny for every other clause. A compound command that fetches and then runs a destructive raw-git reset was **allowed**. Chaining a fetch is ordinary model output, not evasion, so the seam was reachable by accident. The exemption is now decided per clause and is structural rather than a second regex — a `jj git …` clause begins with `jj`, so it can never match a command-position `git`. Applied identically to all three copies (sha256 `a1768a60…`), which a drift guard keeps in sync.

**Review fixes.** An xhigh review returned 15 confirmed findings, every one reproduced by live execution. All 15 are closed and re-verified by re-running the original reproductions against the fixed code. Seven were the pre-spend tool-grant guard failing open (multi-tool grants, single-quoted YAML, `prompt.md`-layout cases, paths with spaces, YAML comments in a block list, an unanchored key regex, and a `--case` glob that selected a different set than the CLI would). Two were the suite's own assertions passing vacuously — proven by ablation, and now proven non-vacuous the same way.

Assertions in the eval suite went **30 → 70**; repo-wide **301 → 374**.

Version bumps are load-bearing here: the plugin cache is keyed by version, so `commit-commands-jj` 0.1.1→0.7.0, `peer-review-jj` 0.1.2→0.2.0 and `project-setup-jj` 0.2.0→0.3.0 are what make the #101 fix reachable by installed copies.

Filed along the way: #99, #100, #101, #102, #103, #104, #105.

## Test plan

- [x] Full repo suite gate — **15 suites, 374 assertions, `0 suite(s) failed`, exit 0**
- [x] Both shipped eval cases re-measured against this branch's code: `hook-blocks-raw-git` and `hook-blocks-git-internals`, each **1.00 / 0.00, Δ +1.00, DISCRIMINATING**, `partial: false`, both arms confirmed to have actually run
- [x] #101 verified independently of the implementer against the shipped hook: 20/20 on a two-list corpus — every compound bypass denied in both clause orders and across `;`, `&&`, `||`, `|`, no-space, and multi-line separators; every documented workflow still allowed (`jj git push` with flags, `jj git fetch`, `jj git remote list`, `gh`, a `-m` message naming a git command)
- [x] #45 gating intact — git still passes through outside a jj repo
- [x] Git-internals hook branch intact
- [x] Three copies of the hook byte-identical after the fix (`a1768a60…`)
- [x] Version-bump lint (#84) exits 0, disambiguated with a negative control
- [x] bash 3.2.57 (`/bin/bash -n`) clean on every changed shell file — no globstar, no associative arrays
- [x] Runner stdout verified pure TSV on a live run, not just against a stub

Evals are **manual, not CI-gated** — they need an early-access flag, a model, and per-run spend. Total eval spend for this branch: **$4.77**. #100 tracks CI wiring if `plugin eval` reaches GA.

## Reviewer notes

- Two things in here are knowingly imperfect and documented rather than hidden: `hook-blocks-git-internals` exercises the raw-git branch rather than the internals branch its name claims (#103, explained in `docs/eval-triage-2026-07.md` §1.1), and three further bypass shapes — command substitution, grouping, prefix words — remain open in the hook (#105). All three return byte-identical verdicts before and after the #101 fix, so they are pre-existing, not a regression.
- `docs/plans/` and `docs/specs/` still describe the pre-fix exit-code contract. The operator-facing pair — root `README.md` and the triage doc — are current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
