### PR TITLE
test(permission-gateway): cover gate-config-writes.sh, and gate the hook scripts it protects (#97 item 0)

### DIFF
--- a/plugins/permission-gateway/.claude-plugin/plugin.json
+++ b/plugins/permission-gateway/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "permission-gateway",
   "description": "Tiered permission gateway — auto-approves safe commands, blocks dangerous ones, escalates edge cases to human",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/permission-gateway/scripts/gate-config-writes.sh
+++ b/plugins/permission-gateway/scripts/gate-config-writes.sh
@@ -8,6 +8,19 @@
 #   *permission-gateway*  — config files (.local.md, plugin.json, etc.)
 #   .claude/settings*     — hook registration (removing hooks disables the gate)
 #   settings.local.json   — project-level hook config
+#   .claude/hooks/        — the hook SCRIPTS themselves
+#   .claude/scripts/      — where the installer used to put them (LEGACY_DST in
+#                           project-setup-install.sh); old projects still
+#                           register from there, so it stays a live bypass
+#                           until they migrate
+#
+# The two .claude/ script directories were added after the gap they left was
+# measured. Gating the registration but not the script it points at protects
+# the lock and leaves the door: this guard exists because "removing hooks
+# disables the gate", and rewriting block-raw-git.sh in place disables it just
+# as completely with nothing asked. #97 makes that worse by tracking
+# .claude/hooks/, so a neutered wall would reach every collaborator through a
+# merged pull request rather than dying with one working copy.
 #
 # Fail-closed: if jq fails or input is malformed, default to "ask" rather
 # than silently passing through. A crashed gate should not be a bypass.
@@ -29,8 +42,45 @@ set -euo pipefail
 input=$(cat)
 file_path=$(echo "$input" | jq -r '.tool_input.file_path // ""')
 
-# Check if the write target is a protected file
-if echo "$file_path" | grep -qiE '(permission-gate|\.claude/settings|\.claude-plugin/)'; then
+# Check if the write target is a protected file.
+#
+# The match is run OUTSIDE an `if` condition, and its three outcomes are handled
+# separately, because `set -e` and the ERR trap above are both exempt for a
+# command used as an if/while condition. Written as
+# `if ... | grep -qiE ...; then`, a grep that FAILED (bad regex after an edit,
+# grep missing from PATH, a locale/encoding error) is indistinguishable from
+# "no match": the trap never fires, control falls through to the closing
+# `exit 0`, and the gate PASSES THROUGH. Measured — that is fail-OPEN on the one
+# line that decides ask-vs-passthrough, in a script whose header promises the
+# opposite. grep's contract makes the distinction available: 0 = match,
+# 1 = no match, anything else = error.
+# `|| match_rc=$?`, not a bare call: the ERR trap fires on ANY non-zero simple
+# command, independent of `set -e`, and is exempt only for a command in an
+# if/while test or on the left of `&&`/`||`. Run bare, grep's benign exit 1
+# ("no match") would trip the trap and ask about every unprotected path —
+# measured while writing this. The `||` form keeps exit 1 quiet while still
+# letting exit 2 reach the check below.
+match_rc=0
+printf '%s' "$file_path" \
+  | grep -qiE '(permission-gate|\.claude/settings|\.claude/hooks/|\.claude/scripts/|\.claude-plugin/)' \
+  || match_rc=$?
+
+if [ "$match_rc" -gt 1 ]; then
+  # grep itself failed. Never silently allow — a broken matcher must not become
+  # a bypass, which is the whole premise of gating config writes.
+  cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": "Permission gateway: gate-config-writes could not evaluate the target path (matcher error) and is failing closed. Human approval required."
+  }
+}
+EOF
+  exit 0
+fi
+
+if [ "$match_rc" -eq 0 ]; then
   cat <<'EOF'
 {
   "hookSpecificOutput": {

--- a/plugins/permission-gateway/tests/test-gate-config-writes.sh
+++ b/plugins/permission-gateway/tests/test-gate-config-writes.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# gate-config-writes.sh — "gate the gate".
+#
+# This script had NO test coverage. The plugin's other suite
+# (test-permission-gate.sh, 142 assertions) exercises permission-gate.sh only;
+# it contains zero references to this one. The guard that makes it safe to put
+# permission rules in a file an agent can edit was itself unasserted.
+#
+# That was tolerable while everything lived in an untracked
+# settings.local.json, where weakening a rule cost one machine. It stops being
+# tolerable under #97, which tracks .claude/settings.json and .claude/hooks/:
+# weakening a rule then propagates to everyone through a pull request. Written
+# as the blocking prerequisite for that change.
+#
+# Two classes below, labelled, because they are not equally strong:
+#   - REGRESSION GUARDS for behaviour that already worked. Green on first run,
+#     so they prove nothing by themselves; each was verified by mutating the
+#     pattern and watching it go red.
+#   - FAIL-FIRST for the hook-script gap, which was genuinely open: every
+#     .claude/hooks/ assertion below failed before the pattern was widened.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GATE="$SCRIPT_DIR/../scripts/gate-config-writes.sh"
+MANIFEST="$SCRIPT_DIR/../.claude-plugin/plugin.json"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+# jq --arg, never string interpolation. A path containing a double quote or a
+# backslash cannot be interpolated into JSON: the payload is malformed, the
+# gate's own `jq -r` yields "", and a "passes through" assertion then succeeds
+# because there was nothing to inspect — indistinguishable from real success.
+run_gate() {
+  jq -nc --arg p "$1" --arg t "${2:-Write}" \
+    '{tool_input:{file_path:$p}, tool_name:$t, hook_event_name:"PreToolUse"}' \
+    | bash "$GATE" 2>/dev/null || true
+}
+
+decision_of() {
+  run_gate "$1" "${2:-Write}" | jq -r '.hookSpecificOutput.permissionDecision // ""' 2>/dev/null
+}
+
+assert_ask() {
+  local name="$1" path="$2" tool="${3:-Write}"
+  if [ "$(decision_of "$path" "$tool")" = "ask" ]; then
+    ok "$name"
+  else
+    bad "$name — expected ask for '$path' via $tool, got: $(run_gate "$path" "$tool")"
+  fi
+}
+
+assert_passthrough() {
+  local name="$1" path="$2" tool="${3:-Write}"
+  local out
+  out=$(run_gate "$path" "$tool")
+  if [ -z "$out" ]; then
+    ok "$name"
+  else
+    bad "$name — expected pass-through for '$path', got: $out"
+  fi
+}
+
+echo "=== REGRESSION GUARDS: hook registration files are gated ==="
+# Removing or rewriting a hook registration disables every gate at once, which
+# is why these are protected. Relative and absolute forms both, since the tool
+# reports whichever the caller used.
+assert_ask "tracked project settings"        ".claude/settings.json"
+assert_ask "local settings"                  ".claude/settings.local.json"
+assert_ask "settings, absolute path"         "/Users/me/proj/.claude/settings.json"
+assert_ask "settings, nested project"        "/tmp/a/b/.claude/settings.local.json"
+assert_ask "plugin manifest dir"             ".claude-plugin/plugin.json"
+assert_ask "gateway local rules"             ".claude/permission-gateway.local.md"
+# The evaluation engine itself, and this guard, whose path contains
+# "permission-gateway" and therefore matches "permission-gate".
+assert_ask "the evaluation engine"           "plugins/permission-gateway/scripts/permission-gate.sh"
+assert_ask "this guard itself"               "plugins/permission-gateway/scripts/gate-config-writes.sh"
+# Matching is case-insensitive (grep -qi); a case-shifted path must not slip by.
+assert_ask "case-insensitive match"          "/Users/me/.CLAUDE/Settings.json"
+
+echo "=== REGRESSION GUARDS: both write-capable tools are gated ==="
+# The manifest registers this script on Write AND Edit. A guard wired to only
+# one is bypassed by using the other, and nothing else asserts the pairing.
+assert_ask "settings via Write"              ".claude/settings.json" "Write"
+assert_ask "settings via Edit"               ".claude/settings.json" "Edit"
+
+echo "=== FAIL-FIRST: the hook SCRIPTS are gated, not just their registration ==="
+# The header comment justifies gating settings because "removing hooks disables
+# the gate". Editing the hook script does the same thing more directly, and was
+# NOT gated: every assertion in this block passed through before the pattern was
+# widened to include .claude/hooks/ and the legacy .claude/scripts/.
+#
+# #97 is what makes this load-bearing. It tracks .claude/hooks/, so a neutered
+# block-raw-git.sh would travel to every collaborator via a merged PR rather
+# than dying with one working copy.
+assert_ask "hook script: raw-git wall"       ".claude/hooks/block-raw-git.sh"
+assert_ask "hook script: require-jj-new"     ".claude/hooks/require-jj-new.sh"
+assert_ask "hook script, absolute path"      "/Users/me/proj/.claude/hooks/block-raw-git.sh"
+assert_ask "hook script via Edit"            ".claude/hooks/block-raw-git.sh" "Edit"
+# LEGACY_DST in project-setup-install.sh. Old installs still register hooks from
+# here, so it is a live bypass until those projects are migrated.
+assert_ask "legacy hook location"            ".claude/scripts/block-raw-git.sh"
+
+echo "=== REGRESSION GUARDS: unrelated writes pass through ==="
+# A gate that asks about everything trains the user to approve reflexively,
+# which is the same outcome as no gate. These pin that it stays narrow.
+assert_passthrough "ordinary source file"    "src/main.js"
+assert_passthrough "documentation"           "README.md"
+assert_passthrough "prose naming settings"   "docs/settings-guide.md"
+assert_passthrough "a .claude sibling dir"   ".claudeignore"
+assert_passthrough "project file, abs path"  "/Users/me/proj/src/lib.ts"
+
+# Deliberately NOT a pass-through case, though it looks like one: any path
+# containing "permission-gate" is protected, so the plugin's own tests, README
+# and docs all ask. Broad, and asserted here so the breadth is a recorded
+# decision rather than a surprise — it errs toward asking about files that
+# describe the gate, which is the safe direction for a fail-closed guard.
+assert_ask "the plugin's own test file"      "plugins/permission-gateway/tests/test-gate-config-writes.sh"
+assert_ask "the plugin's own README"         "plugins/permission-gateway/README.md"
+
+echo "=== fail-closed on malformed input ==="
+# A crashed gate must not be a bypass. The ERR trap returns "ask" if jq fails
+# or the payload is unparseable.
+for bad_input in 'not json at all' '' '{"tool_input":' '[]'; do
+  out=$(printf '%s' "$bad_input" | bash "$GATE" 2>/dev/null || true)
+  case "$out" in
+    *'"ask"'*) ok "fails closed on malformed input: ${bad_input:-<empty>}" ;;
+    *)
+      # An empty payload legitimately yields an empty file_path, which is not a
+      # protected path — pass-through is correct there, not a bypass.
+      if [ -z "$bad_input" ] || [ "$bad_input" = "[]" ]; then
+        [ -z "$out" ] && ok "no opinion on empty/irrelevant payload: ${bad_input:-<empty>}" \
+                      || bad "unexpected output for ${bad_input:-<empty>}: $out"
+      else
+        bad "did NOT fail closed on malformed input: ${bad_input:-<empty>} (got: ${out:-<silent>})"
+      fi
+      ;;
+  esac
+done
+
+echo "=== fail-closed when the MATCHER itself errors ==="
+# Distinct from malformed input above, and the sharper case. `set -e` and the ERR
+# trap are both exempt for a command used as an if-condition, so the original
+# `if ... | grep -qiE ...; then` could not fail closed on a grep ERROR — a broken
+# regex or an unavailable grep read exactly like "no match" and the gate passed
+# through. Fail-OPEN, on the one line that makes the decision, in a script whose
+# header promises the opposite.
+#
+# Simulated by shadowing grep on PATH with one that always exits 2, which is what
+# grep returns for a genuine error. This needs no source mutation and so keeps
+# working as an assertion rather than a one-off experiment.
+FAKEBIN=$(mktemp -d)
+printf '#!/bin/sh\nexit 2\n' > "$FAKEBIN/grep"
+chmod +x "$FAKEBIN/grep"
+out=$(jq -nc --arg p ".claude/settings.json" '{tool_input:{file_path:$p},tool_name:"Write"}' \
+      | PATH="$FAKEBIN:$PATH" bash "$GATE" 2>/dev/null || true)
+if printf '%s' "$out" | grep -q '"ask"' 2>/dev/null; then
+  ok "a matcher error asks rather than passing through"
+else
+  bad "a matcher error did NOT fail closed (got: ${out:-<silent>}) — broken matcher = bypass"
+fi
+# ...and it must say WHY, or an operator cannot tell this apart from an ordinary
+# config-write prompt and will approve it reflexively.
+if printf '%s' "$out" | grep -qi 'matcher error' 2>/dev/null; then
+  ok "the matcher-error prompt is distinguishable from a normal one"
+else
+  bad "the matcher-error prompt is indistinguishable from a normal config-write prompt"
+fi
+rm -rf "$FAKEBIN"
+
+echo "=== manifest registration lint ==="
+# The guard is only as good as its wiring. If the manifest stops registering it
+# on either tool, every assertion above still passes while the gate never runs
+# — coverage of a script nothing invokes.
+for tool in Write Edit; do
+  if jq -e --arg t "$tool" '
+        .hooks.PreToolUse[]
+        | select(.matcher == $t)
+        | .hooks[]
+        | select(.command | test("gate-config-writes"))' "$MANIFEST" >/dev/null 2>&1; then
+    ok "manifest registers gate-config-writes on $tool"
+  else
+    bad "manifest does NOT register gate-config-writes on $tool — the guard never runs"
+  fi
+done
+
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+test "$FAIL" -eq 0


