### PR TITLE
feat(project-setup): tracked settings.json by default, with a .gitignore guard (#97 items 1-2)

### DIFF
--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/README.md
+++ b/plugins/project-setup-jj/README.md
@@ -53,7 +53,8 @@ This creates/updates the following in your project:
 | `.claude/hooks/require-jj-new.sh` | PreToolUse hook — advises Claude to run `jj new` before editing into a non-empty change (informational — does not block) |
 | `.claude/hooks/jj-workspace-create.sh` | WorktreeCreate hook — creates jj workspace for worktree isolation |
 | `.claude/hooks/jj-workspace-remove.sh` | WorktreeRemove hook — cleans up jj workspace |
-| `.claude/settings.local.json` | Hook registration (SessionStart, PreToolUse, PreCompact, WorktreeCreate, WorktreeRemove) + jj permissions |
+| `.claude/settings.json` | Hooks (SessionStart, PreToolUse, PreCompact, WorktreeCreate, WorktreeRemove) + the `Bash(git *)` deny floor — **commit this**, it is what makes fresh clones and jj workspaces enforce the rules (#97) |
+| `.claude/settings.local.json` | Personal settings: jj/gh allow-list, and `statusLine` if `/statusline-jj-setup` is used |
 | `CLAUDE.md` | jj VCS policy directive (created or updated) |
 
 **Restart Claude Code** after running `/project-setup` for the SessionStart hook to take effect.

--- a/plugins/project-setup-jj/commands/project-setup.md
+++ b/plugins/project-setup-jj/commands/project-setup.md
@@ -23,7 +23,24 @@ All install work is done by a deterministic script — do not hand-merge setting
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/project-setup-install.sh" "${CLAUDE_PLUGIN_ROOT}" "$(jj root)"
 ```
 
-The script copies the four hook handlers into `.claude/hooks/`, deep-merges the hooks and permissions into `.claude/settings.local.json` (idempotently — re-running never duplicates entries and never touches unrelated config), and creates/updates the CLAUDE.md `## VCS` section. It prints a `key=value` summary and exits non-zero without writing if an existing `.claude/settings.local.json` is not valid JSON (in which case, report the error and stop — do not attempt to repair it automatically).
+If the user passed `--local` to `/project-setup`, forward it as the first argument:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/project-setup-install.sh" --local "${CLAUDE_PLUGIN_ROOT}" "$(jj root)"
+```
+
+The script copies the four hook handlers into `.claude/hooks/` and creates/updates the CLAUDE.md `## VCS` section. Settings are split (#97):
+
+- **`.claude/settings.json`** — hooks and `permissions.deny`. Meant to be committed, so a fresh clone or `jj workspace add` checkout enforces the same rules. This is the default.
+- **`.claude/settings.local.json`** — `permissions.allow`, plus `statusLine` if `/statusline-jj-setup` is used. Personal, stays untracked.
+
+Both merges are idempotent — re-running never duplicates entries and never touches unrelated config. A tracked install also **removes** the managed hooks from `settings.local.json`: hooks merge additively across scopes, so a registration present in both files fires twice.
+
+`--local` writes everything to `settings.local.json` and touches no tracked path, which is the pre-#97 behaviour.
+
+It prints a `key=value` summary and exits non-zero without writing if an existing settings file is not valid JSON (report the error and stop — do not attempt to repair it automatically).
+
+**Exit 3 — `.gitignore` excludes `.claude/`.** Tracked mode aborts, having written nothing, because neither git nor jj can re-include a file under an excluded directory: a tracked `settings.json` there could never be committed, and adding `!.claude/settings.json` below the blanket rule has no effect. The script prints the replacement rules. Relay them, and offer the two options — narrow the ignore rule and re-run, or re-run with `--local`. Do not edit the user's `.gitignore` yourself.
 
 Earlier versions installed these handlers into `.claude/scripts/`. The script migrates such a project in one run: it re-points the registrations (replacing the old ones rather than adding a second copy beside them) and deletes the four files it owns from `.claude/scripts/`, removing that directory only if nothing else is left in it. Files it does not own — notably `statusline-jj.sh` from `/statusline-jj-setup` — are left alone.
 
@@ -32,7 +49,9 @@ Earlier versions installed these handlers into `.claude/scripts/`. The script mi
 Read the script's `key=value` summary and confirm to the user what was set up:
 
 - Hook handlers installed in `.claude/hooks/` (SessionStart, require-jj-new, workspace create/remove)
-- `.claude/settings.local.json` updated (SessionStart + PreCompact + PreToolUse + WorktreeCreate + WorktreeRemove hooks + jj permissions) — value from `settings=`
+- Which layout was used — value from `mode=` (`tracked` or `local`)
+- `.claude/settings.json` — hooks (SessionStart, PreCompact, PreToolUse, WorktreeCreate, WorktreeRemove) + the `Bash(git *)` deny floor — value from `settings_tracked=` (`created`, `merged`, or `skipped` in `--local` mode). **Tell the user to commit this file** — that is what makes fresh clones and jj workspaces enforce the rules.
+- `.claude/settings.local.json` — jj/gh allow-list, and in `--local` mode the hooks too — value from `settings=`
 - Legacy `.claude/scripts/` — per the `legacy_scripts=` value: `removed` (migrated and the empty directory cleaned up), `kept_not_empty` (our files removed, directory kept because other files such as `statusline-jj.sh` remain), or `absent` (nothing to migrate)
 - CLAUDE.md — `created`, `updated`, or `already up to date` per the `claude_md=` value
 

--- a/plugins/project-setup-jj/scripts/project-setup-install.sh
+++ b/plugins/project-setup-jj/scripts/project-setup-install.sh
@@ -1,17 +1,59 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# project-setup-install.sh <plugin-root> <project-root>
+# project-setup-install.sh [--local] <plugin-root> <project-root>
 # Deterministic installer for /project-setup (#78). No jj dependency.
-# Copies the four consumer hook scripts, deep-merges hooks+permissions into
-# <project-root>/.claude/settings.local.json (replace-by-identity at HOOK
-# granularity; PreCompact by value; permissions union-deduped), installs/updates
-# the CLAUDE.md section (4-case hash logic), and prints a key=value summary.
-# Aborts without any side effect if an existing settings.local.json is invalid
-# JSON. bash 3.2-safe.
+# Copies the four consumer hook scripts, deep-merges hooks+permissions into the
+# project's settings (replace-by-identity at HOOK granularity; PreCompact by
+# value; permissions union-deduped), installs/updates the CLAUDE.md section
+# (4-case hash logic), and prints a key=value summary. Aborts without any side
+# effect if an existing settings file is invalid JSON. bash 3.2-safe.
+#
+# WHERE THE SETTINGS GO (#97)
+#
+# Default is TRACKED: hooks and permissions.deny go to .claude/settings.json,
+# which is meant to be committed. Everything personal — permissions.allow, and
+# statusLine if /statusline-jj-setup is used — stays in settings.local.json.
+#
+# The reason is that untracked enforcement does not travel. A fresh clone, or a
+# `jj workspace add` checkout, gets CLAUDE.md declaring the jj rules and none of
+# the wiring that enforces them, so the rules are weakest exactly where
+# workspace-jj:kaisen fans agents out in parallel. Tracked CLAUDE.md plus
+# untracked enforcement is a declaration and a behaviour disagreeing.
+#
+# The two defaults also fail asymmetrically. Default-tracked fails VISIBLY: an
+# unwanted settings.json shows up in `jj status` and is deleted in seconds.
+# Default-local fails INVISIBLY, and nobody finds out until an agent runs raw
+# git in a workspace that never had the wall.
+#
+# `--local` keeps the old behaviour — everything in settings.local.json, nothing
+# written to a tracked path. It is the escape hatch for a repo you do not want to
+# commit to, and for the `.gitignore` abort below.
+#
+# HOOKS MUST LIVE IN EXACTLY ONE FILE. Measured 2026-07-29: hooks registered at
+# both project and local scope BOTH fire, once each — they merge additively
+# rather than overriding, unlike most settings. So a tracked install must also
+# STRIP the managed hooks out of settings.local.json, or every migrating project
+# runs every handler twice. permissions.deny is the easy half: it merges by
+# documented design and is union-deduped, so a duplicate there is harmless.
 
-PLUGIN_ROOT="${1:?usage: project-setup-install.sh <plugin-root> <project-root>}"
-PROJECT_ROOT="${2:?usage: project-setup-install.sh <plugin-root> <project-root>}"
+MODE="tracked"
+POSITIONAL=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --local) MODE="local"; shift ;;
+    --) shift; break ;;
+    -*) printf 'unknown option: %s\n' "$1" >&2
+        printf 'usage: project-setup-install.sh [--local] <plugin-root> <project-root>\n' >&2
+        exit 64 ;;
+    *) POSITIONAL="$POSITIONAL $1"; shift ;;
+  esac
+done
+# shellcheck disable=SC2086
+set -- $POSITIONAL
+
+PLUGIN_ROOT="${1:?usage: project-setup-install.sh [--local] <plugin-root> <project-root>}"
+PROJECT_ROOT="${2:?usage: project-setup-install.sh [--local] <plugin-root> <project-root>}"
 
 SRC="$PLUGIN_ROOT/scripts"
 TEMPLATE="$PLUGIN_ROOT/templates/CLAUDE.md.template"
