### PR TITLE
jj gotchas in the CLAUDE.md template, plus a drift guard for duplicated plugin scripts

### DIFF
--- a/.github/tests/test-script-copy-parity.sh
+++ b/.github/tests/test-script-copy-parity.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Drift guard for scripts that are deliberately duplicated across plugins.
+#
+# Several plugins ship byte-identical copies of the same script so each plugin
+# stands alone (block-raw-git.sh in three, jj-workspace-create.sh and
+# jj-workspace-remove.sh in two). A fix applied to one copy and not the others
+# is silent: the tests exercise one copy, pass, and the stale copies keep
+# shipping the old behaviour to whoever installed that plugin. #101 was exactly
+# this shape — a security fix that had to land in three places at once.
+#
+# block-raw-git.sh already had a guard inside its own behaviour test. The other
+# two sets had none, so this sweep covers every duplicate by discovery rather
+# than by a hand-maintained list: any basename appearing under more than one
+# plugin's scripts/ must be byte-identical everywhere it appears.
+#
+# Intentional divergence is allowed but must be declared in DIVERGENT below, so
+# a fork is a visible decision rather than an unnoticed drift. A stale entry
+# there is itself a failure — otherwise the allowlist silently grants immunity
+# to a set that later stopped being divergent.
+#
+# Usage: test-script-copy-parity.sh [ROOT]
+#   ROOT defaults to the repo root. It is overridable so the guard can be
+#   pointed at a scratch tree to prove it actually fails on divergence — see
+#   the fail-first note in the commit message.
+# bash 3.2-safe: no globstar, no associative arrays.
+set -euo pipefail
+
+ROOT="${1:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+# Basenames intentionally allowed to differ between plugins. Empty today.
+DIVERGENT=""
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+cd "$ROOT"
+
+# Fail loudly if the structure this guard depends on is missing, rather than
+# sweeping zero files and reporting success — a glob matching nothing is
+# indistinguishable from passing (#82).
+all_scripts=$(find plugins -path '*/scripts/*.sh' -type f 2>/dev/null | sort)
+if [ -z "$all_scripts" ]; then
+  bad "no plugin scripts found under $ROOT — nothing was checked"
+  printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+  test "$FAIL" -eq 0
+fi
+
+duplicated=0
+names=$(printf '%s\n' "$all_scripts" | sed 's#.*/##' | sort -u)
+
+for name in $names; do
+  copies=$(printf '%s\n' "$all_scripts" | grep "/scripts/$name\$" || true)
+  count=$(printf '%s\n' "$copies" | grep -c . || true)
+  [ "$count" -gt 1 ] || continue
+  duplicated=$((duplicated+1))
+
+  if printf '%s\n' "$DIVERGENT" | grep -qx "$name"; then
+    ok "$name is declared intentionally divergent ($count copies, not compared)"
+    continue
+  fi
+
+  hashes=$(printf '%s\n' "$copies" | xargs shasum -a 256 | awk '{print $1}' | sort -u)
+  distinct=$(printf '%s\n' "$hashes" | grep -c .)
+  if [ "$distinct" = "1" ]; then
+    ok "$name: $count copies share one sha256"
+  else
+    bad "$name: $count copies have DIVERGED into $distinct versions"
+    printf '%s\n' "$copies" | xargs shasum -a 256 | sed 's/^/       /'
+  fi
+done
+
+# A duplicate set is the only thing this file exists to check. If discovery
+# stops finding any, the guard has quietly stopped guarding.
+if [ "$duplicated" -gt 0 ]; then
+  ok "discovery found $duplicated duplicated script set(s)"
+else
+  bad "discovery found no duplicated scripts — this guard is no longer guarding anything"
+fi
+
+# A stale allowlist entry would silently exempt a set that is no longer
+# divergent, so require every declared name to still be duplicated.
+for name in $DIVERGENT; do
+  [ -n "$name" ] || continue
+  count=$(printf '%s\n' "$all_scripts" | grep -c "/scripts/$name\$" || true)
+  if [ "$count" -gt 1 ]; then
+    ok "DIVERGENT entry '$name' still names a duplicated script"
+  else
+    bad "DIVERGENT entry '$name' is stale — it names $count copy/copies, so the exemption is dead"
+  fi
+done
+
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+test "$FAIL" -eq 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,15 @@
-<!-- jj-project-setup:start hash:fe023f83 -->
+<!-- jj-project-setup:start hash:be4e280a -->
 ## VCS — jj (Jujutsu)
 
 This project uses **jj (Jujutsu)** as its VCS. Never use raw git commands. Use jj equivalents instead (e.g. `jj log`, `jj status`, `jj diff`). The only exceptions are `jj git` subcommands (e.g. `jj git push`) and the `gh` CLI for GitHub operations.
 
 In jj, the working copy IS a commit. There is no uncommitted state. Never ask "want to commit?" or "ready to commit?" — the work is already committed. Use `jj new` to start a new change, `jj describe` to set intent. The only meaningful checkpoint questions are "want to start a new change?", "want to describe this change?", or "want to push?"