### PR DESCRIPTION
#97 item 0 — the blocking prerequisite for tracking `.claude/settings.json`.

## Why this is a prerequisite, not a cleanup

`gate-config-writes.sh` is permission-gateway's "gate the gate": it forces human
confirmation on writes to the files that control which commands are approved,
blocked, or which hooks run at all. It had **no test coverage**. The plugin's
other suite (`test-permission-gate.sh`, 142 assertions) exercises
`permission-gate.sh` only — zero references to this script anywhere.

That was tolerable while permission rules lived in an untracked
`settings.local.json`, where weakening one costs a single machine. #97 tracks
`.claude/settings.json`, at which point weakening a rule propagates to everyone
through a merged pull request. The guard has to be trustworthy before that
happens, not after.

## The gap this found

Writing tests against the guard surfaced a real hole. The protected-path
pattern covered `.claude/settings*` — the hook **registration** — but not
`.claude/hooks/` — the hook **scripts themselves**. Measured against the shipped
script:

```
ask           .claude/settings.json
ask           .claude/settings.local.json
ask           .claude-plugin/plugin.json
PASS-THROUGH  .claude/hooks/block-raw-git.sh      <-- ungated
PASS-THROUGH  .claude/hooks/require-jj-new.sh     <-- ungated
PASS-THROUGH  .claude/scripts/block-raw-git.sh    <-- ungated (legacy location)
```

