### PR TITLE
fix(project-setup-jj): match markers by line, not by substring

### DIFF
--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/scripts/project-setup-install.sh
+++ b/plugins/project-setup-jj/scripts/project-setup-install.sh
@@ -105,17 +105,32 @@ echo "settings=$settings_outcome"
 md5hash() { if command -v md5 >/dev/null 2>&1; then md5 -q; else md5sum; fi | cut -c1-8; }
 tmpl_hash=$(sed -n '/jj-project-setup:start/,/jj-project-setup:end/p' "$TEMPLATE" | sed '1d;$d' | md5hash)
 
+# Markers are matched by "this LINE is a marker", never by "this line mentions
+# the marker". A plain substring search treats prose such as
+#   never edit inside the jj-project-setup:start block
+# as the marker itself. When that sentence sits above the real block it becomes
+# s_line, and everything from it down to the real end marker is replaced —
+# silently destroying the prose and anything between. A real project documents
+# the convention in exactly this way (just below its block rather than above),
+# so the ordering that triggers it is one edit away.
+#
+# The template's own hash computation deliberately keeps the looser sed address
+# it shares with tests/test-template-hash.sh: the template is repo-controlled
+# and well-formed, and the two must agree byte-for-byte or the pin check breaks.
+START_RE='^[[:space:]]*<!--[[:space:]]*jj-project-setup:start'
+END_RE='^[[:space:]]*<!--[[:space:]]*jj-project-setup:end'
+
 claude_outcome=""
 if [ ! -f "$CLAUDE_MD" ]; then
   cp "$TEMPLATE" "$CLAUDE_MD"
   claude_outcome="created"
-elif grep -q 'jj-project-setup:start' "$CLAUDE_MD"; then
-  installed_hash=$(grep -o 'jj-project-setup:start hash:[0-9a-f]*' "$CLAUDE_MD" | head -1 | sed 's/.*hash://')
+elif grep -qE "$START_RE" "$CLAUDE_MD"; then
+  installed_hash=$(grep -E "$START_RE" "$CLAUDE_MD" | head -1 | grep -o 'hash:[0-9a-f]*' | sed 's/hash://')
   if [ -n "$installed_hash" ] && [ "$installed_hash" = "$tmpl_hash" ]; then
     claude_outcome="unchanged"
   else
-    s_line=$(grep -n 'jj-project-setup:start' "$CLAUDE_MD" | head -1 | cut -d: -f1)
-    e_line=$(grep -n 'jj-project-setup:end' "$CLAUDE_MD" | head -1 | cut -d: -f1)
+    s_line=$(grep -nE "$START_RE" "$CLAUDE_MD" | head -1 | cut -d: -f1)
+    e_line=$(grep -nE "$END_RE" "$CLAUDE_MD" | head -1 | cut -d: -f1)
     # The prefix slice must be skipped entirely when the marker is on line 1.
     # `sed -n "1,0p"` is an inverted range, and BSD sed prints line 1 for it
     # rather than nothing — which re-emitted the stale start marker above the

--- a/plugins/project-setup-jj/tests/test-project-setup-install.sh
+++ b/plugins/project-setup-jj/tests/test-project-setup-install.sh
@@ -131,6 +131,36 @@ if [ "$s_count2" -eq 1 ]; then
 else
   bad "claude_md 5e" "start markers after re-run: $s_count2 (want 1)"
 fi