+
+### Gotchas that surprise git users
+
+- **Hand revisions between steps as change IDs, not commit IDs.** A change ID (`kouorrnv`) survives `jj squash`, `jj describe` and every other rewrite; a commit ID (`92ef691b`) is replaced by each one, so a value captured before an edit is stale after it. Read one with `jj log -r <rev> --no-graph -T 'change_id.short()'`. Commit IDs are fine for a one-shot query or an immutable record — not for anything held across a step.
+- **`jj abandon` re-parents `@` onto the abandoned change's parent.** After abandoning work that was merged upstream, `@` lands on the *pre-merge* base and every merged file reads as reverted on disk. Fix with `jj new trunk()`. The work is safe; the working copy is looking at the wrong revision.
+- **Abandoning `@` always leaves a fresh empty change.** You cannot end up with no working copy, so don't chase the new empty change you just created.
 
 ### Superpowers overrides
 

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/templates/CLAUDE.md.template
+++ b/plugins/project-setup-jj/templates/CLAUDE.md.template
@@ -1,9 +1,15 @@
-<!-- jj-project-setup:start hash:fe023f83 -->
+<!-- jj-project-setup:start hash:be4e280a -->
 ## VCS — jj (Jujutsu)
 
 This project uses **jj (Jujutsu)** as its VCS. Never use raw git commands. Use jj equivalents instead (e.g. `jj log`, `jj status`, `jj diff`). The only exceptions are `jj git` subcommands (e.g. `jj git push`) and the `gh` CLI for GitHub operations.
 
 In jj, the working copy IS a commit. There is no uncommitted state. Never ask "want to commit?" or "ready to commit?" — the work is already committed. Use `jj new` to start a new change, `jj describe` to set intent. The only meaningful checkpoint questions are "want to start a new change?", "want to describe this change?", or "want to push?"
+
+### Gotchas that surprise git users
+
+- **Hand revisions between steps as change IDs, not commit IDs.** A change ID (`kouorrnv`) survives `jj squash`, `jj describe` and every other rewrite; a commit ID (`92ef691b`) is replaced by each one, so a value captured before an edit is stale after it. Read one with `jj log -r <rev> --no-graph -T 'change_id.short()'`. Commit IDs are fine for a one-shot query or an immutable record — not for anything held across a step.
+- **`jj abandon` re-parents `@` onto the abandoned change's parent.** After abandoning work that was merged upstream, `@` lands on the *pre-merge* base and every merged file reads as reverted on disk. Fix with `jj new trunk()`. The work is safe; the working copy is looking at the wrong revision.
+- **Abandoning `@` always leaves a fresh empty change.** You cannot end up with no working copy, so don't chase the new empty change you just created.
 
 ### Superpowers overrides
 


### PR DESCRIPTION
## Summary

Two friction reductions that came out of running a long multi-agent session in this repo. Both target the same failure class: knowledge or invariants that existed only in someone's head, or in prose that wasn't loaded at the moment it was needed.

**1. A jj gotchas block in the `CLAUDE.md` template.** Three behaviours that surprise git users, each one hit for real during #79 tranche 1:

