### PR TITLE
chore: dogfood tracked .claude settings in this repo (#97 item 3)

### DIFF
--- a/.claude/hooks/jj-session-start.sh
+++ b/.claude/hooks/jj-session-start.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# SessionStart hook: Show jj context and workflow reminder
+# Outputs JSON with additionalContext for Claude Code
+
+set -euo pipefail
+
+# Exit silently if not in a jj repo
+if ! jj root >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Gather jj context
+current_change=$(jj log -r @ --no-graph -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read current change)")
+working_status=$(jj status 2>/dev/null || echo "(unable to read status)")
+repo_config=$(jj config list -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read config)")
+
+# Escape string for JSON embedding
+escape_for_json() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '%s' "$s"
+}
+
+context="== jj Session Context ==
+
+Current change:
+${current_change}
+
+Working copy status:
+${working_status}
+
+Repository config (JSON):
+${repo_config}
+
+== jj Workflow Reminder ==
+- Use \`jj new\` to start a fresh change before making edits
+- Use \`jj describe -m \"...\"\` to set intent on the current change
+- Use \`jj diff\` to review working copy changes
+- Never use raw git commands — use jj equivalents"
+
+escaped_context=$(escape_for_json "$context")
+
+cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "${escaped_context}"
+  }
+}
+EOF
+
+exit 0

--- a/.claude/hooks/jj-workspace-create.sh
+++ b/.claude/hooks/jj-workspace-create.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WorktreeCreate hook: Create a jj workspace for Claude Code worktree isolation
+# Input (stdin): JSON with "name" and "cwd" fields
+# Output (stdout): Absolute path to created workspace directory
+
+input=$(cat)
+name=$(echo "$input" | jq -r '.name')
+cwd=$(echo "$input" | jq -r '.cwd')
+
+# Create workspace OUTSIDE the repo to prevent jj's auto-snapshotting in the
+# default workspace from attributing workspace file edits to @.
+# Using /tmp ensures the workspace directory is not under the repo root.
+DIR="/tmp/jj-workspaces/$(basename "$cwd")/$name"
+mkdir -p "$(dirname "$DIR")"
+
+# Pin workspace to the current working copy's parents (not the working copy itself).
+# Without --revision, concurrent workspaces can see each other's changes and chain
+# instead of branching independently. Pinning ensures each workspace creates an
+# independent change from the same base — the fan-out pattern kaisen expects.
+parent_rev=$(jj -R "$cwd" log -r '@-' --no-graph -T 'commit_id' 2>/dev/null || echo "")
+
+if [ -n "$parent_rev" ]; then
+  jj -R "$cwd" workspace add "$DIR" --name "workspace-$name" --revision "$parent_rev" >&2
+else
+  # Fallback: no parent found (empty repo?), use default behavior
+  jj -R "$cwd" workspace add "$DIR" --name "workspace-$name" >&2
+fi
+
+# Print the absolute path for Claude Code
+echo "$DIR"

--- a/.claude/hooks/jj-workspace-remove.sh
+++ b/.claude/hooks/jj-workspace-remove.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WorktreeRemove hook: Remove a jj workspace created by WorktreeCreate
+# Input (stdin): JSON with "worktree_path" and "cwd" fields
+
+input=$(cat)
+# Claude Code sends .worktree_path in the hook JSON (can't change the key name)
+workspace_path=$(echo "$input" | jq -r '.worktree_path')
+cwd=$(echo "$input" | jq -r '.cwd')
+
+# Extract workspace name from directory name
+name=$(basename "$workspace_path")
+
+# Forget the workspace in jj (stop tracking it)
+# Use -R to target the repo, ignore errors if workspace already forgotten
+jj -R "$cwd" workspace forget "workspace-$name" 2>/dev/null || true
+
+# Remove the workspace directory
+rm -rf "$workspace_path"

--- a/.claude/hooks/require-jj-new.sh
+++ b/.claude/hooks/require-jj-new.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# PreToolUse hook: Advise Claude if editing into a non-empty jj change
+# Outputs an informational message — does NOT block or prompt the user
+
+# Only fire in jj repos
+jj root >/dev/null 2>&1 || exit 0
+
+# Check if current change already has content
+status=$(jj log -r @ --no-graph -T 'if(empty, "empty", "has-content")' 2>/dev/null)
+
+if [ "$status" = "has-content" ]; then
+  echo "Note: Current jj change already has content. Consider running \`jj new\` to start a fresh change if appropriate."
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,62 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/jj-session-start.sh",
+            "async": false
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/require-jj-new.sh"
+          }
+        ]
+      }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/jj-workspace-create.sh"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/jj-workspace-remove.sh"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jj status >/dev/null 2>&1 || true"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "deny": [
+      "Bash(git *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
 *.DS_Store
-.claude/
+# Track the shareable half of .claude/, ignore the personal half. Must be
+# `.claude/*` and not `.claude/` or `.claude/**`: a negation cannot re-include a
+# file whose parent directory is excluded, so the blanket forms make every `!`
+# below inert and nothing gets tracked.
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+.claude/settings.local.json
 .jj/
 node_modules/
 *.log


### PR DESCRIPTION
Dogfoods the tracked-settings default that #121 shipped, against this repo — the last open item on #97.

## What changed

Swaps this repo's blanket `.claude/` ignore rule for a carve-out, then runs `project-setup-jj` 0.10.0 in its new default tracked mode.

Now tracked:

- `.claude/settings.json` — the five hook registrations plus `permissions.deny`
- `.claude/hooks/` — the four handlers

Still local, per the Q2 decision: `settings.local.json` and the statusline it points at.

## The ignore pattern is load-bearing

It must be `.claude/*`, **not** `.claude/` or `.claude/**`. A negation cannot re-include a file whose parent directory is excluded, so either blanket form makes every `!` line inert — and does it silently, tracking nothing while reading as correct. Verified with `jj file list` rather than by inspection: five files under `.claude/` are tracked.

This is the same trap the installer's guard aborts on, which is why running `/project-setup` here refused to proceed until the rule was fixed. The guard worked on its own author.

## Hooks live in exactly one file

The handlers were registered in `settings.local.json`. Hooks merge additively across scopes rather than overriding, so leaving that copy would have fired every handler twice. The installer stripped it; `settings.local.json` now holds only `permissions` and `statusLine` (`has("hooks") == false`).

## Verification

- `jj file list` confirms the five tracked paths — the carve-out actually works
- All five hook commands resolve to `.claude/hooks/…`
- All 20 test suites pass, including the script-copy-parity lint
- `claude_md=unchanged` — the VCS section was already current

## Closing #97

Q1 (tracked by default), Q2 (hooks + `permissions.deny` only), Q3 (this repo tracks its own) and Q5 (refuse-and-explain on a blanket rule) are all decided and implemented across #117, #121 and this change.

Q4 — whether `$CLAUDE_PROJECT_DIR` expands in `statusLine.command` — is moot rather than answered. Q2 keeps `statusLine` in `settings.local.json` permanently, so its absolute path is never shared with a collaborator and nothing depends on converting it. Worth re-filing if `statusLine` ever becomes shareable.

Closes #97
