### PR TITLE
fix(evals): reject gated tools that --allow-tools cannot grant (#102 Gap A)

### DIFF
--- a/.github/scripts/run-evals.sh
+++ b/.github/scripts/run-evals.sh
@@ -155,6 +155,20 @@ fi
 # exists to prevent, manufactured by the runner itself.
 GRANTED=$(printf '%s' "$ALLOW_TOOLS" | tr ', ' '\n\n' | grep -v '^$' || true)
 
+# Tools that are gated but that `--allow-tools` cannot grant (#102 Gap A).
+# A `case` pattern, so members are separated by `|` and more can be added
+# without touching the guard. This is a CATEGORY, not one special tool: any
+# tool the CLI gates by a mechanism other than the operator grant belongs here,
+# because a case declaring one can never be measured by ablation.
+#
+# The membership test is a measured denial, never `--help`: --help enumerates
+# the GRANTABLE set (Bash, Write, Edit, WebFetch, mcp__*), and the two lists are
+# not complements — a tool absent from --help is not thereby ungrantable, it may
+# simply be ungated. SlashCommand earned its place by printing
+# `denied tools: SlashCommand` in a real run. Add to this list only on the same
+# evidence.
+UNGRANTABLE_TOOLS='SlashCommand'
+
 # Discover case directories. BOTH supported formats: `case.yaml` and the
 # `prompt.md` + graders/ layout that `claude plugin eval init --bare` writes.
 # A single-format glob would silently skip officially-scaffolded cases (#82).
@@ -361,6 +375,32 @@ while IFS= read -r case_dir; do
   while IFS= read -r tool; do
     [ -n "$tool" ] || continue
     case "$tool" in
+      # Gated but UNGRANTABLE (#102 Gap A). `claude plugin eval --help` (2.1.220)
+      # documents the operator grant as exactly "Bash, Write, Edit, WebFetch,
+      # mcp__*". SlashCommand is gated by a different mechanism and is absent
+      # from that set, so no --allow-tools value can satisfy it. Measured during
+      # the Part A probe: the guard passed clean and the CLI then printed
+      # `denied tools: SlashCommand`, denying it in BOTH arms — 0.00/0.00, read
+      # as NO_GAP, the case silently cut. That is this guard's own failure mode
+      # arriving through the one tool it did not know about.
+      #
+      # Deliberately NOT solved by adding SlashCommand to the grantable list
+      # below: that abort tells the operator to pass a flag value the CLI
+      # cannot accept, so they spend a run discovering the advice was wrong.
+      # This is a different category — declared, gated, ungrantable, therefore
+      # unmeasurable by this harness at all — and it must say so. Granting it
+      # must not rescue the case either, which is why this arm ignores $GRANTED.
+      $UNGRANTABLE_TOOLS)
+        printf 'ERROR: %s declares gated tool "%s", which cannot be granted.\n' \
+          "$case_dir" "$tool" >&2
+        # `%s\n`, not a bare format string: a format beginning with `--` is
+        # parsed by printf as an option and dies with "invalid option".
+        printf '%s\n' '--allow-tools grants only Bash, Write, Edit, WebFetch, mcp__*' >&2
+        printf 'The CLI denies "%s" in BOTH arms, so the case scores 0.00/0.00\n' "$tool" >&2
+        printf 'and reads as "no gap". It cannot be measured by ablation — drop\n' >&2
+        printf 'the tool from the case, or measure the behaviour another way.\n' >&2
+        exit 7
+        ;;
       Bash|Write|Edit|WebFetch|mcp__*)
         # Exact match against the grant list — an unanchored grep lets
         # `--allow-tools BashOutput` satisfy a requirement for `Bash`.

--- a/.github/tests/test-run-evals.sh
+++ b/.github/tests/test-run-evals.sh
@@ -428,6 +428,82 @@ else
   bad "a granted multi-tool case is not blocked by the guard (got rc=$rc)"
 fi
 