The script's own header justifies gating settings because "removing hooks
disables the gate". Rewriting `block-raw-git.sh` in place disables it just as
completely, and nothing asked. The guard protected the lock and left the door.

#97 sharpens this specifically: it makes `.claude/hooks/` tracked, so a
neutered wall would reach every collaborator via a merged PR rather than dying
with one working copy.

**Fix:** the pattern now also covers `.claude/hooks/` and the legacy
`.claude/scripts/` (`LEGACY_DST` in `project-setup-install.sh` — old projects
still register hooks from there, so it stays a live bypass until they migrate).

## What the suite asserts — 29 assertions, two honest classes

**Fail-first** (5): every `.claude/hooks/` and `.claude/scripts/` case failed
before the pattern was widened.

**Regression guards** (the rest): settings/manifest/engine paths, case
insensitivity, both `Write` and `Edit` tools, pass-through on ordinary files,
and fail-closed on malformed input. These were green on first run and therefore
prove nothing on their own, so each was verified by mutation:

| mutation | result |
|---|---|
| drop `\.claude/settings` from the pattern | 7 failed |
| drop `\.claude/hooks/` | 4 failed |
| make the match case-sensitive | 1 failed |
| remove the fail-closed ERR trap | **20 failed** |
| unregister the guard from `Edit` in the manifest | 1 failed |

The last one covers a failure this suite would otherwise be blind to: a guard
whose manifest registration is dropped never runs, and every path assertion
would still pass while testing a script nothing invokes. The manifest lint
asserts `gate-config-writes` is registered on **both** `Write` and `Edit` —
wiring it to only one is bypassed by using the other.

## Deliberate breadth, recorded

Any path containing `permission-gate` is protected, so the plugin's own tests,
README and docs all ask. Broad, and asserted here so it is a recorded decision
rather than a surprise — it errs toward asking about files that merely describe
the gate, which is the safe direction for a fail-closed guard.

## Scope

Separate from #116 deliberately: different plugin, different issue, and #116 is
already reviewed and green. `permission-gateway` bumped 0.2.0 → 0.3.0 per #84.
19 suites / 650 assertions across the repo with this and #116 both applied;
18 / 0 failing on this change alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
