### PR TITLE
fix(project-setup-jj): duplicate marker when CLAUDE.md opens with the block

### DIFF
--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/scripts/project-setup-install.sh
+++ b/plugins/project-setup-jj/scripts/project-setup-install.sh
@@ -116,7 +116,19 @@ elif grep -q 'jj-project-setup:start' "$CLAUDE_MD"; then
   else
     s_line=$(grep -n 'jj-project-setup:start' "$CLAUDE_MD" | head -1 | cut -d: -f1)
     e_line=$(grep -n 'jj-project-setup:end' "$CLAUDE_MD" | head -1 | cut -d: -f1)
-    { sed -n "1,$((s_line-1))p" "$CLAUDE_MD"; cat "$TEMPLATE"; sed -n "$((e_line+1)),\$p" "$CLAUDE_MD"; } > "$CLAUDE_MD.tmp"
+    # The prefix slice must be skipped entirely when the marker is on line 1.
+    # `sed -n "1,0p"` is an inverted range, and BSD sed prints line 1 for it
+    # rather than nothing — which re-emitted the stale start marker above the
+    # fresh one. The file then carried two start markers, and since the hash is
+    # read from the FIRST one, every later run saw a stale hash and duplicated
+    # the pair again. Observed in a real project before this guard existed.
+    # The tail slice needs no such guard: `sed -n "N,\$p"` with N past the last
+    # line correctly prints nothing.
+    {
+      [ "$s_line" -gt 1 ] && sed -n "1,$((s_line-1))p" "$CLAUDE_MD"
+      cat "$TEMPLATE"
+      sed -n "$((e_line+1)),\$p" "$CLAUDE_MD"
+    } > "$CLAUDE_MD.tmp"
     mv "$CLAUDE_MD.tmp" "$CLAUDE_MD"
     claude_outcome="updated"
   fi

--- a/plugins/project-setup-jj/tests/test-project-setup-install.sh
+++ b/plugins/project-setup-jj/tests/test-project-setup-install.sh
@@ -102,6 +102,35 @@ P=$(newproj); mkdir -p "$P"
 printf '# Top\n<!-- jj-project-setup:start hash:deadbeef -->\nOLD BODY\n<!-- jj-project-setup:end -->\n# Bottom\n' > "$P/CLAUDE.md"
 bash "$INSTALL" "$PLUG" "$P" >/dev/null
 grep -q 'Use jj, not git.' "$P/CLAUDE.md" && ! grep -q 'OLD BODY' "$P/CLAUDE.md" && grep -q '# Top' "$P/CLAUDE.md" && grep -q '# Bottom' "$P/CLAUDE.md" && ok "claude_md 5c: section replaced, surroundings intact" || bad "claude_md 5c" "replace wrong"
+# 5d marker on LINE 1 -> replaced without duplicating the marker pair.
+# 5c always has content above the marker, so the prefix slice is 1,N with N>=1
+# and the boundary never gets exercised. With the marker on line 1 the slice
+# becomes `sed -n "1,0p"`, and BSD sed prints line 1 for an inverted range
+# instead of nothing — leaving the stale start marker above the fresh one.
+# A real project hit this: the file grew a duplicate start marker carrying the
+# OLD hash, and because the installer reads the FIRST marker's hash it would
+# recur on every subsequent run.
+P=$(newproj); mkdir -p "$P"
+printf '<!-- jj-project-setup:start hash:deadbeef -->\nOLD BODY\n<!-- jj-project-setup:end -->\n# Bottom\n' > "$P/CLAUDE.md"
+bash "$INSTALL" "$PLUG" "$P" >/dev/null
+s_count=$(grep -c 'jj-project-setup:start' "$P/CLAUDE.md")
+e_count=$(grep -c 'jj-project-setup:end' "$P/CLAUDE.md")
+if [ "$s_count" -eq 1 ] && [ "$e_count" -eq 1 ] && ! grep -q 'deadbeef' "$P/CLAUDE.md" \
+   && grep -q 'Use jj, not git.' "$P/CLAUDE.md" && ! grep -q 'OLD BODY' "$P/CLAUDE.md" \
+   && grep -q '# Bottom' "$P/CLAUDE.md"; then
+  ok "claude_md 5d: marker on line 1 replaced without duplication"
+else
+  bad "claude_md 5d" "start=$s_count end=$e_count (want 1/1, no stale deadbeef)"
+fi
+# 5e re-running over a line-1 marker stays at one pair (the defect compounded
+# per run, so idempotence is the property that actually protects the file).
+bash "$INSTALL" "$PLUG" "$P" >/dev/null
+s_count2=$(grep -c 'jj-project-setup:start' "$P/CLAUDE.md")
+if [ "$s_count2" -eq 1 ]; then
+  ok "claude_md 5e: re-run over a line-1 marker stays at one pair"
+else
+  bad "claude_md 5e" "start markers after re-run: $s_count2 (want 1)"
+fi
 
 # ---- Case 6: malformed existing settings -> abort, no clobber ----
 P=$(newproj); mkdir -p "$P/.claude"