+# --- #102 Gap A: a gated tool that CANNOT be granted at all ---
+#
+# `claude plugin eval --help` (2.1.220) documents the operator grant as exactly
+# "Bash, Write, Edit, WebFetch, mcp__*". SlashCommand is gated by a different
+# mechanism and is absent from that set, so it can never be satisfied by
+# --allow-tools. Measured during the Part A probe: a case declared it, the
+# guard passed clean, and the CLI printed `denied tools: SlashCommand` at run
+# time — both arms denied, both scores zeroed, verdict NO_GAP. That is the
+# guard's own failure mode, reached by the tool it does not know about.
+#
+# The fix is NOT to add SlashCommand to the grantable list: telling the
+# operator to pass `--allow-tools SlashCommand` sends them to a flag that
+# cannot accept it. It is a separate category — declared, gated, ungrantable,
+# therefore unmeasurable — and the abort must say so.
+UNGRANTABLE=$(mk_case_tree needsslash <<'YAML'
+schema_version: "1.1"
+name: needsslash
+execution:
+  prompt: hello
+  allowed_tools: [Bash, SlashCommand]
+graders:
+  - type: regex
+    name: g
+    pattern: hi
+YAML
+)
+rc=$(guard_rc "$UNGRANTABLE" --plugin demo --allow-tools Bash)
+if [ "$rc" -eq 7 ]; then
+  ok "an ungrantable gated tool aborts (exit 7)"
+else
+  bad "an ungrantable gated tool aborts (exit 7) (got rc=$rc)"
+fi
+
+# Granting it must NOT rescue the case — that is the whole difference between
+# this and the ungranted-tool guard above. If passing --allow-tools SlashCommand
+# makes the run proceed, the runner has handed the operator a workaround that
+# the CLI will then deny anyway, and the NO_GAP verdict comes back regardless.
+rc=$(guard_rc "$UNGRANTABLE" --plugin demo --allow-tools Bash,SlashCommand)
+if [ "$rc" -eq 7 ]; then
+  ok "granting an ungrantable tool does not rescue the case"
+else
+  bad "granting an ungrantable tool does not rescue the case (got rc=$rc)"
+fi
+
+# The diagnostic must name the tool and say it cannot be granted. rc alone
+# cannot distinguish this abort from the ordinary missing-grant one, and an
+# operator who reads "add it to --allow-tools" will burn a run finding out.
+err=$( (cd "$UNGRANTABLE" && /bin/bash "$SCRIPT" --plugin demo --allow-tools Bash --dry-run 2>&1 >/dev/null) || true )
+if printf '%s' "$err" | grep -q 'SlashCommand' \
+   && printf '%s' "$err" | grep -qi 'cannot be granted'; then
+  ok "the ungrantable diagnostic names the tool and why it cannot be granted"
+else
+  bad "the ungrantable diagnostic names the tool and why it cannot be granted (got: ${err:-<empty>})"
+fi
+
+# Control: the grantable set must still pass untouched. Without this, the
+# assertions above are satisfied by a guard that rejects every case.
+CONTROL=$(mk_case_tree grantable <<'YAML'
+schema_version: "1.1"
+name: grantable
+execution:
+  prompt: hello
+  allowed_tools: [Bash, Write, Edit, WebFetch]
+graders:
+  - type: regex
+    name: g
+    pattern: hi
+YAML
+)
+rc=$(guard_rc "$CONTROL" --plugin demo --allow-tools Bash,Write,Edit,WebFetch)
+if [ "$rc" -eq 0 ]; then
+  ok "the documented grantable set is not rejected as ungrantable"
+else
+  bad "the documented grantable set is not rejected as ungrantable (got rc=$rc)"
+fi
+
 # Block-style YAML must be caught too — it is the layout `eval init` writes,
 # so a flow-only guard is blind to precisely the cases it exists to protect.
 # Its OWN tree: with a flow-form case left on disk this assertion passes with

--- a/docs/eval-triage-2026-07.md
+++ b/docs/eval-triage-2026-07.md
@@ -493,21 +493,53 @@ over-read them is real.
 
 Three defects in `.github/scripts/run-evals.sh` surfaced during the probes. All
 three were left unfixed at the time and are recorded here so they are not lost.
