### PR TITLE
Align with documented hook conventions: quote CLAUDE_PLUGIN_ROOT, install project hooks to .claude/hooks/

### DIFF
--- a/.github/tests/test-plugin-hook-commands.sh
+++ b/.github/tests/test-plugin-hook-commands.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Every plugin hook command must QUOTE its ${CLAUDE_PLUGIN_ROOT} expansion.
+#
+# Claude Code runs a hook `command` through a shell. An unquoted
+#   ${CLAUDE_PLUGIN_ROOT}/scripts/block-raw-git.sh
+# word-splits the moment the plugin root contains a space — and plugin roots are
+# not ours to choose: they live under the user's home, the marketplace cache, or
+# wherever the user cloned the repo ("~/My Projects/...", "~/Library/Mobile
+# Documents/..."). The shell then tries to execute the first word and passes the
+# rest as arguments, so the hook never launches.
+#
+# A hook that fails to launch is SILENT. For block-raw-git.sh that means the
+# raw-git wall simply stops firing: no error surfaces to the user, and every
+# `git` command the plugin exists to block sails through. That is the worst
+# possible failure mode for a security hook — it fails open, quietly, on a
+# machine whose path the maintainer never sees.
+#
+# The fix is the form official Anthropic plugins ship: the JSON value carries
+# literal double quotes around the expansion, e.g.
+#   "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/block-raw-git.sh\""
+#
+# Scope: plugins/*/.claude-plugin/plugin.json (hook config inline in the
+# manifest) and plugins/*/hooks/hooks.json (the separate-file form documented in
+# the plugins reference). No plugin uses the latter today; it is swept anyway so
+# a future one is covered the day it lands rather than the day it breaks.
+#
+# Usage: test-plugin-hook-commands.sh [ROOT]
+#   ROOT defaults to the repo root. It is overridable so this guard can be
+#   pointed at a scratch tree to prove it actually fails on an unquoted command.
+# bash 3.2-safe: no globstar, no associative arrays.
+set -euo pipefail
+
+ROOT="${1:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+cd "$ROOT"
+
+command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 2; }
+
+# Both hook-carrying file shapes. `find` rather than a bash glob: a glob that
+# matches nothing expands to its own literal text under bash 3.2 defaults.
+files=$(find plugins \( -path '*/.claude-plugin/plugin.json' -o -path '*/hooks/hooks.json' \) \
+  -type f 2>/dev/null | sort)
+
+if [ -z "$files" ]; then
+  bad "no plugin manifests or hooks.json files found under $ROOT — nothing was checked"
+  printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+  test "$FAIL" -eq 0
+fi
+
+# Extract every hook command, shape-agnostically: any object carrying
+# type=="command" with a string .command, wherever it sits. This survives both
+# the inline-manifest shape and the hooks.json shape (and any future nesting)
+# without a hand-maintained path per file.
+extract_commands() {
+  jq -r '[.. | objects | select(.type? == "command" and (.command? | type == "string")) | .command] | .[]' "$1"
+}
+
+total_cmds=0
+for f in $files; do
+  jq empty "$f" >/dev/null 2>&1 || { bad "$f: not valid JSON"; continue; }
+  cmds=$(extract_commands "$f" || true)
+  [ -n "$cmds" ] || continue
+
+  while IFS= read -r cmd; do
+    [ -n "$cmd" ] || continue
+    total_cmds=$((total_cmds + 1))
+
+    # Commands that never name the plugin root cannot word-split on it.
+    n_total=$(printf '%s' "$cmd" | grep -oE '\$\{?CLAUDE_PLUGIN_ROOT\}?' | grep -c . || true)
+    if [ "$n_total" -eq 0 ]; then
+      ok "$f: '$cmd' does not reference CLAUDE_PLUGIN_ROOT"
+      continue
+    fi
+
+    # Quoted form: the expansion opens with a double quote and the run of
+    # non-quote characters after it (the rest of the path) closes with one.
+    n_quoted=$(printf '%s' "$cmd" | grep -oE '"\$\{?CLAUDE_PLUGIN_ROOT\}?[^"]*"' | grep -c . || true)
+
+    if [ "$n_total" -eq "$n_quoted" ]; then
+      ok "$f: hook command quotes CLAUDE_PLUGIN_ROOT ($n_quoted/$n_total) -> $cmd"
+    else
+      bad "$f: hook command leaves CLAUDE_PLUGIN_ROOT UNQUOTED ($n_quoted/$n_total quoted) -> $cmd"
+      printf '       a plugin root containing a space word-splits here and the hook never launches\n'
+    fi
+  done <<EOF
+$cmds
+EOF
+done
+
+# #82 shape: a sweep that finds nothing is indistinguishable from a sweep that
+# passes. Hook commands are the only thing this file exists to check, so zero of
+# them means the extractor broke or the manifests changed — fail loud.
+if [ "$total_cmds" -gt 0 ]; then
+  ok "discovery found $total_cmds hook command(s) across $(printf '%s\n' "$files" | grep -c .) file(s)"
+else
+  bad "discovery found ZERO hook commands — this guard is no longer guarding anything"
+fi
+
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+test "$FAIL" -eq 0

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ Enables Claude Code's `--worktree` flag and subagent `isolation: "worktree"` in 
 /plugin install workspace-jj@muloka-claude-plugins
 
 # 2. Run setup in your jj project (copies hook scripts, configures settings)