- *Hand revisions between steps as change IDs, not commit IDs.* A change ID survives `jj squash`/`jj describe`; a commit ID is replaced by every rewrite, so a value captured before an edit is stale after it. This cost three re-derived diff ranges in the eval-suite work before the pattern was noticed.
- *`jj abandon` re-parents `@` onto the abandoned change's parent.* After abandoning work that merged upstream, `@` lands on the pre-merge base and every merged file reads as reverted on disk. Fix is `jj new trunk()`. Observed live during `/finish` on #106 — the abandon removed 25 files, `jj new trunk()` restored them.
- *Abandoning `@` always leaves a fresh empty change.*

It went into `plugins/project-setup-jj/templates/CLAUDE.md.template` rather than only this repo's `CLAUDE.md`, so it reaches every project `/project-setup` touches, and is mirrored into the installed copy here so template and installation agree. Both markers now carry hash `be4e280a` — and the installed copy was found still carrying the old `fe023f83`, which would have made `/project-setup` read this repo as current when its CLAUDE.md no longer matched.

**2. A drift guard for scripts duplicated across plugins.** Several plugins ship byte-identical copies of the same script so each plugin stands alone. A fix applied to one copy and not the others is silent: the tests exercise one copy, pass, and the stale copies keep shipping old behaviour to whoever installed that plugin. **#101 was exactly this shape** — a security fix that had to land in three places at once.

`block-raw-git.sh` already had a guard inside its own behaviour test. Two other duplicated sets had none — `jj-workspace-create.sh` and `jj-workspace-remove.sh`, both duplicated across `project-setup-jj` and `workspace-jj`.

Rather than hand-list them, the guard **discovers** duplicates: any basename under more than one plugin's `scripts/` must be byte-identical everywhere. A future duplicated script is covered the day it lands — which is precisely what the hand-listed approach missed here, since `block-raw-git.sh` got a guard when it was written and the two workspace scripts never did. Intentional forks are allowed but must be declared in `DIVERGENT`, so a fork is a visible decision; a stale entry there fails too, because an allowlist that outlives its reason silently exempts a live set.

## Test plan

- [x] Full repo suite — **16 suites, 378 assertions, `0 suite(s) failed`, exit 0**
- [x] New suite confirmed discovered by CI's `find plugins .github -path '*/tests/test-*.sh'` glob
- [x] Template hash pin confirmed **failing first** against the stale `fe023f83` before the marker was updated — that guard's whole purpose is that an edited body under an unchanged hash reaches nobody
- [x] Template body and installed body diff byte-identical, markers and hash included
- [x] Version-bump lint (#84) exits 0; `project-setup-jj` 0.3.0 → 0.4.0
- [x] `/bin/bash -n` clean; bash 3.2-safe (no globstar, no associative arrays)

**Fail-first proof for the drift guard.** The copies are identical today, so the guard would otherwise be green on its first run and have proved nothing. Run against scratch trees — the repo tree was never written to:

| scenario | result |
|---|---|
| control, real tree | `4 passed, 0 failed` rc=0 |
| `jj-workspace-create.sh` diverged | `3 passed, 1 failed` rc=1 — that name only |
| `block-raw-git.sh` diverged | `3 passed, 1 failed` rc=1 — that name only |
| empty tree | `0 passed, 1 failed` rc=1 |

Each mutation flips exactly the assertion it should and prints the diverged paths with their hashes.

Two anti-vacuity guards are built in, because a discovery-based lint can silently stop discovering: an empty sweep **fails** rather than reporting success (#82's shape), and the run asserts it found at least one duplicated set.

## Reviewer notes

Deliberately **not** included: a lint forbidding commit IDs in handoff positions. The repo already keys its cross-step handoffs on change IDs (kaisen's ledger, peer-review's `REVIEWED_PARENT`), and the two `commit_id` captures that exist (kaisen's `base_rev`, `jj-workspace-create`'s `parent_rev`) are consumed on the next line, so no staleness window exists. Such a lint would pass on its first run, which this repo's house rule forbids. The convention is written down instead, as the first bullet of the gotchas block.

The drift guard lives in `.github/tests/` rather than inside a plugin because it is a repo-wide invariant, which is also why no plugin version bump was needed for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