@@ -24,25 +66,91 @@ CLAUDE_DIR="$PROJECT_ROOT/.claude"
 DST="$CLAUDE_DIR/hooks"
 LEGACY_DST="$CLAUDE_DIR/scripts"
 SETTINGS="$CLAUDE_DIR/settings.local.json"
+SETTINGS_TRACKED="$CLAUDE_DIR/settings.json"
 CLAUDE_MD="$PROJECT_ROOT/CLAUDE.md"
 
 # The four handlers this installer owns. Named once: the copy loop, the settings
 # upsert identities, and the legacy cleanup must never disagree about the set.
 MANAGED_SCRIPTS="jj-session-start.sh require-jj-new.sh jj-workspace-create.sh jj-workspace-remove.sh"
 
-# --- 0. fail-safe: validate an existing settings file BEFORE any side effect ---
+# --- 0. fail-safe: validate existing settings files BEFORE any side effect ---
 # (must run before the copy loop so a malformed settings file aborts touching
-# nothing on disk — not just leaving settings.local.json itself unchanged.)
-if [ -f "$SETTINGS" ]; then
-  if ! jq empty "$SETTINGS" >/dev/null 2>&1; then
-    echo "ERROR: $SETTINGS exists but is not valid JSON; refusing to overwrite." >&2
-    exit 1
+# nothing on disk — not just leaving the settings file itself unchanged.)
+read_json_or_die() {
+  if [ -f "$1" ]; then
+    if ! jq empty "$1" >/dev/null 2>&1; then
+      echo "ERROR: $1 exists but is not valid JSON; refusing to overwrite." >&2
+      exit 1
+    fi
+    cat "$1"
+  else
+    printf '{}'
   fi
-  base=$(cat "$SETTINGS")
-  settings_outcome="merged"
-else
-  base='{}'
-  settings_outcome="created"
+}
+
+base=$(read_json_or_die "$SETTINGS")
+if [ -f "$SETTINGS" ]; then settings_outcome="merged"; else settings_outcome="created"; fi
+
+tracked_base='{}'
+tracked_outcome="skipped"
+if [ "$MODE" = "tracked" ]; then
+  tracked_base=$(read_json_or_die "$SETTINGS_TRACKED")
+  if [ -f "$SETTINGS_TRACKED" ]; then tracked_outcome="merged"; else tracked_outcome="created"; fi
+fi
+
+# --- 0b. tracked mode requires .gitignore not to exclude the .claude DIRECTORY ---
+# git (and jj) cannot re-include a file whose parent directory is excluded, so a
+# blanket `.claude/` makes `!.claude/settings.json` inert — measured on jj 0.43.0:
+# with the blanket rule plus negations, NOTHING under .claude/ is tracked.
+#
+# That is why appending negations is not a fix, and why this aborts instead of
+# rewriting: an append-only implementation would report success while changing
+# nothing, leaving a fresh clone enforcing nothing — the same silent-success shape
+# as #82. Rewriting a user's ignore rules is the most invasive thing this
+# installer could do in someone else's repository, so it refuses and explains.
+#
+# Abort BEFORE the copy loop: no scripts, no settings, no CLAUDE.md edit.
+if [ "$MODE" = "tracked" ] && [ -f "$PROJECT_ROOT/.gitignore" ]; then
+  blanket=""
+  while IFS= read -r gi_line || [ -n "$gi_line" ]; do
+    gi_line="${gi_line%$'\r'}"
+    # trim trailing whitespace; leading whitespace is not meaningful in gitignore
+    while :; do
+      case "$gi_line" in
+        *' '|*"$(printf '\t')") gi_line="${gi_line%?}" ;;
+        *) break ;;
+      esac
+    done
+    case "$gi_line" in
+      ''|'#'*) continue ;;
+      # Every spelling that excludes the DIRECTORY itself. Matching only the
+      # literal `.claude/` would let the same trap through in four other forms.
+      '.claude/'|'.claude'|'/.claude/'|'/.claude'|'.claude/**'|'/.claude/**')
+        blanket="$gi_line"; break ;;
+    esac
+  done < "$PROJECT_ROOT/.gitignore"
+
+  if [ -n "$blanket" ]; then
+    cat >&2 <<EOF
+ERROR: .gitignore excludes the .claude directory ("$blanket"), so a tracked
+       .claude/settings.json can never be committed. Nothing was changed.
+
+Neither git nor jj can re-include a file whose parent directory is excluded, so
+adding "!.claude/settings.json" below that line has no effect at all.
+
+Replace the "$blanket" line with:
+
+  .claude/*
+  !.claude/settings.json
+  !.claude/hooks/
+  .claude/settings.local.json
+
+Then re-run /project-setup. Or, to keep everything untracked as before:
+
+  /project-setup --local
+EOF
+    exit 3
+  fi
 fi
 
 # --- 1. dirs + copy the four consumer hook scripts ---
@@ -78,8 +186,10 @@ RJN="$HOOK_DIR/require-jj-new.sh"
 WSC="$HOOK_DIR/jj-workspace-create.sh"
 WSR="$HOOK_DIR/jj-workspace-remove.sh"
 
-merged=$(printf '%s' "$base" | jq \
-  --arg ss "$SS" --arg rjn "$RJN" --arg wsc "$WSC" --arg wsr "$WSR" '
+# Shared jq definitions. `upsert`/`upsert_value` add a registration; `strip`/
+# `strip_value` remove one. Both directions are needed now that hooks may have to
+# be moved OUT of settings.local.json rather than only into a file.
+JQ_DEFS='
   # hook-granularity replace-by-identity: strip hooks whose command ends with ANY
   # suffix in $sfxs from every entry of event $ev, drop emptied entries, append
   # $new. $sfxs carries both the current .claude/hooks/ path and the legacy
@@ -95,37 +205,92 @@ merged=$(printf '%s' "$base" | jq \
     );
   def upsert_value($ev; $new):
     .hooks[$ev] = (((.hooks[$ev] // []) | map(select(. != $new))) + [$new]);
+  # Removal counterparts. An event left with no entries is deleted rather than
+  # left as an empty array, so a migrated local file does not accumulate hollow
+  # keys that read as "this file registers hooks" to anyone inspecting it.
+  def strip($ev; $sfxs):
+    if (.hooks | type) == "object" then
+      .hooks[$ev] = (((.hooks[$ev] // [])
+        | map(.hooks = ((.hooks // []) | map(
+            . as $h | select($sfxs | any(. as $s | ($h.command // "") | endswith($s)) | not))))
+        | map(select((.hooks // []) | length > 0))))
+      | (if ((.hooks[$ev] // []) | length) == 0 then del(.hooks[$ev]) else . end)
+    else . end;
+  def strip_value($ev; $v):
+    if (.hooks | type) == "object" then
+      .hooks[$ev] = (((.hooks[$ev] // []) | map(select(. != $v))))
+      | (if ((.hooks[$ev] // []) | length) == 0 then del(.hooks[$ev]) else . end)
+    else . end;
+  def all_hooks: .
+    | upsert("SessionStart";
+        ["/.claude/hooks/jj-session-start.sh", "/.claude/scripts/jj-session-start.sh"];
+        {matcher:"startup|resume|clear|compact", hooks:[{type:"command", command:$ss, async:false}]})
+    | upsert("PreToolUse";
+        ["/.claude/hooks/require-jj-new.sh", "/.claude/scripts/require-jj-new.sh"];
+        {matcher:"Edit|Write|NotebookEdit", hooks:[{type:"command", command:$rjn}]})
+    | upsert("WorktreeCreate";
+        ["/.claude/hooks/jj-workspace-create.sh", "/.claude/scripts/jj-workspace-create.sh"];
+        {hooks:[{type:"command", command:$wsc}]})
+    | upsert("WorktreeRemove";
+        ["/.claude/hooks/jj-workspace-remove.sh", "/.claude/scripts/jj-workspace-remove.sh"];
+        {hooks:[{type:"command", command:$wsr}]})
+    | upsert_value("PreCompact";
+        {hooks:[{type:"command", command:"jj status >/dev/null 2>&1 || true"}]});
+  def strip_all_hooks: .
+    | strip("SessionStart";  ["/.claude/hooks/jj-session-start.sh", "/.claude/scripts/jj-session-start.sh"])
+    | strip("PreToolUse";    ["/.claude/hooks/require-jj-new.sh", "/.claude/scripts/require-jj-new.sh"])
+    | strip("WorktreeCreate";["/.claude/hooks/jj-workspace-create.sh", "/.claude/scripts/jj-workspace-create.sh"])
+    | strip("WorktreeRemove";["/.claude/hooks/jj-workspace-remove.sh", "/.claude/scripts/jj-workspace-remove.sh"])
+    | strip_value("PreCompact"; {hooks:[{type:"command", command:"jj status >/dev/null 2>&1 || true"}]})
+    | (if ((.hooks // {}) | length) == 0 then del(.hooks) else . end);
+  def add_allow: (.permissions //= {})
+    | .permissions.allow = (((.permissions.allow // []) + [
+        "Bash(jj status*)","Bash(jj diff*)","Bash(jj log*)","Bash(jj new*)",
+        "Bash(jj commit*)","Bash(jj describe*)","Bash(jj bookmark*)","Bash(jj git push*)",
+        "Bash(jj git fetch*)","Bash(jj rebase*)","Bash(jj squash*)","Bash(jj edit*)",
+        "Bash(jj abandon*)","Bash(jj undo*)","Bash(jj op log*)","Bash(jj resolve*)",
+        "Bash(jj root*)","Bash(jj file*)","Bash(jj split*)","Bash(jj config*)",
+        "Bash(jj git remote*)","Bash(gh *)"
+      ]) | unique);
+  def add_deny: (.permissions //= {})
+    | .permissions.deny = (((.permissions.deny // []) + ["Bash(git *)"]) | unique);
+  def drop_deny:
+    if (.permissions | type) == "object" and (.permissions.deny | type) == "array" then
+      .permissions.deny = (.permissions.deny | map(select(. != "Bash(git *)")))
+      | (if (.permissions.deny | length) == 0 then del(.permissions.deny) else . end)
+      | (if (.permissions | length) == 0 then del(.permissions) else . end)
+    else . end;
+'
 
-  ( .hooks //= {} )
-  | upsert("SessionStart";
-      ["/.claude/hooks/jj-session-start.sh", "/.claude/scripts/jj-session-start.sh"];
-      {matcher:"startup|resume|clear|compact", hooks:[{type:"command", command:$ss, async:false}]})
-  | upsert("PreToolUse";
-      ["/.claude/hooks/require-jj-new.sh", "/.claude/scripts/require-jj-new.sh"];
-      {matcher:"Edit|Write|NotebookEdit", hooks:[{type:"command", command:$rjn}]})
-  | upsert("WorktreeCreate";
-      ["/.claude/hooks/jj-workspace-create.sh", "/.claude/scripts/jj-workspace-create.sh"];
-      {hooks:[{type:"command", command:$wsc}]})
-  | upsert("WorktreeRemove";
-      ["/.claude/hooks/jj-workspace-remove.sh", "/.claude/scripts/jj-workspace-remove.sh"];
-      {hooks:[{type:"command", command:$wsr}]})
-  | upsert_value("PreCompact";
-      {hooks:[{type:"command", command:"jj status >/dev/null 2>&1 || true"}]})
-  | ( .permissions //= {} )
-  | .permissions.allow = (((.permissions.allow // []) + [
-      "Bash(jj status*)","Bash(jj diff*)","Bash(jj log*)","Bash(jj new*)",
-      "Bash(jj commit*)","Bash(jj describe*)","Bash(jj bookmark*)","Bash(jj git push*)",
-      "Bash(jj git fetch*)","Bash(jj rebase*)","Bash(jj squash*)","Bash(jj edit*)",
-      "Bash(jj abandon*)","Bash(jj undo*)","Bash(jj op log*)","Bash(jj resolve*)",
-      "Bash(jj root*)","Bash(jj file*)","Bash(jj split*)","Bash(jj config*)",
-      "Bash(jj git remote*)","Bash(gh *)"
-    ]) | unique)
-  | .permissions.deny = (((.permissions.deny // []) + ["Bash(git *)"]) | unique)
-  ')
 
 mkdir -p "$CLAUDE_DIR"
-printf '%s\n' "$merged" > "$SETTINGS"
+
+if [ "$MODE" = "tracked" ]; then
+  # Tracked file owns hooks + the deny floor: the enforcement everyone in the
+  # repo should get identically.
+  merged_tracked=$(printf '%s' "$tracked_base" | jq \
+    --arg ss "$SS" --arg rjn "$RJN" --arg wsc "$WSC" --arg wsr "$WSR" \
+    "$JQ_DEFS"' (.hooks //= {}) | all_hooks | add_deny')
+  printf '%s\n' "$merged_tracked" > "$SETTINGS_TRACKED"
+
+  # Local file keeps only what is personal, and must SHED the hooks — hooks merge
+  # additively across scopes, so leaving them here runs every handler twice. The
+  # managed deny entry is dropped too, so a single file owns it; permissions merge
+  # across scopes, so the tracked one still applies.
+  merged_local=$(printf '%s' "$base" | jq \
+    "$JQ_DEFS"' strip_all_hooks | drop_deny | add_allow')
+  printf '%s\n' "$merged_local" > "$SETTINGS"
+else
+  # --local: the pre-#97 behaviour, everything in one untracked file.
+  merged_local=$(printf '%s' "$base" | jq \
+    --arg ss "$SS" --arg rjn "$RJN" --arg wsc "$WSC" --arg wsr "$WSR" \
+    "$JQ_DEFS"' (.hooks //= {}) | all_hooks | add_allow | add_deny')
+  printf '%s\n' "$merged_local" > "$SETTINGS"
+fi
+
+echo "mode=$MODE"
 echo "settings=$settings_outcome"
+echo "settings_tracked=$tracked_outcome"
 
 # --- 3. legacy cleanup: retire .claude/scripts/ ---
 # Runs AFTER the settings write, deliberately. Until settings point at the new

--- a/plugins/project-setup-jj/tests/test-project-setup-install.sh
+++ b/plugins/project-setup-jj/tests/test-project-setup-install.sh
@@ -8,6 +8,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INSTALL="$SCRIPT_DIR/../scripts/project-setup-install.sh"
 
+# Everything below the "#97 tracked mode" section runs with --local, i.e. the
+# single-file layout these assertions were written against. They are about MERGE
+# semantics — replace-by-identity, preserving unrelated entries, retiring stale
+# registrations, aborting on malformed JSON — and that logic is shared by both
+# modes, so running them against one file keeps them focused. Which file owns
+# what is the tracked-mode section's job.
+INSTALL_MODE="--local"
+
 pass=0; fail=0
 ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
 bad() { echo "  FAIL: $1 — $2"; fail=$((fail+1)); }
@@ -37,7 +45,7 @@ newproj() { mktemp -d; }   # fresh project root per case
 
 # ---- Case 1: fresh install ----
 P=$(newproj)
-OUT=$(bash "$INSTALL" "$PLUG" "$P")
+OUT=$(bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P")
 for s in jj-session-start.sh require-jj-new.sh jj-workspace-create.sh jj-workspace-remove.sh; do
   [ -x "$P/.claude/hooks/$s" ] && ok "fresh: $s copied +x" || bad "fresh" "$s not executable/copied"
 done
@@ -66,7 +74,7 @@ printf '%s\n' "$OUT" | grep -qx 'claude_md=created' && ok "fresh: summary claude
 
 # ---- Case 2: idempotent re-run (byte-identical) ----
 BEFORE=$(cat "$P/.claude/settings.local.json")
-OUT2=$(bash "$INSTALL" "$PLUG" "$P")
+OUT2=$(bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P")
 [ "$(cat "$P/.claude/settings.local.json")" = "$BEFORE" ] && ok "rerun: settings byte-identical" || bad "rerun" "settings changed on 2nd run"
 printf '%s\n' "$OUT2" | grep -qx 'claude_md=unchanged' && ok "rerun: claude_md=unchanged" || bad "rerun" "claude_md not unchanged: $OUT2"
 
@@ -75,7 +83,7 @@ P=$(newproj); mkdir -p "$P/.claude"
 cat > "$P/.claude/settings.local.json" <<'JSON'
 {"hooks":{"SessionStart":[{"matcher":"x","hooks":[{"type":"command","command":"/opt/mine/other.sh"}]}]},"permissions":{"allow":["Bash(mytool:*)"]}}
 JSON
-bash "$INSTALL" "$PLUG" "$P" >/dev/null
+bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P" >/dev/null
 [ "$(jq '[.hooks.SessionStart[].hooks[].command] | index("/opt/mine/other.sh") != null' "$P/.claude/settings.local.json")" = true ] && ok "preserve: unrelated hook survives" || bad "preserve" "unrelated hook dropped"
 [ "$(jq '.permissions.allow | index("Bash(mytool:*)") != null' "$P/.claude/settings.local.json")" = true ] && ok "preserve: unrelated permission survives" || bad "preserve" "unrelated permission dropped"
 [ "$(jq '[.hooks.SessionStart[].hooks[].command] | map(select(endswith("jj-session-start.sh"))) | length' "$P/.claude/settings.local.json")" = 1 ] && ok "preserve: our SessionStart added exactly once" || bad "preserve" "our hook count != 1"
@@ -87,25 +95,25 @@ P=$(newproj); mkdir -p "$P/.claude"
 cat > "$P/.claude/settings.local.json" <<JSON
 {"hooks":{"SessionStart":[{"matcher":"OLD","hooks":[{"type":"command","command":"$P/.claude/scripts/jj-session-start.sh"}]}]}}
 JSON
-bash "$INSTALL" "$PLUG" "$P" >/dev/null
+bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P" >/dev/null
 [ "$(jq '[.hooks.SessionStart[].hooks[].command] | map(select(endswith("jj-session-start.sh"))) | length' "$P/.claude/settings.local.json")" = 1 ] && ok "stale: exactly one of our SessionStart" || bad "stale" "duplicate/zero after upgrade"
 [ "$(jq '[.hooks.SessionStart[] | select(.matcher=="OLD")] | length' "$P/.claude/settings.local.json")" = 0 ] && ok "stale: OLD matcher gone" || bad "stale" "OLD entry survived"
 
 # ---- Case 5: CLAUDE.md variants ----
 # 5a matching hash -> unchanged, body untouched
 P=$(newproj)
-bash "$INSTALL" "$PLUG" "$P" >/dev/null           # creates CLAUDE.md w/ current hash
+bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P" >/dev/null           # creates CLAUDE.md w/ current hash
 CM_BEFORE=$(cat "$P/CLAUDE.md")
-OUT=$(bash "$INSTALL" "$PLUG" "$P")
+OUT=$(bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P")
 [ "$(cat "$P/CLAUDE.md")" = "$CM_BEFORE" ] && printf '%s\n' "$OUT" | grep -qx 'claude_md=unchanged' && ok "claude_md 5a: matching hash unchanged" || bad "claude_md 5a" "changed or wrong summary"
 # 5b no marker -> prepend, preserve existing
 P=$(newproj); printf '# Existing\n\nkeep me\n' > "$P/CLAUDE.md"
-bash "$INSTALL" "$PLUG" "$P" >/dev/null
+bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P" >/dev/null
 grep -q 'jj-project-setup:start' "$P/CLAUDE.md" && grep -q 'keep me' "$P/CLAUDE.md" && ok "claude_md 5b: prepended, existing kept" || bad "claude_md 5b" "marker or existing content missing"
 # 5c differing hash -> section replaced, surrounding intact
 P=$(newproj); mkdir -p "$P"
 printf '# Top\n<!-- jj-project-setup:start hash:deadbeef -->\nOLD BODY\n<!-- jj-project-setup:end -->\n# Bottom\n' > "$P/CLAUDE.md"
-bash "$INSTALL" "$PLUG" "$P" >/dev/null
+bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P" >/dev/null
 grep -q 'Use jj, not git.' "$P/CLAUDE.md" && ! grep -q 'OLD BODY' "$P/CLAUDE.md" && grep -q '# Top' "$P/CLAUDE.md" && grep -q '# Bottom' "$P/CLAUDE.md" && ok "claude_md 5c: section replaced, surroundings intact" || bad "claude_md 5c" "replace wrong"
 # 5d marker on LINE 1 -> replaced without duplicating the marker pair.
 # 5c always has content above the marker, so the prefix slice is 1,N with N>=1
@@ -117,7 +125,7 @@ grep -q 'Use jj, not git.' "$P/CLAUDE.md" && ! grep -q 'OLD BODY' "$P/CLAUDE.md"
 # recur on every subsequent run.
 P=$(newproj); mkdir -p "$P"
 printf '<!-- jj-project-setup:start hash:deadbeef -->\nOLD BODY\n<!-- jj-project-setup:end -->\n# Bottom\n' > "$P/CLAUDE.md"
-bash "$INSTALL" "$PLUG" "$P" >/dev/null
+bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P" >/dev/null
 s_count=$(grep -c 'jj-project-setup:start' "$P/CLAUDE.md")
 e_count=$(grep -c 'jj-project-setup:end' "$P/CLAUDE.md")
 if [ "$s_count" -eq 1 ] && [ "$e_count" -eq 1 ] && ! grep -q 'deadbeef' "$P/CLAUDE.md" \
@@ -129,7 +137,7 @@ else
 fi
 # 5e re-running over a line-1 marker stays at one pair (the defect compounded
 # per run, so idempotence is the property that actually protects the file).
-bash "$INSTALL" "$PLUG" "$P" >/dev/null
+bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P" >/dev/null
 s_count2=$(grep -c 'jj-project-setup:start' "$P/CLAUDE.md")
 if [ "$s_count2" -eq 1 ]; then
   ok "claude_md 5e: re-run over a line-1 marker stays at one pair"
@@ -146,7 +154,7 @@ fi
 # away.
 P=$(newproj); mkdir -p "$P"
 printf 'Docs: never edit inside the jj-project-setup:start block.\n# Top\n<!-- jj-project-setup:start hash:deadbeef -->\nOLD BODY\n<!-- jj-project-setup:end -->\n# Bottom\n' > "$P/CLAUDE.md"
-bash "$INSTALL" "$PLUG" "$P" >/dev/null
+bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P" >/dev/null
 if grep -q 'Docs: never edit inside' "$P/CLAUDE.md" && grep -q '# Top' "$P/CLAUDE.md" \
    && grep -q '# Bottom' "$P/CLAUDE.md" && grep -q 'Use jj, not git.' "$P/CLAUDE.md" \
    && ! grep -q 'OLD BODY' "$P/CLAUDE.md"; then
@@ -158,7 +166,7 @@ fi
 # working. Regression guard — expected to pass before and after the fix.
 P=$(newproj); mkdir -p "$P"
 printf '<!-- jj-project-setup:start hash:deadbeef -->\nOLD BODY\n<!-- jj-project-setup:end -->\n# Notes\nThis file has a jj-project-setup:start/end managed block.\n' > "$P/CLAUDE.md"
-bash "$INSTALL" "$PLUG" "$P" >/dev/null
+bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P" >/dev/null
 if grep -q 'managed block' "$P/CLAUDE.md" && grep -q 'Use jj, not git.' "$P/CLAUDE.md" \
    && ! grep -q 'OLD BODY' "$P/CLAUDE.md" \
    && [ "$(grep -cE '^[[:space:]]*<!--[[:space:]]*jj-project-setup:start' "$P/CLAUDE.md")" -eq 1 ]; then
@@ -171,7 +179,7 @@ fi
 P=$(newproj); mkdir -p "$P/.claude"
 printf '{not json' > "$P/.claude/settings.local.json"
 RAW_BEFORE=$(cat "$P/.claude/settings.local.json")
-if bash "$INSTALL" "$PLUG" "$P" >/dev/null 2>&1; then bad "malformed" "exited 0 on invalid JSON"; else ok "malformed: non-zero exit"; fi
+if bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P" >/dev/null 2>&1; then bad "malformed" "exited 0 on invalid JSON"; else ok "malformed: non-zero exit"; fi
 [ "$(cat "$P/.claude/settings.local.json")" = "$RAW_BEFORE" ] && ok "malformed: file untouched" || bad "malformed" "file was clobbered"
 [ ! -d "$P/.claude/hooks" ] && ok "malformed: no side effects (hooks/ not created)" || bad "malformed" ".claude/hooks created before abort"
 
@@ -180,7 +188,7 @@ P=$(newproj); mkdir -p "$P/.claude"
 cat > "$P/.claude/settings.local.json" <<JSON
 {"hooks":{"SessionStart":[{"matcher":"startup|resume|clear|compact","hooks":[{"type":"command","command":"/opt/mine/user.sh"},{"type":"command","command":"$P/.claude/scripts/jj-session-start.sh"}]}]}}
 JSON
-bash "$INSTALL" "$PLUG" "$P" >/dev/null
+bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P" >/dev/null
 [ "$(jq '[.hooks.SessionStart[].hooks[].command] | index("/opt/mine/user.sh") != null' "$P/.claude/settings.local.json")" = true ] && ok "colocated: user hook survives" || bad "colocated" "user hook dropped (entry-granularity bug)"
 [ "$(jq '[.hooks.SessionStart[].hooks[].command] | map(select(endswith("jj-session-start.sh"))) | length' "$P/.claude/settings.local.json")" = 1 ] && ok "colocated: our hook present once" || bad "colocated" "our hook count != 1"
 
@@ -213,7 +221,7 @@ JSON
 }
 
 P=$(newproj); oldlayout "$P"
-bash "$INSTALL" "$PLUG" "$P" >/dev/null
+bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P" >/dev/null
 # 8a scripts land in the new home
 for s in jj-session-start.sh require-jj-new.sh jj-workspace-create.sh jj-workspace-remove.sh; do
   [ -x "$P/.claude/hooks/$s" ] && ok "migrate: $s now in .claude/hooks/ +x" || bad "migrate" "$s not in .claude/hooks/"
@@ -248,7 +256,7 @@ done
 P=$(newproj); oldlayout "$P"
 printf '#!/usr/bin/env bash\necho statusline\n' > "$P/.claude/scripts/statusline-jj.sh"
 chmod +x "$P/.claude/scripts/statusline-jj.sh"
-bash "$INSTALL" "$PLUG" "$P" >/dev/null
+bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P" >/dev/null
 [ -f "$P/.claude/scripts/statusline-jj.sh" ] && ok "coexist: statusline-jj.sh survives migration" || bad "coexist" "statusline-jj.sh was DELETED by /project-setup"
 [ -x "$P/.claude/scripts/statusline-jj.sh" ] && ok "coexist: statusline-jj.sh still executable" || bad "coexist" "statusline lost +x"
 [ -d "$P/.claude/scripts" ] && ok "coexist: .claude/scripts/ kept (not empty)" || bad "coexist" ".claude/scripts/ removed while statusline lived there"
@@ -261,9 +269,9 @@ done
 
 # ---- Case 10: re-running after migration is idempotent ----
 P=$(newproj); oldlayout "$P"
-bash "$INSTALL" "$PLUG" "$P" >/dev/null
+bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P" >/dev/null
 MIG_BEFORE=$(cat "$P/.claude/settings.local.json")
-bash "$INSTALL" "$PLUG" "$P" >/dev/null
+bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P" >/dev/null
 [ "$(cat "$P/.claude/settings.local.json")" = "$MIG_BEFORE" ] && ok "migrate-rerun: settings byte-identical" || bad "migrate-rerun" "settings churned on re-run after migration"
 for pair in "SessionStart:jj-session-start.sh" "PreToolUse:require-jj-new.sh" \
             "WorktreeCreate:jj-workspace-create.sh" "WorktreeRemove:jj-workspace-remove.sh"; do
@@ -272,6 +280,107 @@ for pair in "SessionStart:jj-session-start.sh" "PreToolUse:require-jj-new.sh" \
   [ "$n" = 1 ] && ok "migrate-rerun: $ev still has exactly one $base" || bad "migrate-rerun" "$ev grew to $n registrations of $base"
 done
 [ ! -d "$P/.claude/scripts" ] && ok "migrate-rerun: legacy dir stays gone" || bad "migrate-rerun" ".claude/scripts/ reappeared"
+
+# ---------------------------------------------------------------------------
+# #97 tracked mode — the DEFAULT. Which file owns what, and the migration.
+# ---------------------------------------------------------------------------
+INSTALL_MODE=""
+
+echo "=== tracked (default): enforcement is tracked, preferences stay local ==="
+P=$(mktemp -d)
+OUT=$(bash "$INSTALL" "$PLUG" "$P")
+T="$P/.claude/settings.json"
+L="$P/.claude/settings.local.json"
+
+[ -f "$T" ] && ok "tracked: settings.json created" || bad "tracked" "settings.json missing"
+echo "$OUT" | grep -q '^mode=tracked$'            && ok "tracked: summary reports mode" || bad "tracked" "no mode= line"
+echo "$OUT" | grep -q '^settings_tracked=created$' && ok "tracked: summary reports tracked outcome" || bad "tracked" "no settings_tracked= line"
+
+for ev in SessionStart PreToolUse PreCompact WorktreeCreate WorktreeRemove; do
+  [ "$(jq --arg e "$ev" '(.hooks[$e]|length) > 0' "$T")" = true ] \
+    && ok "tracked: $ev registered in settings.json" || bad "tracked" "$ev missing from settings.json"
+done
+[ "$(jq '.permissions.deny | index("Bash(git *)") != null' "$T")" = true ] \
+  && ok "tracked: deny floor is tracked" || bad "tracked" "deny missing from settings.json"
+
+# The split. permissions.allow is a personal convenience list (Q2), so it must
+# NOT be written to the file everyone shares.
+[ "$(jq 'has("permissions") and (.permissions | has("allow"))' "$T")" = false ] \
+  && ok "tracked: allow-list is NOT tracked" || bad "tracked" "allow-list leaked into settings.json"
+[ "$(jq '.permissions.allow | index("Bash(gh *)") != null' "$L")" = true ] \
+  && ok "tracked: allow-list stays local" || bad "tracked" "allow-list missing from settings.local.json"
+
+# THE ONE THAT MATTERS. Hooks merge additively across scopes — measured, both
+# fire — so a hook present in BOTH files runs twice. The local file must be
+# hook-free after a tracked install.
+[ "$(jq 'has("hooks")' "$L")" = false ] \
+  && ok "tracked: no hooks in settings.local.json (would double-fire)" || bad "tracked" "hooks in BOTH files — every handler runs twice"
+
+echo "=== tracked: migrating a project that already had local hooks ==="
+# The realistic upgrade path: a project installed before #97 has all five
+# registrations in settings.local.json. A tracked install must MOVE them, not
+# copy them. This is the case a write-only implementation gets wrong.
+P=$(mktemp -d)
+bash "$INSTALL" --local "$PLUG" "$P" >/dev/null
+[ "$(jq 'has("hooks")' "$P/.claude/settings.local.json")" = true ] || bad "migrate97" "precondition: local install had no hooks"
+# Add an unrelated user hook that must survive the migration untouched.
+tmp=$(jq '.hooks.SessionStart += [{hooks:[{type:"command",command:"/opt/mine/keepme.sh"}]}]' "$P/.claude/settings.local.json")
+printf '%s\n' "$tmp" > "$P/.claude/settings.local.json"
+
+bash "$INSTALL" "$PLUG" "$P" >/dev/null
+L="$P/.claude/settings.local.json"; T="$P/.claude/settings.json"
+
+for ev in SessionStart PreToolUse PreCompact WorktreeCreate WorktreeRemove; do
+  moved_out=$(jq --arg e "$ev" '[(.hooks[$e] // [])[].hooks[]?.command] | map(select(test("jj-(session-start|workspace-create|workspace-remove)|require-jj-new|jj status"))) | length' "$L")
+  [ "$moved_out" = "0" ] \
+    && ok "migrate97: $ev no longer registered locally" || bad "migrate97" "$ev still local — double-fires with the tracked copy"
+done
+[ "$(jq '(.hooks.SessionStart|length) > 0' "$T")" = true ] \
+  && ok "migrate97: hooks landed in settings.json" || bad "migrate97" "hooks did not move to settings.json"
+[ "$(jq '[.hooks.SessionStart[].hooks[].command] | index("/opt/mine/keepme.sh") != null' "$L")" = true ] \
+  && ok "migrate97: an unrelated user hook survives the move" || bad "migrate97" "user hook destroyed by the migration"
+[ "$(jq '(.permissions.deny // []) | index("Bash(git *)")' "$L")" = "null" ] \
+  && ok "migrate97: managed deny entry no longer duplicated locally" || bad "migrate97" "deny entry left in both files"
+
+echo "=== tracked: a blanket .claude/ ignore rule aborts with no side effects ==="
+# Negations cannot re-include a file under an excluded directory, so writing a
+# tracked settings.json into such a repo produces a file that can never be
+# committed. Refuse, explain, and touch nothing — an append-only "fix" here would
+# report success while changing nothing.
+for rule in '.claude/' '.claude' '/.claude/' '.claude/**'; do
+  P=$(mktemp -d)
+  printf '%s\n' "$rule" > "$P/.gitignore"
+  set +e
+  ERR=$(bash "$INSTALL" "$PLUG" "$P" 2>&1 >/dev/null); rc=$?
+  set -e
+  if [ "$rc" -ne 0 ] && [ ! -d "$P/.claude" ] && [ ! -f "$P/CLAUDE.md" ]; then
+    ok "gitignore($rule): aborts non-zero, nothing written"
+  else
+    bad "gitignore($rule)" "rc=$rc, .claude exists=$([ -d "$P/.claude" ] && echo yes || echo no)"
+  fi
+done
+P=$(mktemp -d); printf '.claude/\n' > "$P/.gitignore"
+set +e; ERR=$(bash "$INSTALL" "$PLUG" "$P" 2>&1 >/dev/null); set -e
+printf '%s' "$ERR" | grep -q 'claude/\*' && ok "gitignore: names the replacement rules" || bad "gitignore" "abort message lacks the fix"
+printf '%s' "$ERR" | grep -q -- '--local' && ok "gitignore: offers the --local escape hatch" || bad "gitignore" "abort message lacks --local"
+
+# The escape hatch must actually work in the repo that just aborted.
+P=$(mktemp -d); printf '.claude/\n' > "$P/.gitignore"
+bash "$INSTALL" --local "$PLUG" "$P" >/dev/null 2>&1
+[ -f "$P/.claude/settings.local.json" ] && [ ! -f "$P/.claude/settings.json" ] \
+  && ok "gitignore: --local installs anyway and writes no tracked file" || bad "gitignore" "--local did not bypass the abort"
+
+# A narrowed ignore file must NOT abort — otherwise the guard blocks the very fix
+# it recommends.
+P=$(mktemp -d)
+printf '.claude/*\n!.claude/settings.json\n!.claude/hooks/\n.claude/settings.local.json\n' > "$P/.gitignore"
+bash "$INSTALL" "$PLUG" "$P" >/dev/null 2>&1
+[ -f "$P/.claude/settings.json" ] \
+  && ok "gitignore: the recommended rule set is accepted" || bad "gitignore" "guard rejects its own recommendation"
+# An unrelated ignore file is none of the guard's business.
+P=$(mktemp -d); printf 'node_modules/\n*.log\n' > "$P/.gitignore"
+bash "$INSTALL" "$PLUG" "$P" >/dev/null 2>&1
+[ -f "$P/.claude/settings.json" ] && ok "gitignore: unrelated rules do not trip the guard" || bad "gitignore" "false positive on unrelated rules"
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="


### PR DESCRIPTION
#97 items 1 and 2. **Stacked on #120 → #119 → #116** — merge those first, then retarget.

Implements the five decisions recorded on the issue: tracked is the default (Q1),
hooks + `permissions.deny` are the shareable subset (Q2), `.gitignore` handling
refuses rather than rewrites (Q5), with Q4 dropped as a consequence of Q2.

## Item 2 — the split

| file | contents | tracked? |
|---|---|---|
| `.claude/settings.json` | hooks (SessionStart, PreToolUse, PreCompact, WorktreeCreate, WorktreeRemove) + `Bash(git *)` deny floor | **yes, by default** |
| `.claude/settings.local.json` | `permissions.allow`, plus `statusLine` if `/statusline-jj-setup` is used | no |

Why default-tracked: the two defaults fail asymmetrically. Default-tracked fails
**visibly** — an unwanted `settings.json` shows up in `jj status` and is deleted in
seconds. Default-local fails **invisibly** — a fresh clone or `jj workspace add`
checkout gets CLAUDE.md declaring the jj rules and none of the wiring, so the
rules are weakest exactly where `workspace-jj:kaisen` fans agents out in parallel.

`--local` preserves the pre-#97 single-file behaviour.

### A tracked install also STRIPS hooks from the local file

Measured 2026-07-29: hooks registered at both project and local scope **both
fire**, once each — they merge additively rather than overriding, unlike most
settings, and unlike what the docs imply. So migration is a move, not a copy;
leaving the old registrations behind runs every handler twice.

`permissions.deny` is the easy half — it merges by documented design and is
union-deduped — but the managed entry is dropped from the local file anyway so one
file owns it.

## Item 1 — the `.gitignore` guard

A blanket `.claude/` rule makes a tracked `settings.json` uncommittable, and
appending `!.claude/settings.json` beneath it does **nothing**: neither git nor jj
can re-include a file under an excluded directory. Measured on jj 0.43.0 — with
the blanket rule plus negations, nothing under `.claude/` is tracked.

So tracked mode aborts **before any write** (no scripts, no settings, no CLAUDE.md
edit), naming the replacement rules and the `--local` escape hatch:

```
.claude/*
!.claude/settings.json
!.claude/hooks/
.claude/settings.local.json
```

Refuse rather than rewrite: an append-only "fix" would report success while
changing nothing, leaving a fresh clone enforcing nothing — the same
silent-success shape as #82. Rewriting a user's ignore rules is the most invasive
thing this installer could do in someone else's repository.

Detection covers `.claude/`, `.claude`, `/.claude/`, `/.claude`, `.claude/**` and
`/.claude/**` — every spelling that excludes the directory. Mutation D below shows
why: matching only the literal `.claude/` lets three of four forms through.

## Tests — 89 assertions (was 60)

The original 60 are preserved verbatim, now run under `--local`. They test *merge
semantics* (replace-by-identity, preserving unrelated entries, retiring stale
registrations, aborting on malformed JSON), which both modes share; which file
owns what is the new section's job.

29 new assertions cover the split, the migration, and the guard — including that
an unrelated user hook survives the move, that the guard accepts its own
recommended rule set, and that unrelated ignore rules do not trip it.

Mutation-verified, since they were green on first run:

| mutation | result |
|---|---|
| don't strip hooks from local | **5 failed** — every event double-registered |
| leak the allow-list into the tracked file | 1 failed |
| drop the `.gitignore` guard | 6 failed |
| guard matches only the literal `.claude/` | 3 failed |

## Not included

`project-setup-jj` 0.10.0 per #84. 19 suites / 670 assertions / 0 failing.

Item 3 (dogfooding this in *this* repo — swapping its own blanket `.claude/` and
committing `settings.json` + `hooks/`) is deliberately separate: it is a change to
this repository's tracked files rather than to the tool, and it should land after
this is reviewed. Note that this repo currently has a blanket `.claude/`, so
running `/project-setup` here will hit the new abort — which is the guard working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