-/workspace-setup
+/project-setup
 
 # 3. Restart Claude Code, then use worktrees
 claude --worktree feature-auth
 ```
 
-Claude Code doesn't pick up `WorktreeCreate`/`WorktreeRemove` hooks from plugins — they must be in project settings. The `/workspace-setup` command handles this by copying scripts to `.claude/scripts/` and configuring `.claude/settings.local.json`.
+Claude Code doesn't pick up `WorktreeCreate`/`WorktreeRemove` hooks from plugins — they must be in project settings. `/project-setup` (from `project-setup-jj`) handles this: its installer copies the hook handlers to `.claude/hooks/` and registers them in `.claude/settings.local.json`. There is no separate `/workspace-setup` command — it was folded into `/project-setup` so one command installs every jj hook.
 
 **Requires:** [jj](https://martinvonz.github.io/jj/) and [jq](https://jqlang.github.io/jq/)
 
@@ -129,7 +129,7 @@ Or browse available plugins:
 /plugin
 ```
 
-**Note:** After installing workspace-jj, run `/workspace-setup` in your jj project and restart Claude Code.
+**Note:** After installing workspace-jj, run `/project-setup` in your jj project and restart Claude Code — that is what installs the `WorktreeCreate`/`WorktreeRemove` hooks into project settings.
 
 ## Evals
 

--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"
@@ -13,7 +13,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/block-raw-git.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/block-raw-git.sh\""
           }
         ]
       }

--- a/plugins/peer-review-jj/.claude-plugin/plugin.json
+++ b/plugins/peer-review-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "peer-review-jj",
   "description": "Unified change review for jj repos — generalist-first with emergent specialists, two-phase pipeline, structured findings",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"
@@ -13,11 +13,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/block-raw-git.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/block-raw-git.sh\""
           },
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/block-review-markers.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/block-review-markers.sh\""
           }
         ]
       }

--- a/plugins/permission-gateway/.claude-plugin/plugin.json
+++ b/plugins/permission-gateway/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "permission-gateway",
   "description": "Tiered permission gateway — auto-approves safe commands, blocks dangerous ones, escalates edge cases to human",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"
@@ -13,7 +13,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/permission-gate.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/permission-gate.sh\""
           }
         ]
       },
@@ -22,7 +22,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/gate-config-writes.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/gate-config-writes.sh\""
           }
         ]
       },
@@ -31,7 +31,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/gate-config-writes.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/gate-config-writes.sh\""
           }
         ]
       }

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"
@@ -13,7 +13,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/block-raw-git.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/block-raw-git.sh\""
           }
         ]
       }

--- a/plugins/project-setup-jj/README.md
+++ b/plugins/project-setup-jj/README.md
@@ -32,10 +32,10 @@ This creates/updates the following in your project:
 
 | File | Purpose |
 |------|---------|
-| `.claude/scripts/jj-session-start.sh` | SessionStart hook showing jj context |
-| `.claude/scripts/require-jj-new.sh` | PreToolUse hook — advises Claude to run `jj new` before editing into a non-empty change (informational — does not block) |
-| `.claude/scripts/jj-workspace-create.sh` | WorktreeCreate hook — creates jj workspace for worktree isolation |
-| `.claude/scripts/jj-workspace-remove.sh` | WorktreeRemove hook — cleans up jj workspace |
+| `.claude/hooks/jj-session-start.sh` | SessionStart hook showing jj context |
+| `.claude/hooks/require-jj-new.sh` | PreToolUse hook — advises Claude to run `jj new` before editing into a non-empty change (informational — does not block) |
+| `.claude/hooks/jj-workspace-create.sh` | WorktreeCreate hook — creates jj workspace for worktree isolation |
+| `.claude/hooks/jj-workspace-remove.sh` | WorktreeRemove hook — cleans up jj workspace |
 | `.claude/settings.local.json` | Hook registration (SessionStart, PreToolUse, PreCompact, WorktreeCreate, WorktreeRemove) + jj permissions |
 | `CLAUDE.md` | jj VCS policy directive (created or updated) |
 
@@ -72,13 +72,13 @@ Two more commands manage a jj-aware statusline, independent of `/project-setup`:
 /statusline-jj-setup
 ```
 
-Copies `.claude/scripts/statusline-jj.sh` into the project and sets it as the `statusLine` command in `.claude/settings.local.json`. The statusline is a powerline-style bar showing the model, bookmark, change ID, change description, trunk-sync status, context-window percentage, and Anthropic service status.
+Copies `.claude/hooks/statusline-jj.sh` into the project and sets it as the `statusLine` command in `.claude/settings.local.json`. The statusline is a powerline-style bar showing the model, bookmark, change ID, change description, trunk-sync status, context-window percentage, and Anthropic service status.
 
 ```
 /statusline-jj-remove
 ```
 
-Removes `.claude/scripts/statusline-jj.sh` and deletes the `statusLine` key from `.claude/settings.local.json`.
+Removes `statusline-jj.sh` and deletes the `statusLine` key from `.claude/settings.local.json`. It clears both `.claude/hooks/` and the legacy `.claude/scripts/`, so a project set up before the move can still uninstall cleanly.
 
 ## Idempotent
 

--- a/plugins/project-setup-jj/commands/project-setup.md
+++ b/plugins/project-setup-jj/commands/project-setup.md
@@ -23,16 +23,19 @@ All install work is done by a deterministic script — do not hand-merge setting
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/project-setup-install.sh" "${CLAUDE_PLUGIN_ROOT}" "$(jj root)"
 ```
 
-The script copies the four hook scripts into `.claude/scripts/`, deep-merges the hooks and permissions into `.claude/settings.local.json` (idempotently — re-running never duplicates entries and never touches unrelated config), and creates/updates the CLAUDE.md `## VCS` section. It prints a `key=value` summary and exits non-zero without writing if an existing `.claude/settings.local.json` is not valid JSON (in which case, report the error and stop — do not attempt to repair it automatically).
+The script copies the four hook handlers into `.claude/hooks/`, deep-merges the hooks and permissions into `.claude/settings.local.json` (idempotently — re-running never duplicates entries and never touches unrelated config), and creates/updates the CLAUDE.md `## VCS` section. It prints a `key=value` summary and exits non-zero without writing if an existing `.claude/settings.local.json` is not valid JSON (in which case, report the error and stop — do not attempt to repair it automatically).
+
+Earlier versions installed these handlers into `.claude/scripts/`. The script migrates such a project in one run: it re-points the registrations (replacing the old ones rather than adding a second copy beside them) and deletes the four files it owns from `.claude/scripts/`, removing that directory only if nothing else is left in it. Files it does not own — notably `statusline-jj.sh` from `/statusline-jj-setup` — are left alone.
 
 ### Step 3: Report
 
 Read the script's `key=value` summary and confirm to the user what was set up:
 
