### PR TITLE
fix(peer-review): derive history concerns in code, and stop non-@ reviews reading the wrong revision

### DIFF
--- a/plugins/peer-review-jj/.claude-plugin/plugin.json
+++ b/plugins/peer-review-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "peer-review-jj",
   "description": "Unified change review for jj repos — generalist-first with emergent specialists, two-phase pipeline, structured findings",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/peer-review-jj/agents/change-reviewer.md
+++ b/plugins/peer-review-jj/agents/change-reviewer.md
@@ -26,6 +26,19 @@ You are a change reviewer. You review jj changes for production readiness. You r
 
 You review the specific files assigned to you. You do not review the entire change — only your partition.
 
+## Reading the Right Content
+
+The working copy holds one revision. If the revision you were asked to review is
+not the working copy, the files on disk belong to a **different** revision, and
+`Read`/`cat` will hand you the wrong code with no error — plausible output, line
+numbers that do not match the diff.
+
+Unless your prompt states that the working copy is at the revision under review,
+read content with `jj file show -r <rev> <path>` rather than `Read`. `jj diff -r
+<rev>` is always safe because it is revision-scoped.
+
+If you cite a line number, it must come from revision-scoped output.
+
 ## What to Review
 
 - **Code quality**: separation of concerns, error handling, edge cases, DRY