+# 5f prose ABOVE the block that merely names the marker must not be mistaken
+# for it. The installer located markers by substring, so a sentence like
+# "never edit inside the jj-project-setup:start block" sitting above the real
+# marker became s_line, and everything from it down to the real end marker was
+# replaced — silently destroying the prose and any content between. A real
+# project (sususisu) documents the convention in exactly this way, just below
+# its block rather than above, so the reordering that triggers this is one edit
+# away.
+P=$(newproj); mkdir -p "$P"
+printf 'Docs: never edit inside the jj-project-setup:start block.\n# Top\n<!-- jj-project-setup:start hash:deadbeef -->\nOLD BODY\n<!-- jj-project-setup:end -->\n# Bottom\n' > "$P/CLAUDE.md"
+bash "$INSTALL" "$PLUG" "$P" >/dev/null
+if grep -q 'Docs: never edit inside' "$P/CLAUDE.md" && grep -q '# Top' "$P/CLAUDE.md" \
+   && grep -q '# Bottom' "$P/CLAUDE.md" && grep -q 'Use jj, not git.' "$P/CLAUDE.md" \
+   && ! grep -q 'OLD BODY' "$P/CLAUDE.md"; then
+  ok "claude_md 5f: prose above the block is not mistaken for the marker"
+else
+  bad "claude_md 5f" "prose/heading above the block was destroyed: $(head -3 "$P/CLAUDE.md" | tr '\n' '|')"
+fi
+# 5g prose BELOW the block (the shape a real project actually has) keeps
+# working. Regression guard — expected to pass before and after the fix.
+P=$(newproj); mkdir -p "$P"
+printf '<!-- jj-project-setup:start hash:deadbeef -->\nOLD BODY\n<!-- jj-project-setup:end -->\n# Notes\nThis file has a jj-project-setup:start/end managed block.\n' > "$P/CLAUDE.md"
+bash "$INSTALL" "$PLUG" "$P" >/dev/null
+if grep -q 'managed block' "$P/CLAUDE.md" && grep -q 'Use jj, not git.' "$P/CLAUDE.md" \
+   && ! grep -q 'OLD BODY' "$P/CLAUDE.md" \
+   && [ "$(grep -cE '^[[:space:]]*<!--[[:space:]]*jj-project-setup:start' "$P/CLAUDE.md")" -eq 1 ]; then
+  ok "claude_md 5g: prose below the block still updates cleanly"
+else
+  bad "claude_md 5g" "below-block prose case broke"
+fi
 
 # ---- Case 6: malformed existing settings -> abort, no clobber ----
 P=$(newproj); mkdir -p "$P/.claude"


### PR DESCRIPTION
## Summary

Follow-up to #108, found while auditing which projects still needed `/project-setup`.

The installer located the managed block with a plain substring search, so any prose that merely **names** the marker was treated as the marker itself. A sentence like:

> never edit inside the `jj-project-setup:start` block

sitting above the real block becomes `s_line`, and everything from it down to the real end marker gets replaced — silently destroying that prose and anything between it and the block.

**This is not hypothetical.** `sususisu` documents the convention in exactly this way, just *below* its block rather than above, so the ordering that triggers the defect is one edit away. That same file also made the audit itself lie: a naive marker count reported it as DUPLICATED, when the second "marker" was that sentence.

Both markers are now matched anchored to line start:

```
^[[:space:]]*<!--[[:space:]]*jj-project-setup:(start|end)
```

and the installed hash is read from the matched marker **line**, rather than by scanning the whole file for a hash-shaped substring.

The template's own hash computation deliberately keeps its looser `sed` address: it is shared verbatim with `tests/test-template-hash.sh`, the template is repo-controlled and well-formed, and the two must agree byte-for-byte or the pin check breaks.

## Test plan

- [x] `test-project-setup-install.sh` — **36 passed, 0 failed** (was 34; +2 new)
- [x] **5f** — prose above the block is not mistaken for the marker. Confirmed **RED** against the unfixed installer: both the prose line and the heading above the block were destroyed, leaving the file starting at the marker
- [x] **5g** — prose below the block still updates cleanly. Regression guard for the shape a real project actually has; passes before and after
- [x] Verified against the real `sususisu` CLAUDE.md as a dry run into a scratch dir — **all 68 lines outside the managed block preserved, zero lost**, block updated `fe023f83` → `be4e280a`, exactly one marker pair, installer `rc=0`
- [x] Full repo suite — **16 suites, 382 assertions, `0 suite(s) failed`, exit 0**
- [x] `/bin/bash -n` clean; bash 3.2-safe
- [x] Version-bump lint (#84); `project-setup-jj` 0.5.0 → 0.6.0

## Note

This is the second defect in the same twenty lines, and both share a root cause: identifying a structural marker by *what a line contains* rather than by *what the line is*. #108 was an inverted `sed` range at the same boundary. Worth keeping in mind if this block is touched again.

No project is currently damaged by this — the audit found zero duplicated or truncated files. The fix is preventative for `sususisu` and anything that later documents its own managed block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