-- Hook scripts installed in `.claude/scripts/` (SessionStart, require-jj-new, workspace create/remove)
+- Hook handlers installed in `.claude/hooks/` (SessionStart, require-jj-new, workspace create/remove)
 - `.claude/settings.local.json` updated (SessionStart + PreCompact + PreToolUse + WorktreeCreate + WorktreeRemove hooks + jj permissions) — value from `settings=`
+- Legacy `.claude/scripts/` — per the `legacy_scripts=` value: `removed` (migrated and the empty directory cleaned up), `kept_not_empty` (our files removed, directory kept because other files such as `statusline-jj.sh` remain), or `absent` (nothing to migrate)
 - CLAUDE.md — `created`, `updated`, or `already up to date` per the `claude_md=` value
 
 Then remind the user to:
 - **Restart Claude Code** for the hooks to take effect
-- Optionally add `.claude/scripts/` to their ignore patterns if they don't want these tracked
+- Optionally add `.claude/hooks/` to their ignore patterns if they don't want these tracked

--- a/plugins/project-setup-jj/commands/statusline-jj-remove.md
+++ b/plugins/project-setup-jj/commands/statusline-jj-remove.md
@@ -1,6 +1,6 @@
 ---
 description: Remove jj statusline from this project
-allowed-tools: Bash(jj:*), Bash(rm:*), Bash(cat:*), Bash(jq:*), Read, Write
+allowed-tools: Bash(jj:*), Bash(rm:*), Bash(rmdir:*), Bash(cat:*), Bash(jq:*), Read, Write
 ---
 
 **CRITICAL: This is a jj (Jujutsu) plugin. You MUST NOT use ANY raw git commands — not even for context discovery. Always use jj equivalents. The only exceptions are `jj git` subcommands and `gh` CLI.**
@@ -15,8 +15,21 @@ Remove the jj statusline script and configuration from this project.
 
 ### Step 2: Remove statusline script
 
+Delete from **both** locations. The statusline now lives in `.claude/hooks/`, but a
+project set up before that move still has it in `.claude/scripts/` — removing only
+the new path would leave that copy behind and the uninstall would silently not
+uninstall anything:
+
 ```bash
+rm -f "$(jj root)/.claude/hooks/statusline-jj.sh"
 rm -f "$(jj root)/.claude/scripts/statusline-jj.sh"
+```
+
+Then drop the legacy directory if it is now empty. Use `rmdir`, never `rm -rf`: it
+refuses a non-empty directory, so a script the user keeps there is never destroyed:
+
+```bash
+rmdir "$(jj root)/.claude/scripts" 2>/dev/null || true
 ```
 
 ### Step 3: Remove statusLine from settings

--- a/plugins/project-setup-jj/commands/statusline-jj-setup.md
+++ b/plugins/project-setup-jj/commands/statusline-jj-setup.md
@@ -1,6 +1,6 @@
 ---
 description: Add jj-aware statusline to this project
-allowed-tools: Bash(jj:*), Bash(cp:*), Bash(chmod:*), Bash(mkdir:*), Bash(cat:*), Bash(jq:*), Read, Write
+allowed-tools: Bash(jj:*), Bash(cp:*), Bash(chmod:*), Bash(mkdir:*), Bash(rm:*), Bash(rmdir:*), Bash(cat:*), Bash(jq:*), Read, Write
 ---
 
 **CRITICAL: This is a jj (Jujutsu) plugin. You MUST NOT use ANY raw git commands — not even for context discovery. Always use jj equivalents. The only exceptions are `jj git` subcommands and `gh` CLI.**
@@ -14,19 +14,28 @@ Install the jj-aware statusline script and configure it in this project's `.clau
 1. Verify this is a jj repo by running `jj root`. If it fails, tell the user this command requires a jj repository and stop.
 2. Find the plugin's scripts directory. Look for the directory containing this command file — it will be something like `~/.claude/plugins/cache/muloka-claude-plugins/project-setup-jj/<hash>/`. The scripts are in `scripts/` relative to the plugin root.
 3. Determine the project root using `jj root`.
-4. Ensure `.claude/scripts/` exists in the project root:
+4. Ensure `.claude/hooks/` exists in the project root:
    ```bash
-   mkdir -p "$(jj root)/.claude/scripts"
+   mkdir -p "$(jj root)/.claude/hooks"
    ```
 
 ### Step 2: Copy statusline script
 
-Copy `statusline-jj.sh` from the plugin's `scripts/` directory to the project's `.claude/scripts/`:
+Copy `statusline-jj.sh` from the plugin's `scripts/` directory to the project's `.claude/hooks/`:
 
 ```bash
-cp <plugin-scripts-dir>/statusline-jj.sh "$(jj root)/.claude/scripts/"
-chmod +x "$(jj root)/.claude/scripts/statusline-jj.sh"
+cp <plugin-scripts-dir>/statusline-jj.sh "$(jj root)/.claude/hooks/"
+chmod +x "$(jj root)/.claude/hooks/statusline-jj.sh"
 ```
+
+If a copy is left over at the old `.claude/scripts/statusline-jj.sh`, remove it so only one copy exists:
+
+```bash
+rm -f "$(jj root)/.claude/scripts/statusline-jj.sh"
+rmdir "$(jj root)/.claude/scripts" 2>/dev/null || true
+```
+
+`rmdir` refuses a non-empty directory, so this only cleans up when nothing else remains there.
 
 ### Step 3: Update `.claude/settings.local.json`
 