### PR DESCRIPTION
## Summary

Reported from a real `/project-setup` run: the installer emitted a second `jj-project-setup:start` marker, leaving the **old** hash line stranded above the new one.

**Cause is an inverted `sed` range.** Marker replacement rebuilds the file as prefix + template + suffix, where the prefix is `sed -n "1,$((s_line-1))p"`. When the marker sits on line 1 that becomes `sed -n "1,0p"` — and BSD sed prints line 1 for an inverted range instead of nothing. Confirmed directly:

```
$ printf 'LINE_ONE\nLINE_TWO\n' | sed -n "1,0p"
LINE_ONE
```

So the stale start marker was re-emitted immediately above the fresh one.

**It compounds.** The installer reads the hash from the *first* marker, which after the first bad run is the stale one. Every subsequent run therefore sees a mismatched hash, takes the replace path again, and duplicates the pair again. A project gains one marker per run indefinitely.

Fixed by skipping the prefix slice entirely when `s_line` is 1. The tail slice needs no equivalent guard — `sed -n "N,\$p"` with N past the last line correctly prints nothing, verified.

## Why the existing test didn't catch it

Case 5c already covered marker replacement, but it always placed content above the marker (`# Top`), so `s_line` was never 1 and the boundary went unexercised. The defect lived behind a passing test.

Adds two cases:

- **5d** — marker on line 1 is replaced without duplication (exactly one start/end pair, stale hash gone, trailing content preserved).
- **5e** — a re-run over a line-1 marker stays at one pair. Compounding was the actual damage, so idempotence is the property that protects the file.

Both confirmed **RED** against the unfixed installer:

```
FAIL: claude_md 5d — start=2 end=1 (want 1/1, no stale deadbeef)
FAIL: claude_md 5e — start markers after re-run: 2 (want 1)
=== Results: 32 passed, 2 failed ===
```

## Test plan

- [x] `test-project-setup-install.sh` — **34 passed, 0 failed** (was 32; +2 new)
- [x] New assertions confirmed failing against the unfixed installer, for the stated reason
- [x] Direct repro against the real template: installer `rc=0`, exactly 1 start / 1 end marker, stale hash absent, trailing content preserved, resulting head is the current `hash:be4e280a`
- [x] Verified the guard is safe under `set -euo pipefail` — the `&&` list is not the group's last command, and the direct repro exits 0
- [x] Full repo suite — **16 suites, 380 assertions, `0 suite(s) failed`, exit 0**
- [x] `/bin/bash -n` clean; bash 3.2-safe
- [x] Version-bump lint (#84); `project-setup-jj` 0.4.0 → 0.5.0

## Note for anyone already affected

A project whose `CLAUDE.md` has already accumulated a duplicated marker pair needs the stray line removed by hand **once** — this fix stops it recurring but does not repair files already damaged. The tell is two `jj-project-setup:start` lines, the first carrying an older hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
