### PR TITLE
fix(hooks): close three raw-git bypass shapes in block-raw-git.sh (#105)

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -27,7 +27,7 @@ Optional directories: `agents/`, `templates/`.
 
 Three layers prevent raw git usage:
 
-1. **PreToolUse hook** — Every plugin that exposes Bash registers `scripts/block-raw-git.sh` as a `PreToolUse` hook on `Bash` in its `plugin.json`. The script allows `jj git *`, `gh *`, and all non-git commands; blocks bare `git *`.
+1. **PreToolUse hook** — Every plugin that exposes Bash registers `scripts/block-raw-git.sh` as a `PreToolUse` hook on `Bash` in its `plugin.json`. It blocks `git` at any position where the shell would start a command — compound clauses (#101) plus substitution, grouping and keyword/assignment prefixes (#105) — and never denies a clause beginning `jj git …`. It matches text rather than parsing the shell, so it both under- and over-catches at the edges. Do not restate the boundary here: the authoritative list is the comment block in the script itself, which is byte-identical across the three plugins and pinned by assertions in `project-setup-jj/tests/test-block-raw-git.sh`.
 
 2. **CRITICAL warning block** — Every command and agent `.md` file begins (after YAML frontmatter) with a bold paragraph:
 

--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/README.md
+++ b/plugins/commit-commands-jj/README.md
@@ -10,6 +10,10 @@ The Commit Commands Plugin for jj automates common Jujutsu operations, reducing 
 
 The plugin itself (independent of any specific command above) also registers a `PreToolUse` hook on all `Bash` calls that blocks raw `git` commands, backed by `scripts/block-raw-git.sh`. This is active as soon as the plugin is enabled.
 
+**Scope of the hook.** It denies `git` where the shell would start a command: on its own, after `;` `&&` `||` `|` or a newline, inside `$(…)` or `<(…)`, inside `(…)` or `{ …; }`, and after a keyword, wrapper or `VAR=value` prefix. A clause beginning `jj git …` is never denied — `/commit-push-pr` and `/finish` rely on that.
+
+It matches text rather than parsing the shell, so some shapes are out of scope (backtick substitution, `bash -c 'git …'`, wrappers with their own options, `/usr/bin/git`), and because it is quote-blind it can over-catch: a git command named right after a separator *inside* a quoted message still reads as command position. Full scope note in the [project-setup-jj README](../project-setup-jj/README.md#overview); the authoritative list is the comment block in `scripts/block-raw-git.sh`, byte-identical across all three plugins.
+
 ## Setup
 
 ### Colocated repos (`.jj/` + `.git/`)

--- a/plugins/commit-commands-jj/scripts/block-raw-git.sh
+++ b/plugins/commit-commands-jj/scripts/block-raw-git.sh
@@ -57,9 +57,70 @@ command_normalized=$(echo "$command" | tr '\n' ';')
 # inside quotes still starts a clause, and prose mentioning a git command
 # mid-clause (`jj describe -m 'replaces git status'`) is still not at command
 # position and still passes. bash 3.2-safe: no globstar, no associative arrays.
+#
+# #105 widened "command position" beyond `; & |`. Three shapes reached a real
+# git invocation without one of those characters immediately before it, and 20
+# of 21 measured cases were ALLOWED:
+#
+#   1. Substitution — `$(git …)`, `<(git …)`. The sed pass rewrites each opening
+#      sigil to `;` so the substituted command starts a clause.
+#   2. Grouping — `(git …)`, `{ git …; }`. A subshell or brace group can only
+#      open where a command may start, i.e. at the head of a clause, so this is
+#      a strippable clause prefix rather than a separator.
+#   3. Prefix words — a keyword (`if`, `then`, `do`, `!`, …), a zero-argument
+#      wrapper (`env`, `time`, `nice`, …), or an environment assignment before
+#      the command. Stripped by the `(…)*` repetition, so they stack:
+#      `then GIT_X=1 git reset` is caught by one pass.
+#
+# The jj-git exemption stays structural and survives all of this: strip the
+# prefixes off `( JJ_USER=ci jj git push )` and the clause still starts with
+# `jj`, so it can never match a command-position `git`.
+#
+# WHERE THE LINE IS, and why it is here. This matcher is quote-blind, so every
+# character it treats as a boundary also fires inside a quoted string. Two
+# rules in the first cut of this fix were withdrawn after review for exactly
+# that reason, having been shipped past a must-allow corpus written by the same
+# pass that wrote them:
+#
+#   - Rewriting every backtick to a separator denied `git` in a markdown code
+#     span. Opening and closing backticks are indistinguishable without pairing
+#     and pairing is impossible quote-blind, so this cannot be narrowed — it is
+#     the whole rule or none of it. None of it: /finish and /commit-push-pr both
+#     instruct writing a PR body inline, and a body naming a git command in
+#     backticks could not be submitted.
+#   - Rewriting every `) ` to a separator denied parenthesised prose followed by
+#     the word git (`-m 'per (#101) git is blocked'`). It bought only the
+#     case-statement pattern `a) git status`, the rarest shape in the set.
+#
+# The assignment prefix keeps quoted values whole for the same reason: stopping
+# at the first space left `git ` at the head of `MSG="a git b" jj describe`.
+# The unquoted alternative excludes quote characters so it cannot win by
+# matching a shorter prefix — grep needs only SOME alternative to match, so a
+# permissive branch defeats a stricter one sitting beside it.
+#
+# Known-open, documented in the READMEs and pinned by pass-through assertions
+# in test-block-raw-git.sh: backtick substitution, case patterns, an
+# interpreter handed git as data (`bash -c 'git status'`), wrappers carrying
+# their own options (`eval "git …"`, `sudo -u me git`, `timeout 5 git`), and
+# spellings other than the bare word (`/usr/bin/git`, `\git`). All need
+# argument parsing or quote tracking, i.e. a shell parser. The wall is a
+# guardrail against habit, not a sandbox — anyone who wants git can disable the
+# plugin. Reaching further with a regex is what produced the false positives.
+sq="'"
+dq='"'
+# VAR=value, VAR="value with spaces", VAR='…', and concatenations of those
+# (VAR="a"b is one word to the shell). The value is a SEQUENCE of runs, not a
+# choice between them: a single alternation stops after the first run and then
+# demands whitespace, so VAR="a"b git status slipped through.
+assign_re="[A-Za-z_][A-Za-z0-9_]*=(${dq}[^${dq}]*${dq}|${sq}[^${sq}]*${sq}|[^[:space:]${dq}${sq}])*"
+wrappers_re='if|then|elif|else|do|while|until|!|time|command|exec|env|eval|nohup|nice|sudo|xargs'
+prefix_re="(([({][[:space:]]*)|((${assign_re}|${wrappers_re})[[:space:]]+))*"
+
 has_raw_git=false
-if printf '%s\n' "$command_normalized" | tr ';&|' '\n\n\n' \
-   | grep -qE '^[[:space:]]*git[[:space:]]'; then
+if printf '%s\n' "$command_normalized" \
+   | sed -E -e 's/\$\(/;/g' -e 's/[<>]\(/;/g' \
+   | tr ';&|' '\n\n\n' \
+   | grep -qE "^[[:space:]]*${prefix_re}git[[:space:]]"; then
   has_raw_git=true
 fi
 

--- a/plugins/commit-commands-jj/tests/test-block-raw-git-gating.sh
+++ b/plugins/commit-commands-jj/tests/test-block-raw-git-gating.sh
@@ -5,27 +5,47 @@ PASS=0; FAIL=0
 ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
 
+# Payloads are built with `jq --arg`, never printf interpolation. A command
+# containing a double quote cannot be interpolated into JSON: the payload is
+# malformed, the hook's `jq -r` yields an empty command, and the case then
+# passes because there was nothing to block — which for an "allows …" assertion
+# is indistinguishable from success. project-setup-jj's suite was migrated for
+# this reason; leaving this one on printf would have reintroduced the hazard the
+# moment a case like `eval "git reset --hard origin/main"` was added below.
+payload() { jq -nc --arg c "$1" --arg d "$JJ_DIR" '{cwd:$d, tool_input:{command:$c}}'; }
+
 # Inside a jj repo: raw git is denied.
 JJ_DIR=$(mktemp -d); mkdir -p "$JJ_DIR/.jj"
-out=$(printf '{"cwd":"%s","tool_input":{"command":"git status"}}' "$JJ_DIR" | /bin/bash "$HOOK")
+out=$(payload 'git status' | /bin/bash "$HOOK")
 if printf '%s' "$out" | grep -q '"permissionDecision": *"deny"'; then
   ok "denies raw git inside a jj repo"
 else
   bad "denies raw git inside a jj repo (got: $out)"
 fi
 
-# #101: the `jj git …` exemption used to be evaluated over the whole command
-# string, so one jj-git token anywhere exempted every other clause and
-# `jj git fetch && git reset --hard origin/main` came back ALLOWED. These run
-# against THIS plugin's copy of the hook — the drift-guard in project-setup-jj
-# proves byte-identity, this proves the shipped bytes behave.
+# These run against THIS plugin's copy of the hook. The drift guard in
+# project-setup-jj proves the three copies are byte-identical; only this proves
+# the shipped bytes behave, which byte-identity alone would not — a sha256 guard
+# is equally satisfied by three stale copies.
+#
+# Entries 1-4 are #101: the `jj git …` exemption used to be evaluated over the
+# whole command string, so one jj-git token anywhere exempted every other clause
+# and `jj git fetch && git reset --hard origin/main` came back ALLOWED.
+#
+# Entries 5-7 are #105: one representative per family of commands that put git
+# at a real command position without a `; & |` before it. The full corpus lives
+# in project-setup-jj's suite against the canonical copy.
 for denied in \
   'jj git fetch && git reset --hard origin/main' \
   'git status; jj git fetch' \
   'jj git fetch;git status' \
-  'jj git fetch\ngit reset --hard origin/main'
+  $'jj git fetch\ngit reset --hard origin/main' \
+  'echo $(git status)' \
+  '(git status)' \
+  'if git diff --quiet; then echo clean; fi' \
+  'git commit -m "wip"'
 do
-  out=$(printf '{"cwd":"%s","tool_input":{"command":"%s"}}' "$JJ_DIR" "$denied" | /bin/bash "$HOOK")
+  out=$(payload "$denied" | /bin/bash "$HOOK")
   if printf '%s' "$out" | grep -q '"permissionDecision": *"deny"'; then
     ok "denies raw git in a compound command: $denied"
   else
@@ -40,7 +60,7 @@ done
 # `.git/` path access reaches here. Anchor on the internals message itself:
 # asserting merely "something was denied" would pass against the raw-git branch
 # and prove nothing, which is the entire point of this assertion.
-out=$(printf '{"cwd":"%s","tool_input":{"command":"cat .git/HEAD"}}' "$JJ_DIR" | /bin/bash "$HOOK")
+out=$(payload 'cat .git/HEAD' | /bin/bash "$HOOK")
 if printf '%s' "$out" | grep -q 'BLOCKED: Git internals'; then
   ok "denies .git/ access via the internals branch"
 else
@@ -51,7 +71,7 @@ fi
 # dir — the dev checkout is itself a jj repo, so a relative cwd would walk up
 # into the real .jj and invert this test.
 PLAIN=$(mktemp -d)
-out=$(printf '{"cwd":"%s","tool_input":{"command":"git status"}}' "$PLAIN" | /bin/bash "$HOOK")
+out=$(jq -nc --arg d "$PLAIN" '{cwd:$d, tool_input:{command:"git status"}}' | /bin/bash "$HOOK")
 if [ -z "$out" ]; then
   ok "passes git through outside a jj repo (#45)"
 else
@@ -66,15 +86,29 @@ fi
 # pure stdin/stdout function, so the assertion belongs here where it is
 # deterministic and free.
 #
-# The trailing three are #101 regression guards rather than fail-first cases:
-# they passed before the per-clause split and must still pass after it. This
-# hook is a hard wall, so a false positive costs as much as a bypass —
+# Everything after it is a regression guard rather than a fail-first case: each
+# passed before the change that prompted it and must still pass after. This hook
+# is a hard wall, so a false positive costs as much as a bypass —
 # /commit-push-pr and /finish both instruct `jj git push` in their own prose.
+#
+# Entries 3-5 are #101. Entries 6-11 are #105: widening what counts as a command
+# position made `(`, `)`, backticks and `=` significant, and every one of them is
+# ordinary punctuation in jj revsets and in this repo's own prose. The last four
+# are the shapes that a first cut of #105 actually regressed — a PR body or
+# description naming a git command in backticks, or after a parenthetical, and a
+# quoted assignment value. They are here because /finish and /commit-push-pr, in
+# THIS plugin, are the commands that write such text.
 for allowed in "jj git remote list" "gh pr list" \
                "jj git push --bookmark feature-x" \
                "jj git fetch && jj rebase -d main" \
-               "echo 'git status'"; do
-  out=$(printf '{"cwd":"%s","tool_input":{"command":"%s"}}' "$JJ_DIR" "$allowed" | /bin/bash "$HOOK")
+               "echo 'git status'" \
+               "( jj git push )" \
+               "jj log -r 'trunk()..@'" \
+               "jj describe -m 'switch from (git status) to jj status'" \
+               'gh pr create --body '"'"'stop using `git log` here'"'"'' \
+               "jj describe -m 'per (#101) git is blocked'" \
+               'MSG="a git b" jj describe -m x'; do
+  out=$(payload "$allowed" | /bin/bash "$HOOK")
   if [ -z "$out" ]; then
     ok "allows '$allowed' inside a jj repo (lookahead)"
   else

--- a/plugins/peer-review-jj/.claude-plugin/plugin.json
+++ b/plugins/peer-review-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "peer-review-jj",
   "description": "Unified change review for jj repos — generalist-first with emergent specialists, two-phase pipeline, structured findings",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/peer-review-jj/README.md
+++ b/plugins/peer-review-jj/README.md
@@ -29,7 +29,7 @@ Generalists scale with change size (1 per ~300 lines). Specialists emerge from r
 - `skills/requesting-change-review/SKILL.md` — phase 1: dispatch
 - `skills/receiving-change-review/SKILL.md` — phase 2: aggregation
 - `agents/change-reviewer.md` — generalist reviewer agent
-- `scripts/block-raw-git.sh` — hook: prevent raw git commands
+- `scripts/block-raw-git.sh` — hook: deny `git` at any shell command position (see the scope note in [project-setup-jj](../project-setup-jj/README.md); the three copies are byte-identical)
 - `scripts/block-review-markers.sh` — hook: prevent review markers in commits
 
 ## Replaces

--- a/plugins/peer-review-jj/scripts/block-raw-git.sh
+++ b/plugins/peer-review-jj/scripts/block-raw-git.sh
@@ -57,9 +57,70 @@ command_normalized=$(echo "$command" | tr '\n' ';')
 # inside quotes still starts a clause, and prose mentioning a git command
 # mid-clause (`jj describe -m 'replaces git status'`) is still not at command
 # position and still passes. bash 3.2-safe: no globstar, no associative arrays.
+#
+# #105 widened "command position" beyond `; & |`. Three shapes reached a real
+# git invocation without one of those characters immediately before it, and 20
+# of 21 measured cases were ALLOWED:
+#
+#   1. Substitution — `$(git …)`, `<(git …)`. The sed pass rewrites each opening
+#      sigil to `;` so the substituted command starts a clause.
+#   2. Grouping — `(git …)`, `{ git …; }`. A subshell or brace group can only
+#      open where a command may start, i.e. at the head of a clause, so this is
+#      a strippable clause prefix rather than a separator.
+#   3. Prefix words — a keyword (`if`, `then`, `do`, `!`, …), a zero-argument
+#      wrapper (`env`, `time`, `nice`, …), or an environment assignment before
+#      the command. Stripped by the `(…)*` repetition, so they stack:
+#      `then GIT_X=1 git reset` is caught by one pass.
+#
+# The jj-git exemption stays structural and survives all of this: strip the
+# prefixes off `( JJ_USER=ci jj git push )` and the clause still starts with
+# `jj`, so it can never match a command-position `git`.
+#
+# WHERE THE LINE IS, and why it is here. This matcher is quote-blind, so every
+# character it treats as a boundary also fires inside a quoted string. Two
+# rules in the first cut of this fix were withdrawn after review for exactly
+# that reason, having been shipped past a must-allow corpus written by the same
+# pass that wrote them:
+#
+#   - Rewriting every backtick to a separator denied `git` in a markdown code
+#     span. Opening and closing backticks are indistinguishable without pairing
+#     and pairing is impossible quote-blind, so this cannot be narrowed — it is
+#     the whole rule or none of it. None of it: /finish and /commit-push-pr both
+#     instruct writing a PR body inline, and a body naming a git command in
+#     backticks could not be submitted.
+#   - Rewriting every `) ` to a separator denied parenthesised prose followed by
+#     the word git (`-m 'per (#101) git is blocked'`). It bought only the
+#     case-statement pattern `a) git status`, the rarest shape in the set.
+#
+# The assignment prefix keeps quoted values whole for the same reason: stopping
+# at the first space left `git ` at the head of `MSG="a git b" jj describe`.
+# The unquoted alternative excludes quote characters so it cannot win by
+# matching a shorter prefix — grep needs only SOME alternative to match, so a
+# permissive branch defeats a stricter one sitting beside it.
+#
+# Known-open, documented in the READMEs and pinned by pass-through assertions
+# in test-block-raw-git.sh: backtick substitution, case patterns, an
+# interpreter handed git as data (`bash -c 'git status'`), wrappers carrying
+# their own options (`eval "git …"`, `sudo -u me git`, `timeout 5 git`), and
+# spellings other than the bare word (`/usr/bin/git`, `\git`). All need
+# argument parsing or quote tracking, i.e. a shell parser. The wall is a
+# guardrail against habit, not a sandbox — anyone who wants git can disable the
+# plugin. Reaching further with a regex is what produced the false positives.
+sq="'"
+dq='"'
+# VAR=value, VAR="value with spaces", VAR='…', and concatenations of those
+# (VAR="a"b is one word to the shell). The value is a SEQUENCE of runs, not a
+# choice between them: a single alternation stops after the first run and then
+# demands whitespace, so VAR="a"b git status slipped through.
+assign_re="[A-Za-z_][A-Za-z0-9_]*=(${dq}[^${dq}]*${dq}|${sq}[^${sq}]*${sq}|[^[:space:]${dq}${sq}])*"
+wrappers_re='if|then|elif|else|do|while|until|!|time|command|exec|env|eval|nohup|nice|sudo|xargs'
+prefix_re="(([({][[:space:]]*)|((${assign_re}|${wrappers_re})[[:space:]]+))*"
+
 has_raw_git=false
-if printf '%s\n' "$command_normalized" | tr ';&|' '\n\n\n' \
-   | grep -qE '^[[:space:]]*git[[:space:]]'; then
+if printf '%s\n' "$command_normalized" \
+   | sed -E -e 's/\$\(/;/g' -e 's/[<>]\(/;/g' \
+   | tr ';&|' '\n\n\n' \
+   | grep -qE "^[[:space:]]*${prefix_re}git[[:space:]]"; then
   has_raw_git=true
 fi
 

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/README.md
+++ b/plugins/project-setup-jj/README.md
@@ -14,6 +14,15 @@ When starting a new Claude Code project that uses jj, there's no automated way t
 
 The plugin itself (independent of running `/project-setup`) also registers a `PreToolUse` hook on all `Bash` calls that blocks raw `git` commands and git internals access, backed by `scripts/block-raw-git.sh`. This is active as soon as the plugin is enabled.
 
+**Scope of the hook.** It denies `git` where the shell would start a command: on its own, after `;` `&&` `||` `|` or a newline, inside `$(…)` or `<(…)`, inside `(…)` or `{ …; }`, and after a keyword, wrapper or `VAR=value` prefix. A clause beginning `jj git …` is never denied.
+
+It matches text rather than parsing the shell, which cuts both ways.
+
+- **Not caught** (deliberately): backtick substitution, an interpreter handed git as data (`bash -c 'git status'`), wrappers carrying their own options (`eval "git …"`, `sudo -u me git`, `timeout 5 git`), and spellings other than the bare word (`/usr/bin/git`).
+- **Over-caught**: it is quote-blind, so a git command named after a separator *inside* a quoted string still reads as command position — `jj describe -m 'first; git status next'` is denied. Prose that merely mentions git is fine; prose that puts it right after a separator is not.
+
+The authoritative list is the comment block in `scripts/block-raw-git.sh`, which is byte-identical across all three plugins and pinned by pass-through assertions in `project-setup-jj/tests/test-block-raw-git.sh`. It is a guardrail against habit, not a sandbox — anyone who needs git can disable the plugin.
+
 ## Installation
 
 ```bash

--- a/plugins/project-setup-jj/scripts/block-raw-git.sh
+++ b/plugins/project-setup-jj/scripts/block-raw-git.sh
@@ -57,9 +57,70 @@ command_normalized=$(echo "$command" | tr '\n' ';')
 # inside quotes still starts a clause, and prose mentioning a git command
 # mid-clause (`jj describe -m 'replaces git status'`) is still not at command
 # position and still passes. bash 3.2-safe: no globstar, no associative arrays.
+#
+# #105 widened "command position" beyond `; & |`. Three shapes reached a real
+# git invocation without one of those characters immediately before it, and 20
+# of 21 measured cases were ALLOWED:
+#
+#   1. Substitution — `$(git …)`, `<(git …)`. The sed pass rewrites each opening
+#      sigil to `;` so the substituted command starts a clause.
+#   2. Grouping — `(git …)`, `{ git …; }`. A subshell or brace group can only
+#      open where a command may start, i.e. at the head of a clause, so this is
+#      a strippable clause prefix rather than a separator.
+#   3. Prefix words — a keyword (`if`, `then`, `do`, `!`, …), a zero-argument
+#      wrapper (`env`, `time`, `nice`, …), or an environment assignment before
+#      the command. Stripped by the `(…)*` repetition, so they stack:
+#      `then GIT_X=1 git reset` is caught by one pass.
+#
+# The jj-git exemption stays structural and survives all of this: strip the
+# prefixes off `( JJ_USER=ci jj git push )` and the clause still starts with
+# `jj`, so it can never match a command-position `git`.
+#
+# WHERE THE LINE IS, and why it is here. This matcher is quote-blind, so every
+# character it treats as a boundary also fires inside a quoted string. Two
+# rules in the first cut of this fix were withdrawn after review for exactly
+# that reason, having been shipped past a must-allow corpus written by the same
+# pass that wrote them:
+#
+#   - Rewriting every backtick to a separator denied `git` in a markdown code
+#     span. Opening and closing backticks are indistinguishable without pairing
+#     and pairing is impossible quote-blind, so this cannot be narrowed — it is
+#     the whole rule or none of it. None of it: /finish and /commit-push-pr both
+#     instruct writing a PR body inline, and a body naming a git command in
+#     backticks could not be submitted.
+#   - Rewriting every `) ` to a separator denied parenthesised prose followed by
+#     the word git (`-m 'per (#101) git is blocked'`). It bought only the
+#     case-statement pattern `a) git status`, the rarest shape in the set.
+#
+# The assignment prefix keeps quoted values whole for the same reason: stopping
+# at the first space left `git ` at the head of `MSG="a git b" jj describe`.
+# The unquoted alternative excludes quote characters so it cannot win by
+# matching a shorter prefix — grep needs only SOME alternative to match, so a
+# permissive branch defeats a stricter one sitting beside it.
+#
+# Known-open, documented in the READMEs and pinned by pass-through assertions
+# in test-block-raw-git.sh: backtick substitution, case patterns, an
+# interpreter handed git as data (`bash -c 'git status'`), wrappers carrying
+# their own options (`eval "git …"`, `sudo -u me git`, `timeout 5 git`), and
+# spellings other than the bare word (`/usr/bin/git`, `\git`). All need
+# argument parsing or quote tracking, i.e. a shell parser. The wall is a
+# guardrail against habit, not a sandbox — anyone who wants git can disable the
+# plugin. Reaching further with a regex is what produced the false positives.
+sq="'"
+dq='"'
+# VAR=value, VAR="value with spaces", VAR='…', and concatenations of those
+# (VAR="a"b is one word to the shell). The value is a SEQUENCE of runs, not a
+# choice between them: a single alternation stops after the first run and then
+# demands whitespace, so VAR="a"b git status slipped through.
+assign_re="[A-Za-z_][A-Za-z0-9_]*=(${dq}[^${dq}]*${dq}|${sq}[^${sq}]*${sq}|[^[:space:]${dq}${sq}])*"
+wrappers_re='if|then|elif|else|do|while|until|!|time|command|exec|env|eval|nohup|nice|sudo|xargs'
+prefix_re="(([({][[:space:]]*)|((${assign_re}|${wrappers_re})[[:space:]]+))*"
+
 has_raw_git=false
-if printf '%s\n' "$command_normalized" | tr ';&|' '\n\n\n' \
-   | grep -qE '^[[:space:]]*git[[:space:]]'; then
+if printf '%s\n' "$command_normalized" \
+   | sed -E -e 's/\$\(/;/g' -e 's/[<>]\(/;/g' \
+   | tr ';&|' '\n\n\n' \
+   | grep -qE "^[[:space:]]*${prefix_re}git[[:space:]]"; then
   has_raw_git=true
 fi
 

--- a/plugins/project-setup-jj/tests/test-block-raw-git.sh
+++ b/plugins/project-setup-jj/tests/test-block-raw-git.sh
@@ -15,10 +15,20 @@ pass=0
 fail=0
 
 # Run the hook with a command + cwd; capture stdout (hook never uses stderr).
+#
+# The payload is built with `jq --arg`, not string interpolation. Interpolation
+# cannot express a command containing a double quote — it produces malformed
+# JSON, the hook's `jq -r` yields an empty command, and the case then passes
+# for the wrong reason (nothing to block is not the same as nothing blocked).
+# The #105 must-allow corpus is full of such commands (`jq '… ["Bash(git *)"]'`,
+# `-T 'if(empty, "empty", …)'`), and those are exactly the cases most likely to
+# regress. Pass a real newline with $'…' where a multi-line command is meant.
 run_hook() {
   local cmd="$1"
   local cwd="$2"
-  local json='{"tool_input":{"command":"'"$cmd"'"},"tool_name":"Bash","hook_event_name":"PreToolUse","cwd":"'"$cwd"'"}'
+  local json
+  json=$(jq -nc --arg c "$cmd" --arg d "$cwd" \
+    '{tool_input:{command:$c}, tool_name:"Bash", hook_event_name:"PreToolUse", cwd:$d}')
   echo "$json" | bash "$HOOK" 2>/dev/null || true
 }
 
@@ -77,9 +87,61 @@ assert_blocked "no space after ; separator"       "jj git fetch;git status"     
 assert_blocked "no space after && separator"      "jj git fetch&&git status"                     "$JJ_DIR"
 assert_blocked "raw git in a third clause"        "echo hi && jj git fetch && git status"        "$JJ_DIR"
 # Newlines are folded to ';' before analysis, so a multi-line command must
-# split the same way. The \n below is a JSON escape: jq hands the hook a real
-# newline.
-assert_blocked "multi-line: newline is a separator" 'jj git fetch\ngit reset --hard origin/main' "$JJ_DIR"
+# split the same way. $'…' makes the newline real in the shell string; run_hook
+# encodes it for the hook.
+assert_blocked "multi-line: newline is a separator" $'jj git fetch\ngit reset --hard origin/main' "$JJ_DIR"
+
+# #105: three further shapes put git at a real command position without a
+# `; & |` immediately before it, so the per-clause anchor from #101 never saw
+# them. Measured against the pre-fix hook, 20 of the 21 cases below came back
+# ALLOWED. They are grouped by the family they belong to; each family is closed
+# by a different part of the fix, so a regression in one must not be masked by
+# the others.
+echo "=== jj repo: git at command position without a clause separator (#105) ==="
+
+# Family 1 — command substitution. The character before `git` is `(`, which was
+# not a separator. Process substitution is the same mechanism with a different
+# sigil. Backticks are deliberately NOT covered — see the boundary section.
+assert_blocked "substitution: \$( )"          'echo $(git status)'                  "$JJ_DIR"
+assert_blocked "substitution: assignment"     'x=$(git log --oneline)'              "$JJ_DIR"
+assert_blocked "substitution: in a for list"  'for f in $(git ls-files); do echo $f; done' "$JJ_DIR"
+assert_blocked "substitution: process <( )"   'diff <(git log) /dev/null'           "$JJ_DIR"
+
+# Family 2 — grouping. A subshell or brace group opens a new command position,
+# but `(` and `{` were not separators, so the clause began with the grouping
+# character instead of with git.
+assert_blocked "grouping: subshell"           '(git status)'                        "$JJ_DIR"
+assert_blocked "grouping: subshell, spaced"   '( git reset --hard origin/main )'    "$JJ_DIR"
+assert_blocked "grouping: brace group"        '{ git status; }'                     "$JJ_DIR"
+assert_blocked "grouping: brace after clause" 'true; { git log --oneline; }'        "$JJ_DIR"
+assert_blocked "grouping: nested in keyword"  'if true; then (git status); fi'      "$JJ_DIR"
+
+# Family 3 — prefix words. The clause genuinely starts with a shell keyword or
+# an environment assignment, so the anchor did not fire even though git runs.
+assert_blocked "prefix: if test position"     'if git diff --quiet; then echo clean; fi' "$JJ_DIR"
+assert_blocked "prefix: while test position"  'while git pull; do echo again; done' "$JJ_DIR"
+assert_blocked "prefix: do body"              'for f in a b; do git add $f; done'   "$JJ_DIR"
+assert_blocked "prefix: env assignment"       'GIT_AUTHOR_NAME=x git commit -m y'   "$JJ_DIR"
+assert_blocked "prefix: quoted assignment"    'GIT_MSG="a b" git commit -F -'       "$JJ_DIR"
+# A shell word may concatenate quoted and unquoted runs. Treating the value as
+# a single run stopped after the first and then demanded whitespace, so these
+# two slipped through the first version of the quoted-assignment fix.
+assert_blocked "prefix: quote-then-bare value" 'FOO="a"b git status'                "$JJ_DIR"
+assert_blocked "prefix: bare-then-quote value" 'FOO=a"b" git status'                "$JJ_DIR"
+assert_blocked "prefix: two assignments"       'A="x y" B=2 git reset --hard origin/main' "$JJ_DIR"
+assert_blocked "prefix: time"                 'time git status'                     "$JJ_DIR"
+assert_blocked "prefix: negation"             '! git diff --quiet'                  "$JJ_DIR"
+assert_blocked "prefix: env"                  'env git status'                      "$JJ_DIR"
+assert_blocked "prefix: sudo"                 'sudo git status'                     "$JJ_DIR"
+assert_blocked "prefix: nice"                 'nice git status'                     "$JJ_DIR"
+assert_blocked "prefix: stacked keyword+assign" 'if [ -d sub ]; then GIT_X=1 git reset --hard origin/main; fi' "$JJ_DIR"
+
+# Not a #105 family — a harness guard. run_hook builds its payload with jq
+# precisely so a command containing a double quote survives the trip. If it
+# ever goes back to string interpolation the JSON breaks, the hook reads an
+# empty command, and every must-allow case below passes vacuously. This case
+# fails loudly in that world, because an empty command is never denied.
+assert_blocked "double quotes survive the harness" 'git commit -m "wip"'            "$JJ_DIR"
 
 # These are regression guards, not fail-first cases: every one of them passed
 # before the #101 per-clause fix and must still pass after it. A false positive
@@ -102,6 +164,93 @@ assert_passthrough "gh with flags"          "gh pr create --title x --body y" "$
 assert_passthrough "git named inside a -m message" "jj describe -m 'replace git status with jj status'" "$JJ_DIR"
 assert_passthrough "quoted git string echoed"      "echo 'git status'" "$JJ_DIR"
 assert_passthrough "non-git command"        "ls -la"               "$JJ_DIR"
+
+# #105 must-allow corpus. Closing the three families above widened what counts
+# as a command position, and every character it now keys on — `(`, `{`, `)`,
+# backtick, `=` — is ordinary punctuation in jj's own revset and template
+# syntax, in shell parameter expansion, and in the permission strings this
+# repo's own installer writes. A false positive here is worse than the bypass
+# it prevents: these are the shapes the plugins' command prose instructs.
+# Every case below was measured ALLOWED against the pre-#105 hook and must
+# stay that way.
+echo "=== jj repo: #105 must-allow — parens and prefixes that are not git ==="
+# jj revset and template syntax is parenthesis-heavy, and `git_head()` puts the
+# literal string "git" directly before a paren.
+assert_passthrough "revset: trunk() range"  "jj log -r 'trunk()..@'"               "$JJ_DIR"
+assert_passthrough "revset: bare trunk()"   "jj diff --from trunk() --to @ --stat" "$JJ_DIR"
+assert_passthrough "revset: git_head()"     "jj log -r 'ancestors(git_head())'"    "$JJ_DIR"
+assert_passthrough "revset: grouped+funcs"  "jj log --ignore-working-copy -r '(trunk()..@) & ~empty()' --no-graph -T 'json(self)'" "$JJ_DIR"
+assert_passthrough "template: if() with strings" "jj log -r @ --no-graph -T 'if(empty, \"empty\", \"has-content\")'" "$JJ_DIR"
+# Substitution and grouping around a jj command — the exemption must stay
+# structural, i.e. survive being wrapped rather than depend on clause index.
+assert_passthrough "substitution around jj" 'echo $(jj root)'                      "$JJ_DIR"
+assert_passthrough "substitution then jj"   'cd $(jj root) && jj status'           "$JJ_DIR"
+assert_passthrough "substitution feeds jj git push" "BOOKMARK=\$(jj log -r @ --no-graph -T 'bookmarks') && jj git push --bookmark \"\$BOOKMARK\"" "$JJ_DIR"
+assert_passthrough "process substitution, jj" 'diff <(jj log) <(jj log -r @)'      "$JJ_DIR"
+assert_passthrough "subshell around jj git"  '( jj git push )'                     "$JJ_DIR"
+assert_passthrough "brace group around jj"   '{ jj status; jj log; }'              "$JJ_DIR"
+# Prefix words in front of jj must be stripped and then find `jj`, not `git`.
+assert_passthrough "assignment then jj git"  'JJ_USER=ci jj git push'              "$JJ_DIR"
+assert_passthrough "if test position, jj"    'if jj diff --quiet; then echo clean; fi' "$JJ_DIR"
+assert_passthrough "do body, jj"             'for r in a b; do jj show $r; done'   "$JJ_DIR"
+assert_passthrough "time, jj"                'time jj status'                      "$JJ_DIR"
+# Parameter expansion is `${`, not a command position — this exact string is
+# how every plugin.json references its hook.
+assert_passthrough "\${VAR} is not a group"  'bash "${CLAUDE_PLUGIN_ROOT}/scripts/block-raw-git.sh"' "$JJ_DIR"
+# The permission string project-setup-install.sh writes. `(` here is inside a
+# word, not at command position, so it must not open a clause.
+assert_passthrough "Bash(git *) permission string" "jq '.permissions.deny += [\"Bash(git *)\"]' .claude/settings.local.json" "$JJ_DIR"
+assert_passthrough "Bash(git *) echoed"      "echo 'deny: Bash(git *)'"            "$JJ_DIR"
+# Prose naming a git command. The hook is quote-blind, so this is the case most
+# at risk from the widened boundary — and the one this repo would hit first,
+# since its own commit messages and PR bodies talk about git constantly.
+#
+# The first two shapes below shipped in the original #105 fix and survived only
+# by accident: `(` precedes git, and `)` is followed by a non-space. Code review
+# found that both MIRROR IMAGES regressed — a review that generated its own
+# corpus instead of reusing the one written alongside the fix. `git` after a
+# backtick and `git` after `) ` were denied, which breaks /finish and
+# /commit-push-pr: both instruct writing a PR body inline, and a body naming a
+# git command in backticks could not be submitted. The two rules responsible
+# (rewriting every backtick, and every `) `, to a clause separator) were
+# dropped; these assertions pin that they stay dropped.
+assert_passthrough "parenthesised prose in -m"   "jj describe -m 'switch from (git status) to jj status'" "$JJ_DIR"
+assert_passthrough "parenthesised prose in body" "gh pr create --body 'closes #105 (git wall)'" "$JJ_DIR"
+assert_passthrough "backtick code span in -m"    'jj describe -m '"'"'replaces `git status` with jj status'"'"'' "$JJ_DIR"
+assert_passthrough "backtick code span in body"  'gh pr create --body '"'"'stop using `git log` here'"'"'' "$JJ_DIR"
+assert_passthrough "prose: ) then the word git"  "jj describe -m 'per (#101) git is blocked'" "$JJ_DIR"
+assert_passthrough "prose: ) then git in body"   "gh pr comment --body 'see (CONVENTIONS.md) git is denied'" "$JJ_DIR"
+# A quoted assignment value is one token to the shell. Stripping only up to the
+# first space left `git ` at clause head and denied an ordinary jj command.
+assert_passthrough "quoted assignment value naming git" 'MSG="a git b" jj describe -m x' "$JJ_DIR"
+# Other tools whose syntax uses the same punctuation.
+assert_passthrough "awk brace block"         "jj diff -r @ --summary | awk '{print \$2}'" "$JJ_DIR"
+assert_passthrough "find -exec naming git"   'find . -name "*.sh" -exec grep -l git {} \;' "$JJ_DIR"
+
+# Documented boundary. These are NOT desired behaviour — they are shapes the
+# wall does not catch, pinned so the READMEs cannot drift away from what the
+# hook does. The wall matches text at command position; it does not parse the
+# shell, and every attempt to reach further with a regex is what produced the
+# false positives above. Closing any of these means updating the scope note in
+# all three READMEs and CONVENTIONS.md in the same change.
+echo "=== jj repo: documented boundary — known-open shapes (#105) ==="
+# Backtick substitution. Dropped deliberately: opening and closing backticks are
+# indistinguishable without pairing, and pairing is impossible quote-blind, so
+# covering this necessarily denies every code span in prose.
+assert_passthrough "boundary: backtick substitution" 'echo `git status`'            "$JJ_DIR"
+# Case-statement pattern. Reached only by rewriting every `) ` to a separator,
+# which denies parenthesised prose — a much likelier command than this one.
+assert_passthrough "boundary: case pattern"  'case $x in a) git status;; esac'      "$JJ_DIR"
+# An interpreter handed git as data.
+assert_passthrough "boundary: bash -c"       "bash -c 'git status'"                 "$JJ_DIR"
+# Wrappers carrying their own options — the alternation strips a bare wrapper
+# word only. Matching option-bearing forms needs argument parsing.
+assert_passthrough "boundary: eval quoted"   'eval "git reset --hard origin/main"'  "$JJ_DIR"
+assert_passthrough "boundary: sudo -u"       'sudo -u me git status'                "$JJ_DIR"
+assert_passthrough "boundary: timeout"       'timeout 5 git status'                 "$JJ_DIR"
+# Spellings that are not the bare word `git`.
+assert_passthrough "boundary: absolute path" '/usr/bin/git status'                  "$JJ_DIR"
+assert_passthrough "boundary: escaped word"  '\git status'                          "$JJ_DIR"
 
 echo "=== non-jj repo: git is allowed ==="
 assert_passthrough "git status in git root"   "git status"          "$GIT_DIR"


### PR DESCRIPTION
#101 made the raw-git wall decide each clause of a compound command
separately. Three shapes still reached a real git invocation without a clause
separator immediately before it, so the per-clause anchor never saw them.
Measured against the shipped hook, 20 of 21 such commands were ALLOWED.

- Substitution — `$(…)`, `<(…)`: a sed pass rewrites each opening sigil to a
  clause separator.
- Grouping — `(…)` and `{ …; }`: handled as a strippable clause prefix rather
  than as a separator. A subshell can only open where a command may start.
- Prefix words — shell keywords, zero-argument wrappers and `VAR=value`
  assignments, stripped by a repetition group so that they stack.

#105 recommended closing only the first two, on the grounds that the
prefix-word list was the likeliest source of false positives. That was
measured rather than assumed against a must-allow corpus harvested from the
plugins' own command prose — jj revsets and templates, `${VAR}` expansion, the
`Bash(git *)` permission string the installer writes, awk and find syntax.

A first cut of this change went further and regressed two prose shapes. Code
review caught them by generating its own corpus instead of reusing the one
written alongside the fix; both are now fail-first assertions:

- Rewriting every backtick to a separator denied a git command named in a
  markdown code span. Opening and closing backticks cannot be told apart
  quote-blind, so the rule cannot be narrowed — it is withdrawn. /finish and
  /commit-push-pr both instruct writing a PR body inline, and a body naming a
  git command in backticks could not be submitted.
- Rewriting every `) ` to a separator denied parenthesised prose followed by
  the word git. It bought only the case-statement pattern, the rarest shape in
  the set — also withdrawn.
- The assignment prefix stopped at the first space, so `MSG="a git b" jj
  describe` was denied. Quoted values are now kept whole, and the unquoted
  alternative excludes quote characters: grep needs only SOME alternative to
  match, so a permissive branch defeats a stricter one beside it.

`nice` joins the wrapper list. Wrappers carrying their own options, `bash -c`,
and non-bare spellings stay out of scope — reaching further with a regex is
what produced the false positives. Every known-open shape now has a
pass-through assertion so the READMEs cannot drift from the behaviour, and the
scope note no longer claims `gh …` is unconditionally allowed, which was never
true.

Each part of the fix is mutation-proven: neutralising it flips exactly the
assertions that describe it, including the permissive-branch subtlety.

Both suites build their JSON payloads with `jq --arg`. Interpolation cannot
express a command containing a double quote, and a malformed payload would
have made every must-allow case pass vacuously; reverting either harness
breaks the double-quote guards.

Tests: 39 → 95 assertions in project-setup-jj's suite, 12 → 22 in
commit-commands-jj's gating suite. Full gate 17/17, 480 assertions. Versions
bumped on all three plugins carrying the byte-identical copy.

Closes #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