@@ -36,7 +45,7 @@ Read the current `.claude/settings.local.json` (may not exist). Deep-merge the f
 {
   "statusLine": {
     "type": "command",
-    "command": "<project-root>/.claude/scripts/statusline-jj.sh"
+    "command": "<project-root>/.claude/hooks/statusline-jj.sh"
   }
 }
 ```
@@ -48,7 +57,7 @@ Replace `<project-root>` with the actual absolute path from `jj root`.
 ### Step 4: Confirm to user
 
 Show:
-- Statusline script copied to `.claude/scripts/statusline-jj.sh`
+- Statusline script copied to `.claude/hooks/statusline-jj.sh`
 - `statusLine` config added to `.claude/settings.local.json`
 - **Restart Claude Code** for the statusline to appear
 

--- a/plugins/project-setup-jj/scripts/project-setup-install.sh
+++ b/plugins/project-setup-jj/scripts/project-setup-install.sh
@@ -16,9 +16,19 @@ PROJECT_ROOT="${2:?usage: project-setup-install.sh <plugin-root> <project-root>}
 SRC="$PLUGIN_ROOT/scripts"
 TEMPLATE="$PLUGIN_ROOT/templates/CLAUDE.md.template"
 CLAUDE_DIR="$PROJECT_ROOT/.claude"
-DST="$CLAUDE_DIR/scripts"
+# Project hook handlers live in .claude/hooks/ — the location every example in
+# the Claude Code hooks docs uses. Nothing auto-discovers it (hooks are always
+# registered in a settings file), so this is convention rather than mechanism,
+# but it is the convention every reader arrives with. LEGACY_DST is where this
+# installer used to put them; it is migrated from, never written to.
+DST="$CLAUDE_DIR/hooks"
+LEGACY_DST="$CLAUDE_DIR/scripts"
 SETTINGS="$CLAUDE_DIR/settings.local.json"
 CLAUDE_MD="$PROJECT_ROOT/CLAUDE.md"
+
+# The four handlers this installer owns. Named once: the copy loop, the settings
+# upsert identities, and the legacy cleanup must never disagree about the set.
+MANAGED_SCRIPTS="jj-session-start.sh require-jj-new.sh jj-workspace-create.sh jj-workspace-remove.sh"
 
 # --- 0. fail-safe: validate an existing settings file BEFORE any side effect ---
 # (must run before the copy loop so a malformed settings file aborts touching
@@ -37,7 +47,7 @@ fi
 
 # --- 1. dirs + copy the four consumer hook scripts ---
 mkdir -p "$DST"
-for s in jj-session-start.sh require-jj-new.sh jj-workspace-create.sh jj-workspace-remove.sh; do
+for s in $MANAGED_SCRIPTS; do
   cp "$SRC/$s" "$DST/$s"
   chmod +x "$DST/$s"
 done
@@ -54,7 +64,15 @@ echo "workspace_hooks=copied"
 # The endswith() upsert below matches on the shared suffix, so re-running the
 # installer over a pre-existing absolute-path entry replaces it in place instead of
 # leaving a duplicate (covered by the "stale" case in test-project-setup-install.sh).
-HOOK_DIR='$CLAUDE_PROJECT_DIR/.claude/scripts'
+#
+# The upsert strips a LIST of suffixes, not one. Handlers moved from
+# .claude/scripts/ to .claude/hooks/, and a project installed before that move
+# carries a registration under the OLD path. If identity were matched on the new
+# suffix alone, that old registration would not match, would survive untouched,
+# and the fresh entry would be appended beside it — leaving TWO registrations per
+# event, both of which fire. Listing the legacy suffix alongside the current one
+# makes a single run REPLACE the old registration instead of joining it.
+HOOK_DIR='$CLAUDE_PROJECT_DIR/.claude/hooks'
 SS="$HOOK_DIR/jj-session-start.sh"
 RJN="$HOOK_DIR/require-jj-new.sh"
 WSC="$HOOK_DIR/jj-workspace-create.sh"
@@ -62,12 +80,16 @@ WSR="$HOOK_DIR/jj-workspace-remove.sh"
 
 merged=$(printf '%s' "$base" | jq \
   --arg ss "$SS" --arg rjn "$RJN" --arg wsc "$WSC" --arg wsr "$WSR" '
-  # hook-granularity replace-by-identity: strip hooks whose command ends with
-  # $sfx from every entry of event $ev, drop emptied entries, append $new.
-  def upsert($ev; $sfx; $new):
+  # hook-granularity replace-by-identity: strip hooks whose command ends with ANY
+  # suffix in $sfxs from every entry of event $ev, drop emptied entries, append
+  # $new. $sfxs carries both the current .claude/hooks/ path and the legacy
+  # .claude/scripts/ one, so a project on either layout ends with exactly one
+  # registration rather than one per layout it has ever been installed under.
+  def upsert($ev; $sfxs; $new):
     .hooks[$ev] = (
       ((.hooks[$ev] // [])
-        | map(.hooks = ((.hooks // []) | map(select((.command // "") | endswith($sfx) | not))))
+        | map(.hooks = ((.hooks // []) | map(
+            . as $h | select($sfxs | any(. as $s | ($h.command // "") | endswith($s)) | not))))
         | map(select((.hooks // []) | length > 0)))
       + [$new]
     );
@@ -75,13 +97,17 @@ merged=$(printf '%s' "$base" | jq \
     .hooks[$ev] = (((.hooks[$ev] // []) | map(select(. != $new))) + [$new]);
 
   ( .hooks //= {} )
-  | upsert("SessionStart"; "/.claude/scripts/jj-session-start.sh";
+  | upsert("SessionStart";
+      ["/.claude/hooks/jj-session-start.sh", "/.claude/scripts/jj-session-start.sh"];
       {matcher:"startup|resume|clear|compact", hooks:[{type:"command", command:$ss, async:false}]})
-  | upsert("PreToolUse"; "/.claude/scripts/require-jj-new.sh";
+  | upsert("PreToolUse";
+      ["/.claude/hooks/require-jj-new.sh", "/.claude/scripts/require-jj-new.sh"];
       {matcher:"Edit|Write|NotebookEdit", hooks:[{type:"command", command:$rjn}]})
-  | upsert("WorktreeCreate"; "/.claude/scripts/jj-workspace-create.sh";
+  | upsert("WorktreeCreate";
+      ["/.claude/hooks/jj-workspace-create.sh", "/.claude/scripts/jj-workspace-create.sh"];
       {hooks:[{type:"command", command:$wsc}]})
-  | upsert("WorktreeRemove"; "/.claude/scripts/jj-workspace-remove.sh";
+  | upsert("WorktreeRemove";
+      ["/.claude/hooks/jj-workspace-remove.sh", "/.claude/scripts/jj-workspace-remove.sh"];
       {hooks:[{type:"command", command:$wsr}]})
   | upsert_value("PreCompact";
       {hooks:[{type:"command", command:"jj status >/dev/null 2>&1 || true"}]})
@@ -101,7 +127,35 @@ mkdir -p "$CLAUDE_DIR"
 printf '%s\n' "$merged" > "$SETTINGS"
 echo "settings=$settings_outcome"
 
-# --- 3. CLAUDE.md (4-case hash logic) ---
+# --- 3. legacy cleanup: retire .claude/scripts/ ---
+# Runs AFTER the settings write, deliberately. Until settings point at the new
+# location, the old files are still the live handlers; deleting them first would
+# leave a window where the registered command names a file that no longer exists.
+#
+# Only the four files this installer owns are removed, by name. `.claude/scripts/`
+# is NOT ours exclusively — /statusline-jj-setup installs statusline-jj.sh there,
+# and users may keep their own scripts alongside. A blanket `rm -rf` would delete
+# a file installed by a different command, silently breaking a statusline the
+# person never asked this command to touch.
+#
+# The directory itself goes only when it is empty, and `rmdir` is what enforces
+# that: it refuses on a non-empty directory, so the emptiness check and the
+# removal are the same atomic operation. A test-then-remove would race, and a
+# `-rf` would not check at all.
+legacy_outcome="absent"
+if [ -d "$LEGACY_DST" ]; then
+  for s in $MANAGED_SCRIPTS; do
+    rm -f "$LEGACY_DST/$s"
+  done
+  if rmdir "$LEGACY_DST" 2>/dev/null; then
+    legacy_outcome="removed"
+  else
+    legacy_outcome="kept_not_empty"
+  fi
+fi
+echo "legacy_scripts=$legacy_outcome"
+
+# --- 4. CLAUDE.md (4-case hash logic) ---
 md5hash() { if command -v md5 >/dev/null 2>&1; then md5 -q; else md5sum; fi | cut -c1-8; }
 tmpl_hash=$(sed -n '/jj-project-setup:start/,/jj-project-setup:end/p' "$TEMPLATE" | sed '1d;$d' | md5hash)
 

--- a/plugins/project-setup-jj/tests/test-project-setup-install.sh
+++ b/plugins/project-setup-jj/tests/test-project-setup-install.sh
@@ -39,7 +39,7 @@ newproj() { mktemp -d; }   # fresh project root per case
 P=$(newproj)
 OUT=$(bash "$INSTALL" "$PLUG" "$P")
 for s in jj-session-start.sh require-jj-new.sh jj-workspace-create.sh jj-workspace-remove.sh; do
-  [ -x "$P/.claude/scripts/$s" ] && ok "fresh: $s copied +x" || bad "fresh" "$s not executable/copied"
+  [ -x "$P/.claude/hooks/$s" ] && ok "fresh: $s copied +x" || bad "fresh" "$s not executable/copied"
 done
 jq empty "$P/.claude/settings.local.json" 2>/dev/null && ok "fresh: settings valid JSON" || bad "fresh" "settings not valid JSON"
 for ev in SessionStart PreCompact PreToolUse WorktreeCreate WorktreeRemove; do
@@ -53,8 +53,11 @@ done
 allcmds=$(jq -r '[.hooks[][].hooks[].command] | .[]' "$P/.claude/settings.local.json")
 n_abs=$(printf '%s\n' "$allcmds" | grep -c '^/' || true)
 [ "$n_abs" -eq 0 ] && ok "fresh: no absolute hook paths" || bad "fresh" "$n_abs hook command(s) absolute: $allcmds"
-n_portable=$(printf '%s\n' "$allcmds" | grep -c '^\$CLAUDE_PROJECT_DIR/\.claude/scripts/' || true)
-[ "$n_portable" -eq 4 ] && ok "fresh: 4 hook paths use \$CLAUDE_PROJECT_DIR" || bad "fresh" "expected 4 portable hook paths, got $n_portable"
+n_portable=$(printf '%s\n' "$allcmds" | grep -c '^\$CLAUDE_PROJECT_DIR/\.claude/hooks/' || true)
+[ "$n_portable" -eq 4 ] && ok "fresh: 4 hook paths use \$CLAUDE_PROJECT_DIR/.claude/hooks" || bad "fresh" "expected 4 portable hook paths under .claude/hooks, got $n_portable"
+# Nothing may still point at the legacy .claude/scripts/ location.
+n_legacy=$(printf '%s\n' "$allcmds" | grep -c '/\.claude/scripts/' || true)
+[ "$n_legacy" -eq 0 ] && ok "fresh: no hook path points at legacy .claude/scripts/" || bad "fresh" "$n_legacy legacy hook path(s) remain"
 [ "$(jq '.permissions.allow | index("Bash(gh *)") != null' "$P/.claude/settings.local.json")" = true ] && ok "fresh: allow has gh" || bad "fresh" "allow missing gh"
 [ "$(jq '.permissions.deny | index("Bash(git *)") != null' "$P/.claude/settings.local.json")" = true ] && ok "fresh: deny has git" || bad "fresh" "deny missing git"
 [ -f "$P/CLAUDE.md" ] && grep -q 'jj-project-setup:start' "$P/CLAUDE.md" && ok "fresh: CLAUDE.md created w/ marker" || bad "fresh" "CLAUDE.md missing marker"
@@ -75,15 +78,17 @@ JSON
 bash "$INSTALL" "$PLUG" "$P" >/dev/null
 [ "$(jq '[.hooks.SessionStart[].hooks[].command] | index("/opt/mine/other.sh") != null' "$P/.claude/settings.local.json")" = true ] && ok "preserve: unrelated hook survives" || bad "preserve" "unrelated hook dropped"
 [ "$(jq '.permissions.allow | index("Bash(mytool:*)") != null' "$P/.claude/settings.local.json")" = true ] && ok "preserve: unrelated permission survives" || bad "preserve" "unrelated permission dropped"
-[ "$(jq '[.hooks.SessionStart[].hooks[].command] | map(select(endswith("/.claude/scripts/jj-session-start.sh"))) | length' "$P/.claude/settings.local.json")" = 1 ] && ok "preserve: our SessionStart added exactly once" || bad "preserve" "our hook count != 1"
+[ "$(jq '[.hooks.SessionStart[].hooks[].command] | map(select(endswith("jj-session-start.sh"))) | length' "$P/.claude/settings.local.json")" = 1 ] && ok "preserve: our SessionStart added exactly once" || bad "preserve" "our hook count != 1"
 
 # ---- Case 4: stale-version managed hook replaced, not duplicated ----
+# The seeded command uses the LEGACY .claude/scripts/ path, so this case doubles
+# as the narrowest migration proof: identity must be recognised across the move.
 P=$(newproj); mkdir -p "$P/.claude"
 cat > "$P/.claude/settings.local.json" <<JSON
 {"hooks":{"SessionStart":[{"matcher":"OLD","hooks":[{"type":"command","command":"$P/.claude/scripts/jj-session-start.sh"}]}]}}
 JSON
 bash "$INSTALL" "$PLUG" "$P" >/dev/null
-[ "$(jq '[.hooks.SessionStart[].hooks[].command] | map(select(endswith("/.claude/scripts/jj-session-start.sh"))) | length' "$P/.claude/settings.local.json")" = 1 ] && ok "stale: exactly one of our SessionStart" || bad "stale" "duplicate/zero after upgrade"
+[ "$(jq '[.hooks.SessionStart[].hooks[].command] | map(select(endswith("jj-session-start.sh"))) | length' "$P/.claude/settings.local.json")" = 1 ] && ok "stale: exactly one of our SessionStart" || bad "stale" "duplicate/zero after upgrade"
 [ "$(jq '[.hooks.SessionStart[] | select(.matcher=="OLD")] | length' "$P/.claude/settings.local.json")" = 0 ] && ok "stale: OLD matcher gone" || bad "stale" "OLD entry survived"
 
 # ---- Case 5: CLAUDE.md variants ----
@@ -168,7 +173,7 @@ printf '{not json' > "$P/.claude/settings.local.json"
 RAW_BEFORE=$(cat "$P/.claude/settings.local.json")
 if bash "$INSTALL" "$PLUG" "$P" >/dev/null 2>&1; then bad "malformed" "exited 0 on invalid JSON"; else ok "malformed: non-zero exit"; fi
 [ "$(cat "$P/.claude/settings.local.json")" = "$RAW_BEFORE" ] && ok "malformed: file untouched" || bad "malformed" "file was clobbered"
-[ ! -d "$P/.claude/scripts" ] && ok "malformed: no side effects (scripts/ not created)" || bad "malformed" ".claude/scripts created before abort"
+[ ! -d "$P/.claude/hooks" ] && ok "malformed: no side effects (hooks/ not created)" || bad "malformed" ".claude/hooks created before abort"
 
 # ---- Case 7: user hook co-located in same entry survives (hook granularity) ----
 P=$(newproj); mkdir -p "$P/.claude"
@@ -177,7 +182,96 @@ cat > "$P/.claude/settings.local.json" <<JSON
 JSON
 bash "$INSTALL" "$PLUG" "$P" >/dev/null
 [ "$(jq '[.hooks.SessionStart[].hooks[].command] | index("/opt/mine/user.sh") != null' "$P/.claude/settings.local.json")" = true ] && ok "colocated: user hook survives" || bad "colocated" "user hook dropped (entry-granularity bug)"
-[ "$(jq '[.hooks.SessionStart[].hooks[].command] | map(select(endswith("/.claude/scripts/jj-session-start.sh"))) | length' "$P/.claude/settings.local.json")" = 1 ] && ok "colocated: our hook present once" || bad "colocated" "our hook count != 1"
+[ "$(jq '[.hooks.SessionStart[].hooks[].command] | map(select(endswith("jj-session-start.sh"))) | length' "$P/.claude/settings.local.json")" = 1 ] && ok "colocated: our hook present once" || bad "colocated" "our hook count != 1"
+
+# ---- Case 8: a project on the OLD .claude/scripts/ layout migrates ----
+# Project hook handlers belong in .claude/hooks/ — the directory every example in
+# the hooks docs uses. The migration's whole risk is DUPLICATION: upsert strips a
+# managed hook by matching its command suffix, so if it only knew the new
+# .claude/hooks/ suffix the pre-existing .claude/scripts/ registration would
+# survive untouched and the fresh one would be appended beside it. The project
+# would then carry TWO registrations per event and BOTH would fire — the session
+# banner printed twice, require-jj-new evaluated twice, the workspace hooks
+# creating and removing a workspace twice. Hence every count assertion below
+# matches on BASENAME, not on the new path: matching the new path alone would
+# score a duplicate as a pass, which is the exact defect being guarded.
+oldlayout() {   # oldlayout <project> — seed a project as the previous installer left it
+  local p="$1"
+  mkdir -p "$p/.claude/scripts"
+  for s in jj-session-start.sh require-jj-new.sh jj-workspace-create.sh jj-workspace-remove.sh; do
+    printf '#!/usr/bin/env bash\n# OLD %s\n' "$s" > "$p/.claude/scripts/$s"
+    chmod +x "$p/.claude/scripts/$s"
+  done
+  cat > "$p/.claude/settings.local.json" <<JSON
+{"hooks":{
+  "SessionStart":[{"matcher":"startup|resume|clear|compact","hooks":[{"type":"command","command":"\$CLAUDE_PROJECT_DIR/.claude/scripts/jj-session-start.sh","async":false}]}],
+  "PreToolUse":[{"matcher":"Edit|Write|NotebookEdit","hooks":[{"type":"command","command":"\$CLAUDE_PROJECT_DIR/.claude/scripts/require-jj-new.sh"}]}],
+  "WorktreeCreate":[{"hooks":[{"type":"command","command":"\$CLAUDE_PROJECT_DIR/.claude/scripts/jj-workspace-create.sh"}]}],
+  "WorktreeRemove":[{"hooks":[{"type":"command","command":"\$CLAUDE_PROJECT_DIR/.claude/scripts/jj-workspace-remove.sh"}]}]
+}}
+JSON
+}
+
+P=$(newproj); oldlayout "$P"
+bash "$INSTALL" "$PLUG" "$P" >/dev/null
+# 8a scripts land in the new home
+for s in jj-session-start.sh require-jj-new.sh jj-workspace-create.sh jj-workspace-remove.sh; do
+  [ -x "$P/.claude/hooks/$s" ] && ok "migrate: $s now in .claude/hooks/ +x" || bad "migrate" "$s not in .claude/hooks/"
+done
+# 8b settings point at the new home, and nothing points at the old one
+mig_cmds=$(jq -r '[.hooks[][].hooks[].command] | .[]' "$P/.claude/settings.local.json")
+m_new=$(printf '%s\n' "$mig_cmds" | grep -c '^\$CLAUDE_PROJECT_DIR/\.claude/hooks/' || true)
+[ "$m_new" -eq 4 ] && ok "migrate: 4 hook commands point at .claude/hooks/" || bad "migrate" "expected 4 new-path commands, got $m_new"
+m_old=$(printf '%s\n' "$mig_cmds" | grep -c '/\.claude/scripts/' || true)
+[ "$m_old" -eq 0 ] && ok "migrate: zero commands still point at .claude/scripts/" || bad "migrate" "$m_old stale command(s) still registered"
+# 8c exactly ONE registration per hook — the duplicate-registration guard
+for pair in "SessionStart:jj-session-start.sh" "PreToolUse:require-jj-new.sh" \
+            "WorktreeCreate:jj-workspace-create.sh" "WorktreeRemove:jj-workspace-remove.sh"; do
+  ev="${pair%%:*}"; base="${pair##*:}"
+  n=$(jq --arg e "$ev" --arg b "$base" '[.hooks[$e][].hooks[].command] | map(select(endswith($b))) | length' "$P/.claude/settings.local.json")
+  [ "$n" = 1 ] && ok "migrate: exactly one $ev registration for $base" || bad "migrate" "$ev has $n registrations of $base (want 1 — both would fire)"
+done
+# 8d the four old files are gone
+leftover=0
+for s in jj-session-start.sh require-jj-new.sh jj-workspace-create.sh jj-workspace-remove.sh; do
+  [ -e "$P/.claude/scripts/$s" ] && leftover=$((leftover+1))
+done
+[ "$leftover" -eq 0 ] && ok "migrate: all four legacy scripts removed from .claude/scripts/" || bad "migrate" "$leftover legacy script(s) left behind"
+# 8e the legacy directory itself is gone once nothing else remains
+[ ! -d "$P/.claude/scripts" ] && ok "migrate: empty .claude/scripts/ removed" || bad "migrate" ".claude/scripts/ survived while empty"
+
+# ---- Case 9: a statusline installed by a DIFFERENT command must survive ----
+# .claude/scripts/ is not ours alone: /statusline-jj-setup puts statusline-jj.sh
+# there. A blanket `rm -rf .claude/scripts` during migration would silently break
+# that user's statusline — a command they never ran deleting a file it does not
+# own. The directory may only go when it is empty of everything else.
+P=$(newproj); oldlayout "$P"
+printf '#!/usr/bin/env bash\necho statusline\n' > "$P/.claude/scripts/statusline-jj.sh"
+chmod +x "$P/.claude/scripts/statusline-jj.sh"
+bash "$INSTALL" "$PLUG" "$P" >/dev/null
+[ -f "$P/.claude/scripts/statusline-jj.sh" ] && ok "coexist: statusline-jj.sh survives migration" || bad "coexist" "statusline-jj.sh was DELETED by /project-setup"
+[ -x "$P/.claude/scripts/statusline-jj.sh" ] && ok "coexist: statusline-jj.sh still executable" || bad "coexist" "statusline lost +x"
+[ -d "$P/.claude/scripts" ] && ok "coexist: .claude/scripts/ kept (not empty)" || bad "coexist" ".claude/scripts/ removed while statusline lived there"
+s_left=0
+for s in jj-session-start.sh require-jj-new.sh jj-workspace-create.sh jj-workspace-remove.sh; do
+  [ -e "$P/.claude/scripts/$s" ] && s_left=$((s_left+1))
+done
+[ "$s_left" -eq 0 ] && ok "coexist: our four legacy scripts still removed" || bad "coexist" "$s_left legacy script(s) left behind"
+[ -x "$P/.claude/hooks/jj-session-start.sh" ] && ok "coexist: hooks still installed to .claude/hooks/" || bad "coexist" "hooks not installed"
+
+# ---- Case 10: re-running after migration is idempotent ----
+P=$(newproj); oldlayout "$P"
+bash "$INSTALL" "$PLUG" "$P" >/dev/null
+MIG_BEFORE=$(cat "$P/.claude/settings.local.json")
+bash "$INSTALL" "$PLUG" "$P" >/dev/null
+[ "$(cat "$P/.claude/settings.local.json")" = "$MIG_BEFORE" ] && ok "migrate-rerun: settings byte-identical" || bad "migrate-rerun" "settings churned on re-run after migration"
+for pair in "SessionStart:jj-session-start.sh" "PreToolUse:require-jj-new.sh" \
+            "WorktreeCreate:jj-workspace-create.sh" "WorktreeRemove:jj-workspace-remove.sh"; do
+  ev="${pair%%:*}"; base="${pair##*:}"
+  n=$(jq --arg e "$ev" --arg b "$base" '[.hooks[$e][].hooks[].command] | map(select(endswith($b))) | length' "$P/.claude/settings.local.json")
+  [ "$n" = 1 ] && ok "migrate-rerun: $ev still has exactly one $base" || bad "migrate-rerun" "$ev grew to $n registrations of $base"
+done
+[ ! -d "$P/.claude/scripts" ] && ok "migrate-rerun: legacy dir stays gone" || bad "migrate-rerun" ".claude/scripts/ reappeared"
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="


### PR DESCRIPTION
## Summary

Two changes aligning with Claude Code's documented hook conventions. Prompted by noticing a fork had moved `.claude/scripts/` → `.claude/hooks/`; on checking the docs, the fork was right and this repo was the outlier.

### A. Quote `${CLAUDE_PLUGIN_ROOT}` in hook commands

All 7 hook commands across 4 manifests were bare paths:

```
${CLAUDE_PLUGIN_ROOT}/scripts/block-raw-git.sh
```

A plugin root containing a space word-splits, and the hook never launches. **This was verified as a live hole, not a theoretical one** — the 2.1.220 bundle runs shell-form hooks via `bash -c`, and reproducing an unquoted command under a spacey root gives **exit 127: the hook never starts and raw git sails straight through**. For `block-raw-git.sh` that means the wall silently stops existing.

Now `bash "${CLAUDE_PLUGIN_ROOT}/scripts/..."`, matching the form used by 10/10 official hook commands.

New lint `.github/tests/test-plugin-hook-commands.sh` (8 assertions) sweeps every `plugins/*/.claude-plugin/plugin.json` and any `plugins/*/hooks/hooks.json`, and fails loudly if it discovers zero hook commands so it cannot quietly stop checking (#82's shape).

### B. Install project hooks to `.claude/hooks/`

Every example in the [hooks reference](https://code.claude.com/docs/en/hooks) and [hooks guide](https://code.claude.com/docs/en/hooks-guide) uses `.claude/hooks/`; neither ever uses `.claude/scripts/`. Hooks are not auto-discovered — the directory is convention, not mechanism — but it is the convention every reader arrives with.

**Plugin-internal `scripts/` is deliberately unchanged.** The plugins-reference example puts handlers at `"${CLAUDE_PLUGIN_ROOT}"/scripts/format-code.sh`, so that layout was already idiomatic. Only the *project-side* destination moves.

Migration is the substance. `upsert` strips hooks whose command `endswith($sfx)` before appending; it now strips a **list** of suffixes (old `.claude/scripts/...` and new `.claude/hooks/...`), so one run replaces an old registration instead of adding a duplicate beside it. Without that widening, existing projects end up with two registrations per hook and **both fire**.

Filesystem cleanup removes only the four scripts the installer owns, then `rmdir`s — which refuses a non-empty directory, so `statusline-jj.sh` survives atomically. The statusline moves too, and `/statusline-jj-remove` now deletes from both old and new paths so anyone on the old layout can still uninstall.

Also fixed: the root README described a `/workspace-setup` command that does not exist (three separate references). The worktree hooks are installed by `project-setup-install.sh`.

## Test plan

- [x] Full repo suite — **17 suites, 414 assertions, `0 suite(s) failed`, exit 0**
- [x] `test-project-setup-install.sh` 36 → **60**; new hook-command lint **8**
- [x] Change A lint confirmed **RED** first: `1 passed, 7 failed`
- [x] Change B confirmed RED against the unmigrated installer: `43 passed, 17 failed`
- [x] Version-bump lint exit 0 against a `trunk()`-materialised base tree, and ablated (unbumped → exit 1)
- [x] `/bin/bash -n` clean; bash 3.2-safe
- [x] Independent end-to-end migration harness, 8/8 — old-layout project migrates, statusline survives, old handlers removed, exactly one registration, points at `hooks/`, no stale `scripts/` entry, idempotent on re-run, empty `scripts/` removed

### A note on controls

The unmigrated installer is the **wrong** control for the duplicate-registration and statusline assertions — both pass against it, so "RED against old" would have proved nothing there. Those two were instead ablated against realistic *wrong implementations*: a naive migration that does not widen the strip list (→ `2 registrations… both would fire`) and a blanket `rm -rf` of the directory (→ `statusline-jj.sh was DELETED`).

## Upgrade note

Existing projects migrate automatically on the next `/project-setup` — handlers move, the old registration is replaced rather than duplicated, and `.claude/scripts/` is removed unless a statusline still lives there. No manual step.

## Known, not fixed

`plugins/project-setup-jj/README.md` ends with a hand-written `Version 1.0.0` that disagrees with `plugin.json` 0.7.0. Three plugin READMEs carry this; no lint covers it. Left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