--- a/plugins/peer-review-jj/scripts/append-review-history.sh
+++ b/plugins/peer-review-jj/scripts/append-review-history.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Append one review to .claude/peer-review/history.jsonl, deriving the
+# `concerns` array mechanically from the generalists' specialist_recommendations.
+#
+# WHY THIS IS A SCRIPT AND NOT AN INSTRUCTION
+#
+# The receiving skill used to describe the history line as a JSONL template with
+# `"concerns":[{"type":"<enum>","pattern":"<description>",...}]` in it, and said
+# nothing about where those values come from. The generalist schema does not even
+# use those names — it returns `specialist_recommendations[]` with `concern` and
+# `rationale`. So the producer had no instruction and the consumer (specialist
+# emergence, which counts distinct patterns per concern type) depended on the
+# field being filled.
+#
+# Measured on this repo's own history file: 3 of 3 entries had `concerns: []`,
+# including one recording 3 important + 4 minor findings. Emergence reads that
+# array, so the mechanism could never fire — it had been inert since the plugin
+# shipped. Nothing caught it because peer-review-jj had no tests at all.
+#
+# Re-stating the mapping in prose would be the same bet that just lost: it was
+# already implicitly required. Deriving it in code makes the mapping impossible
+# to skip and testable, which is what tests/test-review-history.sh does.
+#
+# bash 3.2-safe: no globstar, no associative arrays.
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: append-review-history.sh --revision <short-id> [--timestamp <unix>] [--history <path>]
+
+Reads the aggregated review JSON on stdin:
+
+  {
+    "files_reviewed": ["a", "b"],
+    "findings": [ { "severity": "important", ... } ],
+    "specialist_recommendations": [
+      { "concern": "Security", "rationale": "...", "files": [...], "line_ranges": [...] }
+    ],
+    "verdict": "with_fixes"
+  }
+
+Appends one JSONL line and prints it. --timestamp exists so tests are
+deterministic; omit it in real use.
+USAGE
+  exit 64
+}
+
+REVISION=""
+TIMESTAMP=""
+HISTORY=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --revision)  REVISION="${2:-}"; shift 2 ;;
+    --timestamp) TIMESTAMP="${2:-}"; shift 2 ;;
+    --history)   HISTORY="${2:-}"; shift 2 ;;
+    -h|--help)   usage ;;
+    *) printf 'unknown argument: %s\n' "$1" >&2; usage ;;
+  esac
+done
+
+[ -n "$REVISION" ] || { printf 'ERROR: --revision is required\n' >&2; usage; }
+[ -n "$HISTORY" ] || HISTORY=".claude/peer-review/history.jsonl"
+[ -n "$TIMESTAMP" ] || TIMESTAMP=$(date +%s)
+
+case "$TIMESTAMP" in
+  ''|*[!0-9]*) printf 'ERROR: --timestamp must be a unix integer, got "%s"\n' "$TIMESTAMP" >&2; exit 64 ;;
+esac
+
+input=$(cat)
+
+# Validate BEFORE touching the history file. A malformed aggregate must not
+# leave a half-written or bogus line behind — the file is append-only and read
+# by the emergence check, so one bad line silently poisons every later count.
+if ! printf '%s' "$input" | jq -e . >/dev/null 2>&1; then
+  printf 'ERROR: stdin is not valid JSON — nothing appended.\n' >&2
+  exit 65
+fi
+
+# The whole point of the file: concerns are DERIVED, never hand-written.
+#   concern   -> type
+#   rationale -> pattern
+# `// []` on each lookup so a generalist that omits a key yields an empty array
+# rather than a null that would serialise into the history and break jq readers
+# downstream. -c for one line per entry, which is what JSONL means.
+line=$(printf '%s' "$input" | jq -c \
+  --arg rev "$REVISION" \
+  --argjson ts "$TIMESTAMP" \
+  '{
+     timestamp: $ts,
+     revision: $rev,
+     files_reviewed: (.files_reviewed // []),
+     findings_count: {
+       critical:  [(.findings // [])[] | select(.severity == "critical")]  | length,
+       important: [(.findings // [])[] | select(.severity == "important")] | length,
+       minor:     [(.findings // [])[] | select(.severity == "minor")]     | length
+     },
+     concerns: [
+       (.specialist_recommendations // [])[]
+       | {
+           type:        (.concern   // "Other"),
+           pattern:     (.rationale // ""),
+           files:       (.files // []),
+           line_ranges: (.line_ranges // [])
+         }
+     ],
+     verdict: (.verdict // "unknown")
+   }')
+
+mkdir -p "$(dirname "$HISTORY")"
+# tee -a, not Write: the file is an append-only log. Overwriting it destroys the
+# history that specialist emergence is counted from.
+printf '%s\n' "$line" | tee -a "$HISTORY" >/dev/null
+printf '%s\n' "$line"

--- a/plugins/peer-review-jj/skills/receiving-change-review/SKILL.md
+++ b/plugins/peer-review-jj/skills/receiving-change-review/SKILL.md
@@ -58,12 +58,32 @@ Three occurrences of the same pattern is repetition, not emergence. Three *diffe
 
 ## Step 6: Append to History
 
-1. Create `.claude/peer-review/` directory if needed: `mkdir -p .claude/peer-review`
-2. Append one JSONL line using `tee -a` (not Write, which would overwrite):
+Do NOT hand-write the JSONL line. Pipe the aggregated review to the script:
 
 ```bash
-echo '{"timestamp":<unix>,"revision":"<short>","files_reviewed":[...],"findings_count":{"critical":N,"important":N,"minor":N},"concerns":[{"type":"<enum>","pattern":"<description>","files":[...],"line_ranges":[...]}],"verdict":"<verdict>"}' | tee -a .claude/peer-review/history.jsonl > /dev/null
+printf '%s' "$AGGREGATED_JSON" \
+  | bash "${CLAUDE_PLUGIN_ROOT}/scripts/append-review-history.sh" --revision <short-id>
 ```
+
+`$AGGREGATED_JSON` is the merged result of Steps 2–4: `files_reviewed`,
+`findings`, `specialist_recommendations`, `verdict`. The script derives
+`timestamp`, `findings_count` (tallied by severity) and — critically —
+`concerns`, mapping each specialist recommendation's `concern` → `type` and
+`rationale` → `pattern`. It creates the directory, appends with `tee -a`, and
+refuses to touch the file if the input is not valid JSON.
+
+**Why a script and not a template.** This step used to show the JSONL shape with
+`"concerns":[{"type":"<enum>","pattern":"<description>",…}]` and never said where
+those values came from — and the generalist schema does not use those names, it
+returns `specialist_recommendations[]` with `concern` and `rationale`. So the
+producer had no instruction while Step 5's emergence check depended on the field.
+Measured on this repo: **3 of 3 history entries had `concerns: []`**, one of them
+recording 7 findings. Emergence had been inert since the plugin shipped.
+
+Re-stating the mapping in prose would repeat the bet that already failed — it was
+implicitly required and skipped every time. `tests/test-review-history.sh` pins
+the derivation, including the specific regression: a review with findings must
+never record `concerns: []`.
 
 ## Step 7: Present Results
 

--- a/plugins/peer-review-jj/skills/requesting-change-review/SKILL.md
+++ b/plugins/peer-review-jj/skills/requesting-change-review/SKILL.md
@@ -51,10 +51,34 @@ Split changed files across generalists using these rules in priority order:
 Each generalist receives a prompt with:
 
 - **Scope**: which files are theirs and only theirs
-- **How to read**: `jj diff -r <rev>` scoped to their files, plus permission to read full files for surrounding context
+- **How to read**: `jj diff -r <rev>` scoped to their files, plus surrounding context — but see the warning below about WHERE that context comes from
 - **Guidelines**: relevant CLAUDE.md content inline (read CLAUDE.md files from the project root and any subdirectories containing changed files)
 - **Change context**: revision, description, change metadata from `jj log -r <rev> --no-graph -T 'json(self) ++ "\n"'`
 - **Output schema**: the generalist response JSON schema (from the change-reviewer agent spec)
+
+### Reviewing a revision that is not `@`
+
+The working copy holds ONE revision. If `<rev>` is not `@`, the files on disk are
+a **different** revision's content, and a reviewer that opens them with `Read` or
+`cat` silently reviews the wrong code — no error, plausible-looking output, line
+numbers that quietly do not correspond to the diff.
+
+Before dispatching, resolve whether the target is the working copy:
+
+```bash
+jj log -r '<rev> & @' --no-graph -T '"same"'
+```
+
+- **Empty output** (target is not `@`) — either move the working copy first with
+  `jj edit <rev>`, so disk and revision agree, or state explicitly in every agent
+  prompt that file contents must be read with `jj file show -r <rev> <path>` and
+  that `Read`/`cat` on the work tree is off-limits. Moving the working copy is
+  usually simpler and removes the hazard rather than documenting it.
+- **`same`** — `Read` is safe; disk is the revision under review.
+
+`--track` does not have this problem: it does `jj edit $DUPLICATE`, so the work
+tree always matches what is being reviewed. The hazard exists only on the plain
+non-`@` path.
 
 ## Step 5: If --track Enabled
 

--- a/plugins/peer-review-jj/tests/test-review-history.sh
+++ b/plugins/peer-review-jj/tests/test-review-history.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# peer-review-jj's FIRST test suite.
+#
+# The plugin shipped with zero tests and zero eval cases — 1 command, 2 skills,
+# 1 agent, entirely unasserted. That is why a dead mechanism survived unnoticed:
+# specialist emergence counts distinct `pattern` values per concern `type` in
+# .claude/peer-review/history.jsonl, and every entry ever written had
+# `concerns: []`, because nothing told the writer where that array comes from.
+#
+# These assertions cover the derivation that replaced the prose. They are
+# fail-first by construction: append-review-history.sh did not exist when they
+# were written.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APPEND="$SCRIPT_DIR/../scripts/append-review-history.sh"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+HIST="$TMP/history.jsonl"
+
+# A realistic aggregate: two severities, two specialist recommendations whose
+# field names deliberately differ from the history's (concern/rationale vs
+# type/pattern) — the mismatch that made the mapping easy to skip.
+AGG='{
+  "files_reviewed": ["a.sh", "b.sh"],
+  "findings": [
+    {"severity":"important","description":"x"},
+    {"severity":"important","description":"y"},
+    {"severity":"minor","description":"z"}
+  ],
+  "specialist_recommendations": [
+    {"concern":"Security","rationale":"gate scoped to Write/Edit only","files":["a.sh"],"line_ranges":[{"start":1,"end":2}]},
+    {"concern":"ErrorHandling","rationale":"ERR trap cannot fire in an if-condition","files":["b.sh"],"line_ranges":[{"start":9,"end":9}]}
+  ],
+  "verdict": "with_fixes"
+}'
+
+run() { printf '%s' "$1" | bash "$APPEND" --revision "${2:-abcd1234}" --timestamp "${3:-1000000000}" --history "$HIST"; }
+
+echo "=== concerns are derived, not hand-written ==="
+out=$(run "$AGG")
+n=$(printf '%s' "$out" | jq -r '.concerns | length')
+if [ "$n" = "2" ]; then
+  ok "two specialist recommendations produce two concerns"
+else
+  bad "two specialist recommendations produce two concerns (got $n)"
+fi
+
+# The specific mapping. Asserting only "concerns is non-empty" would pass against
+# a writer that emitted the right shape with wrong contents, which is most of the
+# way back to the bug.
+if [ "$(printf '%s' "$out" | jq -r '.concerns[0].type')" = "Security" ]; then
+  ok "concern -> type"
+else
+  bad "concern -> type (got $(printf '%s' "$out" | jq -r '.concerns[0].type'))"
+fi
+if [ "$(printf '%s' "$out" | jq -r '.concerns[0].pattern')" = "gate scoped to Write/Edit only" ]; then
+  ok "rationale -> pattern"
+else
+  bad "rationale -> pattern (got $(printf '%s' "$out" | jq -r '.concerns[0].pattern'))"
+fi
+if [ "$(printf '%s' "$out" | jq -r '.concerns[1].line_ranges[0].start')" = "9" ]; then
+  ok "line_ranges carried through"
+else
+  bad "line_ranges carried through"
+fi
+
+echo "=== the regression this suite exists for ==="
+# The exact defect: findings present, specialist recommendations present, and the
+# history line nonetheless recording concerns: []. Emergence counts that array,
+# so an empty one with findings above it means the mechanism is inert.
+have_findings=$(printf '%s' "$out" | jq -r '(.findings_count.critical + .findings_count.important + .findings_count.minor) > 0')
+have_concerns=$(printf '%s' "$out" | jq -r '(.concerns | length) > 0')
+if [ "$have_findings" = "true" ] && [ "$have_concerns" = "true" ]; then
+  ok "a review with findings does not record concerns: []"
+else
+  bad "a review with findings recorded concerns: [] — emergence is inert again"
+fi
+
+echo "=== findings_count is tallied by severity ==="
+if [ "$(printf '%s' "$out" | jq -r '.findings_count.important')" = "2" ] \
+   && [ "$(printf '%s' "$out" | jq -r '.findings_count.minor')" = "1" ] \
+   && [ "$(printf '%s' "$out" | jq -r '.findings_count.critical')" = "0" ]; then
+  ok "severities tallied: 0 critical / 2 important / 1 minor"
+else
+  bad "severities tallied (got $(printf '%s' "$out" | jq -c '.findings_count'))"
+fi
+
+echo "=== append, never overwrite ==="
+# The history is the only record emergence is computed from. A writer that
+# truncates loses every prior review while still looking like it worked.
+run "$AGG" "second99" >/dev/null
+lines=$(grep -c . "$HIST")
+if [ "$lines" = "2" ]; then
+  ok "second review appends rather than overwriting"
+else
+  bad "second review appends rather than overwriting (file has $lines line(s))"
+fi
+if [ "$(tail -1 "$HIST" | jq -r '.revision')" = "second99" ] \
+   && [ "$(head -1 "$HIST" | jq -r '.revision')" = "abcd1234" ]; then
+  ok "both revisions are present and ordered"
+else
+  bad "both revisions are present and ordered"
+fi
+
+echo "=== one line per entry (JSONL, not pretty-printed) ==="
+if [ "$(printf '%s' "$out" | grep -c .)" = "1" ]; then
+  ok "entry serialises to a single line"
+else
+  bad "entry spans multiple lines — the file would stop being JSONL"
+fi
+
+echo "=== an empty recommendation set legitimately yields no concerns ==="
+CLEAN='{"files_reviewed":["c.sh"],"findings":[],"specialist_recommendations":[],"verdict":"yes"}'
+out2=$(run "$CLEAN" "clean001")
+if [ "$(printf '%s' "$out2" | jq -r '.concerns | length')" = "0" ] \
+   && [ "$(printf '%s' "$out2" | jq -r '.verdict')" = "yes" ]; then
+  ok "a clean review records concerns: [] without inventing any"
+else
+  bad "a clean review records concerns: [] without inventing any"
+fi
+
+echo "=== missing keys degrade to empty arrays, not nulls ==="
+# A null here serialises into the log and breaks every later jq reader, including
+# the emergence count — a poisoned line is worse than a missing one.
+SPARSE='{"verdict":"yes"}'
+out3=$(run "$SPARSE" "sparse01")
+if [ "$(printf '%s' "$out3" | jq -r '.concerns | type')" = "array" ] \
+   && [ "$(printf '%s' "$out3" | jq -r '.files_reviewed | type')" = "array" ]; then
+  ok "absent keys become arrays, never null"
+else
+  bad "absent keys became null — downstream jq readers would break"
+fi
+
+echo "=== malformed input is rejected before the file is touched ==="
+before=$(grep -c . "$HIST")
+set +e
+printf 'not json' | bash "$APPEND" --revision bad1 --timestamp 1 --history "$HIST" >/dev/null 2>&1
+rc=$?
+set -e
+after=$(grep -c . "$HIST")
+if [ "$rc" -ne 0 ] && [ "$before" = "$after" ]; then
+  ok "invalid JSON exits non-zero and appends nothing"
+else
+  bad "invalid JSON: rc=$rc, lines went $before -> $after"
+fi
+
+echo "=== argument validation ==="
+set +e
+printf '%s' "$AGG" | bash "$APPEND" --timestamp 1 --history "$HIST" >/dev/null 2>&1
+rc_norev=$?
+printf '%s' "$AGG" | bash "$APPEND" --revision r --timestamp notanumber --history "$HIST" >/dev/null 2>&1
+rc_badts=$?
+set -e
+[ "$rc_norev" -ne 0 ] && ok "missing --revision is rejected" || bad "missing --revision was accepted"
+[ "$rc_badts" -ne 0 ] && ok "non-numeric --timestamp is rejected" || bad "non-numeric --timestamp was accepted"
+
+echo "=== the history file it writes is readable by the emergence query ==="
+# Step 5 of the receiving skill counts distinct patterns per type. If that query
+# returns nothing against a freshly written file, the format is wrong regardless
+# of what the assertions above say.
+counted=$(jq -r '.concerns[]? | "\(.type)\t\(.pattern)"' "$HIST" 2>/dev/null | sort -u | grep -c . || true)
+if [ "$counted" -ge 2 ]; then
+  ok "emergence query reads $counted distinct type/pattern pairs back"
+else
+  bad "emergence query read $counted pairs — the written format is unusable"
+fi
+
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+test "$FAIL" -eq 0


### PR DESCRIPTION
Two defects in `peer-review-jj`, both found by running `/peer-review` on a real
change — the plugin had never been pointed at anything in this repo.

**Stacked on #119 → #116.** Merge those first, then retarget.

## 1. Specialist emergence was inert since the plugin shipped

Step 5 of the receiving skill counts distinct `pattern` values per concern `type`
in `.claude/peer-review/history.jsonl`. Every entry ever written had
`concerns: []` — **3 of 3**, one of them recording 3 important + 4 minor findings.
So the threshold could never be reached.

Root cause is a disconnected contract, not a typo. Step 6 showed the JSONL shape
with `"concerns":[{"type":…,"pattern":…}]` and never said where those values come
from, and the generalist schema does not use those names — it returns
`specialist_recommendations[]` with `concern` and `rationale`:

| generalist returns | history expects |
|---|---|
| `concern` | `type` |
| `rationale` | `pattern` |

The producer had no instruction; the consumer depended on the field.

**Fix: derive it in code, not prose.** `scripts/append-review-history.sh` takes
the aggregated review on stdin and emits the line — deriving `findings_count` by
severity and `concerns` by that mapping, appending with `tee -a`, and refusing to
touch the file when the input is not valid JSON (a poisoned line silently
corrupts every later emergence count).

Re-stating the mapping in prose would repeat the bet that already failed: it was
implicitly required and skipped every single time.

## 2. Reviewing a non-`@` revision silently reviews the wrong code

The working copy holds one revision. Asked to review a different one, a reviewer
that opens files with `Read` gets another revision's content — no error, plausible
findings, line numbers that do not match the diff. Step 4 actively invited it:
*"plus permission to read full files for surrounding context."*

Hit live during this review: `@` was on another change, so the target's files on
disk were trunk's versions.

**Fix:** the skill now resolves `jj log -r '<rev> & @'` before dispatch and either
moves the working copy or requires `jj file show -r <rev> <path>` in every agent
prompt; `agents/change-reviewer.md` carries the same rule so it travels with the
agent. Noted that `--track` is unaffected — it already does `jj edit $DUPLICATE`.

## Tests — the plugin's first

`tests/test-review-history.sh`, 15 assertions, fail-first by construction (the
script did not exist when they were written). peer-review-jj previously had **zero**
tests and zero eval cases, which is why a dead mechanism survived unnoticed.

Beyond the mapping itself: the specific regression (findings present must never
coexist with `concerns: []`), append-not-overwrite across two runs, single-line
JSONL, absent keys degrading to `[]` rather than `null`, malformed input rejected
with nothing appended, argument validation, and a round-trip check that Step 5's
own emergence query reads the written file back.

Defect 2 gets no test: whether an agent reaches for `Read` or `jj file show` is
not mechanically checkable. Its failure is at least self-revealing — cited line
numbers stop matching the diff.

`peer-review-jj` 0.6.0 per #84. 19 suites / 0 failing on this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