-**Gap C has since been closed** (see below); Gaps A and B remain open.
+**Gaps A and C are closed; Gap B remains open** (#102). The diagnoses are kept
+because the measurements behind them are what any fix must be anchored to.
 
 **Gap A — `SlashCommand` is missing from the exit-7 guard's gated list.**
-The guard (`.github/scripts/run-evals.sh:351`) matches
-`Bash|Write|Edit|WebFetch|mcp__*`. A case declaring `SlashCommand` in
-`allowed_tools` passes the guard clean while the CLI denies the tool at runtime:
+The guard matched `Bash|Write|Edit|WebFetch|mcp__*`. A case declaring
+`SlashCommand` in `allowed_tools` passed the guard clean while the CLI denied
+the tool at runtime:
 `cmd-describe: denied tools (pass --allow-tools to grant): SlashCommand`. The
 guard exists precisely to prevent an ungranted tool silently zeroing an arm, and
 it had a hole for the one tool Part A depended on.
 
+**Closed**, but not as originally framed. `claude plugin eval --help` (2.1.220)
+documents the operator grant as exactly "Bash, Write, Edit, WebFetch, mcp__*" —
+the guard's grantable list was already correct and complete. `SlashCommand` is
+gated by a *different* mechanism and is absent from that set, so **no
+`--allow-tools` value can ever satisfy it**. Adding it to the grantable list
+would have produced an abort telling the operator to pass a flag value the CLI
+rejects. It is instead a separate category — declared, gated, ungrantable,
+therefore unmeasurable by ablation — and the exit-7 diagnostic now says so.
+Granting it deliberately does *not* rescue the case.
+
 **Gap B — negative-only graders score vacuously on a 0-turn arm.**
 Dissected in §2.3. A dead arm banks free score, inflating the delta, and lands
 above the both-arms-zero floor so the runner's "broken, never no-gap" guard never
-fires. Candidate fixes: a `turns > 0` precondition on scored runs, or a hard
-requirement that every case carry at least one positive outcome grader.
+fires.
+
+**Still open.** A first attempt was withdrawn under review, and the reason is
+worth recording because it is the trap anyone fixing this will walk into.
+
+The `{"num_turns":0,...}` record quoted in §2.2 above is the CLI's **per-run
+result message**, not a field of `aggregate-result.json`. The aggregate is what
+`classify()` reads, and its per-run entries call the field **`turns`**:
+
+```
+.cases[].runs[]  keys = cost_usd, duration_seconds, error, graders,
+                        judge_cost_usd, score, started_at, trace_path, turns
+```
+
+Verified against two real captures from the 2026-07-26 probe. A tripwire keyed
+on `num_turns` therefore fires on every real run: the sweep pays its full
+budget, completes, and is then discarded with a schema-drift error. The fixtures
+asserting `num_turns` were hand-written, so the suite was green against a field
+the CLI never emits.
+
+Anyone fixing this should commit a real captured aggregate as a fixture first —
+the error class is unreachable once the tests run against captured output rather
+than an approximation of it.
 
 **Gap C — zero loadable cases kills the runner on `find` before `classify()`.**
 When the CLI loads 0 cases it writes no output directory, so


### PR DESCRIPTION
A case declaring `SlashCommand` in `allowed_tools` passed the tool guard clean
and the CLI then denied the tool at run time, zeroing BOTH ablation arms. The
result read 0.00/0.00 — NO_GAP — and the case was silently cut. That is the
guard's own failure mode, arriving through the one tool it did not know about.

Not fixed by adding SlashCommand to the grantable list, which is what the issue
proposed. `claude plugin eval --help` (2.1.220) documents the operator grant as
exactly "Bash, Write, Edit, WebFetch, mcp__*", so the guard's grantable list was
already complete. SlashCommand is gated by a different mechanism and is absent
from that set, meaning no `--allow-tools` value can satisfy it — an abort that
says "add it to your grant" sends the operator to a flag that will reject it,
and they spend a run finding out.

It is a separate category: declared, gated, ungrantable, therefore unmeasurable
by ablation. Exit 7 with a diagnostic that says so, and granting it deliberately
does not rescue the case. The category is a `case` pattern rather than a
hardcoded literal, with the membership rule stated: a measured denial, never
`--help`. The two lists are not complements — a tool absent from --help may
simply be ungated rather than ungrantable.

Also fixes a printf whose format string began with `--` and died with
"invalid option".

Gap C was already closed in #106; the triage doc recorded that and the issue did
not. Gap B — a 0-turn arm banking free score — is NOT in this change. A first
attempt was withdrawn under review: it keyed on `num_turns`, which is the CLI's
per-run RESULT MESSAGE field, while the aggregate `classify()` actually reads
calls it `turns`. Every real sweep would have paid its full budget and then been
discarded with a schema-drift error. The triage doc now records the real
`.cases[].runs[]` key set, verified against two captured runs, so the next
attempt starts from measured output instead of an approximation.

Tests: 58 → 62 assertions in test-run-evals.sh, mutation-proven — emptying the
ungrantable list flips exactly the three assertions that describe it. Full gate
17/17, 487 assertions. No plugin files touched, so no version bump applies.

Part of #102 (Gap A). Gap B remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
