### PR TITLE
fix(permission-gateway): reduce the Bash bypass surface at protected config paths (#123)

### DIFF
--- a/plugins/permission-gateway/.claude-plugin/plugin.json
+++ b/plugins/permission-gateway/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "permission-gateway",
   "description": "Tiered permission gateway — auto-approves safe commands, blocks dangerous ones, escalates edge cases to human",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/permission-gateway/README.md
+++ b/plugins/permission-gateway/README.md
@@ -16,7 +16,7 @@ Seven evaluation stages, one exit per command. Each decision is logged for rule 
 
 | Tier | Action | Examples |
 |------|--------|---------|
-| **Gate-the-Gate** | Confirms config writes | Write/Edit to `*permission-gate*`, `.claude/settings*`, or `.claude-plugin/` paths |
+| **Gate-the-Gate** | Confirms config writes | Any write — Write, Edit, or Bash — to `*permission-gate*`, `.claude/settings*`, `.claude/hooks/`, `.claude/scripts/`, or `.claude-plugin/` paths |
 | **Deny** | Blocked, never runs | `rm -rf /`, `sudo`, `eval`, `dd`, `kill -9` |
 | **Confirm** | Human sees prompt | `npm publish`, `ssh`, `mv`, `docker run`, `xargs` |
 | **Approve** | Silent, no prompt | `ls`, `npm test`, `jj log`, `cargo build`, `grep` |
@@ -26,7 +26,21 @@ Seven evaluation stages, one exit per command. Each decision is logged for rule 
 
 **One-way ratchet:** Hardcoded deny runs before `.local.md` rules. No override can loosen a deny — the deny tier is an immutable floor. This prevents prompt injection attacks where malicious content instructs Claude to write `.local.md` rules promoting dangerous commands.
 
-**Gate the gate:** Writes to the gateway's own scripts/config (`*permission-gate*`), hook registration (`.claude/settings*`), or the plugin manifest (`.claude-plugin/`) trigger a human confirmation prompt via a separate Write/Edit hook (`gate-config-writes.sh`). The injection attempt is caught before the file is modified.
+**Gate the gate:** Writes to the gateway's own scripts/config (`*permission-gate*`), hook registration (`.claude/settings*`), the hook scripts themselves (`.claude/hooks/`, and `.claude/scripts/` for projects that predate the move), or the plugin manifest (`.claude-plugin/`) trigger a human confirmation prompt. The injection attempt is caught before the file is modified.
+
+This is enforced on **two** paths, because one is not enough. `gate-config-writes.sh` covers the `Write` and `Edit` tools. `permission-gate.sh` covers `Bash`, which reaches the same files four ways — a redirect target (`>` and `>>` alike), a write verb such as `tee`, `cp`, `dd`, `install` or `truncate`, a `cd` into a protected directory followed by a write to a bare filename, or a write whose target cannot be read statically at all. Every one of these returned *no decision at all* rather than a prompt before #123.
+
+Matching runs on a quote-stripped, separator-normalized copy of the command, and captures whole command segments rather than single tokens. A literal substring test reads only the path as written, so `.claude//settings.json`, `.claude/./settings.json`, `cd '.claude'` and `> $(echo .claude/settings.json)` all reach the same files while matching nothing. Every equivalent spelling is otherwise a separate hole.
+
+Only writes are gated — reading or grepping a protected path stays silent, or the prompt becomes noise on ordinary inspection and gets tuned out. Where precision and safety conflict the gate over-asks: any argument of a write verb counts as a candidate destination rather than parsing flags for the real one, and any `$` or backtick in a target makes it unreadable and therefore worth a prompt. So `echo x > $OUT` asks, while `echo $VERSION > version.txt` — dynamic on the *source* side, literal target — stays silent.
+
+### Why the last rule is about the safelist, not the paths
+
+The Tier-1 safelist approves on the **leading verb alone**, and `echo`, `cat`, `cd` and `cp` are all on it. That means a protected-path check that fails to recognise a spelling does not degrade to "no opinion" — it degrades to an explicit approve, several dozen lines later. Every bypass found during review reached the filesystem through that amplifier rather than through the gap itself. Treating an unreadable target as a prompt is what stops an unrecognised shell construct from becoming an approval.
+
+**Known limit — this is shape matching, not argument resolution.** It reasons about the text of a command rather than the files that command would touch, and it cannot be proved exhaustive. Three review rounds each found a new class that slipped through: relative and `cd` path forms, then quoted directory names and `cp -t DEST src`, then command substitution — and a sweep immediately after the third fix found ANSI-C quoting (`$'\056claude/...'`) still open. Constructs it does not recognise specifically (`pushd`, a subshell, a `cd` via variable) fall through to the Tier-2 catch-all, which still asks: weaker wording, not a bypass. #123 remains open for resolving arguments properly.
+
+The two copies of the protected-path set are held identical by `tests/test-protected-paths-parity.sh`; drift between them would silently reopen the gap on whichever tool the stale copy handles, with every other suite still green.
 
 **Full-string scanning:** Dangerous patterns (`rm -rf`, `> ~/path`) are scanned in the full command string, not just the leading command. This prevents bypass via wrappers like `find -exec`, `xargs`, or redirect clobbers to paths outside the project directory.
 
@@ -83,14 +97,18 @@ The command scans the log, normalizes commands into patterns (`pip install reque
 ## Components
 
 - `.claude-plugin/plugin.json` — hook registration (Bash, Write, Edit matchers)
-- `scripts/permission-gate.sh` — tiered evaluation engine (Bash commands)
+- `scripts/permission-gate.sh` — tiered evaluation engine (Bash commands), including gate-the-gate for Bash writes at protected paths
 - `scripts/gate-config-writes.sh` — gate-the-gate hook (Write/Edit to config files)
 - `prompts/permission-evaluate.md` — Tier 2 LLM evaluation prompt template
 - `commands/tune.md` — `/tune` command for log-based rule self-tuning
-- `tests/test-permission-gate.sh` — 127 tests
+- `tests/test-permission-gate.sh` — tiered evaluation, including the Bash routes to protected paths
+- `tests/test-gate-config-writes.sh` — the Write/Edit gate, including its fail-closed paths
+- `tests/test-protected-paths-parity.sh` — holds the two copies of the protected-path set identical
 
 ## Testing
 
 ```bash
-bash plugins/permission-gateway/tests/test-permission-gate.sh
+for t in plugins/permission-gateway/tests/test-*.sh; do bash "$t"; done
 ```
+
+Suite sizes are deliberately not quoted here — a hand-written count drifts silently the first time someone adds a case, and a stale number reads as authoritative (see #112 for the same failure with version strings). Run the suites for the current figure.

--- a/plugins/permission-gateway/scripts/permission-gate.sh
+++ b/plugins/permission-gateway/scripts/permission-gate.sh
@@ -459,6 +459,184 @@ if echo "$command_normalized" | grep -qE '(^|[;&|]\s*)find\s.*(-exec|-delete)'; 
   ask "find with -exec/-delete can be destructive — requires human confirmation."
 fi
 
+# Protected config paths reached via Bash (#123)
+#
+# gate-config-writes.sh guards these same paths, but it is registered on Write
+# and Edit only, so a Bash write never reaches it. The redirect check below
+# deliberately exempts relative targets — right for ordinary work, wrong for the
+# handful of paths that decide what this gate itself enforces. Measured before
+# this existed: `echo x > .claude/settings.json` produced NO decision at all,
+# not ask and not deny, so the write proceeded under the ambient permission
+# mode. #97 sharpened it by tracking .claude/, making those files the
+# enforcement surface for every fresh clone and every jj workspace.
+#
+# The path set is duplicated from gate-config-writes.sh rather than sourced: a
+# shared file would itself become a bypass target, and one more thing needing a
+# gate. Change one, change the other.
+PROTECTED_PATHS_RE='(permission-gate|\.claude/settings|\.claude/hooks/|\.claude/scripts/|\.claude-plugin/)'
+
+# Directory forms, for the `cd` route below. A bare `.claude` does not match
+# PROTECTED_PATHS_RE (which wants `.claude/settings`, `.claude/hooks/`, ...), but
+# `cd`-ing into it leaves the working directory one bare filename away from every
+# protected file.
+PROTECTED_DIRS_RE='(\.claude([^[:alnum:]_-]|$)|\.claude-plugin([^[:alnum:]_-]|$)|permission-gate)'
+
+# Only WRITES count. Naming a protected path is not writing to one — `cat
+# .claude/settings.json` and `grep -r x .claude/hooks/` must stay silent, or the
+# gate becomes noise on ordinary inspection and gets tuned out.
+#
+# Matching runs on a quote-stripped, separator-normalized copy. A literal
+# substring test reads only the path as WRITTEN, so every equivalent spelling of
+# the same file is a separate hole:
+#
+#   * `.claude//settings.json` and `.claude/./settings.json` reach the same file
+#     while matching nothing.
+#   * `cd '.claude'` defeated a boundary that wanted `/` or end-of-line right
+#     after `.claude`, because the closing quote sat there instead — and quoting
+#     a short bare directory name is the most natural thing to type.
+#
+# Quotes are stripped first, then separators collapsed. The `/./` substitution
+# runs twice because a global substitution resumes after each replacement and so
+# skips the overlap in `/././`. Stripping quotes can make a quoted `>` inside a
+# string look like a redirect; that direction costs a prompt, never a bypass.
+cmd_paths=$(printf '%s' "$command_normalized" \
+  | sed -e "s/['\"]//g" -e 's|/\./|/|g' -e 's|/\./|/|g' -e 's|//*|/|g')
+
+# Fails closed on a matcher error, mirroring gate-config-writes.sh: grep's
+# contract is 0 = match, 1 = no match, anything else = broken, and a broken
+# matcher must never read as "no match". Always called as an `if` condition,
+# where the ERR trap and `set -e` are both exempt, so a benign exit 1 stays quiet.
+contains_protected() {
+  local rc=0
+  printf '%s' "$1" | grep -qiE "$PROTECTED_PATHS_RE" || rc=$?
+  if [ "$rc" -gt 1 ]; then
+    ask "Permission gateway: could not evaluate a write target (matcher error) and is failing closed. Human approval required."
+  fi
+  return "$rc"
+}
+
+protected_route=""
+
+# Route 1 — redirect targets, `>` and `>>` alike. Appending a permissive rule
+# loosens a settings file as effectively as clobbering it, and the existing
+# check below matches only `>`. Relative targets are NOT exempt here; that
+# exemption is precisely the bug.
+# Capture from the `>` to the next command separator, NOT the next whitespace.
+# A single-token capture stopped at the space inside `$(echo .claude/...)`, so
+# the protected substring was truncated away before it could be matched. Route 2
+# was immune only by accident, having been changed to whole-segment capture for
+# an unrelated reason last round.
+redirect_rc=0
+redirect_targets=$(printf '%s' "$cmd_paths" \
+  | grep -oE '>>?[^;&|]*') || redirect_rc=$?
+if [ "$redirect_rc" -gt 1 ]; then
+  ask "Permission gateway: could not scan redirect targets (matcher error) and is failing closed. Human approval required."
+fi
+if [ -n "$redirect_targets" ] && contains_protected "$redirect_targets"; then
+  protected_route="redirect"
+fi
+
+# Route 2 — verbs that write a file named as a plain argument, with no redirect
+# to catch. The verb must be at COMMAND POSITION: matching it anywhere made
+# `grep -rn tee .claude/hooks/` — searching for the word "tee" — ask.
+#
+# ANY argument of such a verb counts as a candidate destination. An earlier
+# version took cp's and install's destination to be the last argument, so that an
+# ordinary backup reading *out* of a protected directory stayed quiet. That
+# precision is not safely reachable: `cp -t .claude/hooks/ f` puts the
+# destination first and `cp a b -v` puts a flag last, and both were silent.
+# Silent is especially bad here — `cp` is on the Tier-1 safelist below
+# (`^(mkdir|cp|touch|ln)\b`), so a miss reaches an explicit approve rather than
+# merely no opinion. Flag parsing is an open-ended surface (`-t`,
+# `--target-directory=`, `-T`, combined shorts like `-vt`) on which every
+# unhandled form is another silent approve, so this over-asks instead: the cost
+# is a prompt when copying a protected file elsewhere.
+#
+# `mv`, `rm` and `sed -i` are absent deliberately: each already asks via a rule
+# above that ignores its target entirely, so listing them adds nothing. Verb
+# enumeration is not airtight and is not claimed to be — the general fix is
+# resolving every argument against the protected set, tracked in #123.
+if [ -z "$protected_route" ]; then
+  seg_rc=0
+  write_segments=$(printf '%s' "$cmd_paths" \
+    | grep -oE '(^|[;&|][[:space:]]*)(tee|cp|dd|install|truncate)[[:space:]][^;&|]*') || seg_rc=$?
+  if [ "$seg_rc" -gt 1 ]; then
+    ask "Permission gateway: could not scan for write verbs (matcher error) and is failing closed. Human approval required."
+  fi
+  if [ -n "$write_segments" ] && contains_protected "$write_segments"; then
+    protected_route="write verb"
+  fi
+fi
+
+# Route 3 — `cd` into a protected directory, then write to a bare filename.
+# `cd .claude && echo x > settings.json` is ordinary shell, and after the cd the
+# protected substring never appears in the command at all: routes 1 and 2 both
+# see only `settings.json`. Resolving that properly means tracking the working
+# directory across a command chain, which this gate does not do, so it asks
+# whenever a protected `cd` and any write route appear together. Reading after
+# such a cd stays silent — `cd .claude && cat settings.json` is inspection.
+if [ -z "$protected_route" ]; then
+  cd_rc=0
+  cd_targets=$(printf '%s' "$cmd_paths" \
+    | grep -oE '(^|[;&|][[:space:]]*)cd[[:space:]]+[^;&|]*') || cd_rc=$?
+  if [ "$cd_rc" -gt 1 ]; then
+    ask "Permission gateway: could not scan cd targets (matcher error) and is failing closed. Human approval required."
+  fi
+  if [ -n "$cd_targets" ]; then
+    cd_match_rc=0
+    printf '%s' "$cd_targets" | grep -qiE "$PROTECTED_DIRS_RE" || cd_match_rc=$?
+    if [ "$cd_match_rc" -gt 1 ]; then
+      ask "Permission gateway: could not evaluate a cd target (matcher error) and is failing closed. Human approval required."
+    fi
+    if [ "$cd_match_rc" -eq 0 ]; then
+      write_rc=0
+      printf '%s' "$cmd_paths" \
+        | grep -qE '(>|(^|[;&|][[:space:]]*)(tee|cp|dd|install|truncate)[[:space:]])' || write_rc=$?
+      if [ "$write_rc" -gt 1 ]; then
+        ask "Permission gateway: could not scan for a write after cd (matcher error) and is failing closed. Human approval required."
+      fi
+      if [ "$write_rc" -eq 0 ]; then
+        protected_route="cd into a protected directory, then write"
+      fi
+    fi
+  fi
+fi
+
+# Route 4 — a write whose TARGET cannot be read statically. Command
+# substitution, backticks and parameter expansion all produce their value at run
+# time, so no amount of matching on the command text can say whether the target
+# is protected.
+#
+# This exists because of the amplifier, not the gap. The Tier-1 safelist below
+# approves on the LEADING VERB alone, and `echo`, `cat` and `cp` are all on it —
+# so a target this block cannot read does not degrade to "no opinion", it
+# degrades to an explicit approve. Every bypass found across three review rounds
+# reached the filesystem that way. An unreadable target must therefore cost a
+# prompt.
+#
+# Deliberately restricted to the TARGET side: `echo $VERSION > version.txt` is
+# ordinary work and stays silent, because the dynamic value is on the source.
+if [ -z "$protected_route" ]; then
+  dyn_rc=0
+# ANY `$`, not an enumerated list of expansion forms. Listing `$(`, `${` and
+# `$NAME` left `$'\056claude/...'` — ANSI-C quoting, which spells `.` as an octal
+# escape — silent, found by sweeping right after the previous enumeration was
+# fixed. The question the gate can actually answer is "does this target contain
+# something resolved at run time", and any `$` or backtick answers it.
+  printf '%s' "$redirect_targets$write_segments" \
+    | grep -qE '[$`]' || dyn_rc=$?
+  if [ "$dyn_rc" -gt 1 ]; then
+    ask "Permission gateway: could not scan a write target for dynamic expansion (matcher error) and is failing closed. Human approval required."
+  fi
+  if [ "$dyn_rc" -eq 0 ]; then
+    protected_route="write to a target this gate cannot read statically"
+  fi
+fi
+
+if [ -n "$protected_route" ]; then
+  ask "Writing to permission-gateway or hook configuration via Bash ($protected_route) — requires human confirmation. This file controls which commands are auto-approved, blocked, or which hooks are active."
+fi
+
 # Redirect clobber — > (not >>) to paths outside project working directory
 # ./relative and bare filenames are fine; absolute paths and ~/ deserve confirmation
 if echo "$command_normalized" | grep -qE '[^>]>\s*[^>]'; then

--- a/plugins/permission-gateway/tests/test-permission-gate.sh
+++ b/plugins/permission-gateway/tests/test-permission-gate.sh
@@ -10,9 +10,15 @@ fail=0
 # Helper: run gate with a command string, capture output and exit code
 run_gate() {
   local cmd="$1"
-  local json='{"tool_input":{"command":"'"$cmd"'"},"tool_name":"Bash","hook_event_name":"PreToolUse"}'
+  # Build the payload with jq, never by string interpolation. Interpolating a
+  # command containing a double quote produced INVALID JSON, which the gate's
+  # ERR trap turns into `ask` — so any assertion expecting `ask` passed for the
+  # wrong reason, and no assertion could express a double-quoted command at all.
+  # That is a vacuous-test generator sitting under every case in this file.
+  local json
+  json=$(printf '%s' "$cmd" | jq -Rc '{tool_input:{command:.},tool_name:"Bash",hook_event_name:"PreToolUse"}')
   local output
-  output=$(echo "$json" | bash "$GATE" 2>/dev/null) || true
+  output=$(printf '%s' "$json" | bash "$GATE" 2>/dev/null) || true
   echo "$output"
 }
 
@@ -387,6 +393,128 @@ assert_decision "no-misfire: deny path"    "rm -rf /"      "deny"
 assert_decision "no-misfire: ask path"     "git push origin main" "ask"
 assert_decision "no-misfire: approve path" "ls -la"        "silent"
 assert_decision "no-misfire: tier2 clean"  "htop"          "ask"
+
+# ---- Protected config paths reached via Bash (#123) ----
+# gate-config-writes.sh is registered on Write/Edit only. Everything below
+# arrives as a Bash tool call, so it never reaches that gate — and the redirect
+# check above deliberately ignores relative targets ("./relative and bare
+# filenames are fine"), which is correct for ordinary work and wrong for the
+# handful of paths that decide what the gate itself enforces.
+#
+# Measured before the fix: every one of these returned NO decision at all —
+# not ask, not deny — so the write proceeded under the ambient permission mode.
+echo "=== Protected config paths via Bash (#123) ==="
+assert_decision "clobber settings.json (relative)"   "echo pwned > .claude/settings.json"                 "ask"
+assert_decision "clobber settings.json (leading ./)" "echo x > ./.claude/settings.json"                   "ask"
+assert_decision "append to settings.json"            "echo pwned >> .claude/settings.json"                "ask"
+assert_decision "truncate a hook script"             "cat /dev/null > .claude/hooks/require-jj-new.sh"    "ask"
+assert_decision "clobber legacy scripts dir"         "echo x > .claude/scripts/block-raw-git.sh"          "ask"
+assert_decision "clobber the gate itself"            "echo x > plugins/permission-gateway/scripts/permission-gate.sh" "ask"
+assert_decision "tee into settings.json"             "tee .claude/settings.json < /dev/null"              "ask"
+assert_decision "cp over a hook script"              "cp /dev/null .claude/hooks/require-jj-new.sh"       "ask"
+# Deliberately NOT asserted here: `mv` and `rm` at a protected path. Both already
+# ask via generic rules that ignore the target entirely, so an assertion on them
+# would pass with or without this fix — coverage that measures nothing. Same
+# reason `printf` is avoided above: it is not Tier-1, so it asks about every
+# target and would hide whether the protected-path check ran at all.
+
+# Ordinary work must stay ungated — a fix that asks about every relative
+# redirect, or about merely NAMING a protected path, is worse than the gap.
+assert_decision "ordinary relative redirect"         "echo hi > notes.txt"                                "silent"
+assert_decision "ordinary nested redirect"           "echo test > ./src/fixture.txt"                      "silent"
+assert_decision "reading a protected file"           "cat .claude/settings.json"                          "silent"
+assert_decision "grepping a protected dir"           "grep -r foo .claude/hooks/"                         "silent"
+
+# A literal substring test sees only the path as WRITTEN. These three shapes all
+# reach the same file and were all silent when first implemented — found in
+# review, not by the tests above, which is the point: the cases you think of are
+# the ones your matcher already handles.
+echo "=== Protected paths reached by a path the matcher does not read literally (#123) ==="
+# 1. cd first, then a bare filename. Utterly ordinary shell, and after the cd the
+#    protected substring never appears in the command at all.
+assert_decision "cd then clobber"                    "cd .claude && echo pwned > settings.json"           "ask"
+assert_decision "cd then tee"                        "cd .claude; tee settings.json < /dev/null"          "ask"
+assert_decision "cd into hooks then clobber"         "cd .claude/hooks && echo x > require-jj-new.sh"     "ask"
+# 2. Redundant separators — same file, non-literal spelling, no cd required.
+assert_decision "double slash"                       "echo x > .claude//settings.json"                    "ask"
+assert_decision "dot segment"                        "echo x > .claude/./settings.json"                   "ask"
+
+# The cd rule must not swallow ordinary work: cd somewhere harmless, or cd into
+# a protected directory and only READ.
+assert_decision "cd elsewhere then write"            "cd src && echo x > foo.txt"                         "silent"
+assert_decision "cd into protected then read"        "cd .claude && cat settings.json"                    "silent"
+
+# A grep whose SEARCH TERM happens to be a write verb must stay silent — this
+# fired `ask` when the verb check matched at any command position.
+assert_decision "grep for the word tee"              "grep -rn tee .claude/hooks/"                        "silent"
+
+# DELIBERATE REVERSAL, second review round. This asserted "silent" when the
+# destination was taken to be cp's last argument, so that reading OUT of a
+# protected directory stayed quiet. That precision was not safely reachable:
+# `cp -t .claude/hooks/ f` puts the destination first and `cp a b -v` puts a flag
+# last, and BOTH were silent — worse than ordinary silence, because `cp` is on
+# the Tier-1 safelist (`^(mkdir|cp|touch|ln)\b`), so a miss reaches an explicit
+# approve rather than merely no opinion.
+#
+# Flag parsing is an open-ended surface (`-t`, `--target-directory=`, `-T`,
+# combined shorts like `-vt`) where every form not handled is another silent
+# approve. So cp/install now treat ANY argument as a candidate destination, the
+# same tradeoff already made for tee/truncate/dd: over-ask rather than
+# under-ask. The cost is this one prompt on an uncommon operation.
+assert_decision "backup out of a protected dir"      "cp .claude/hooks/require-jj-new.sh /tmp/backup.sh"  "ask"
+# ...while writing INTO one still asks.
+assert_decision "restore into a protected dir"       "cp /tmp/backup.sh .claude/hooks/require-jj-new.sh"  "ask"
+
+# ---- Quoting and flag placement (#123, second review round) ----
+# Both classes below were silent bypasses in the first redesign. They share a
+# root cause: the matcher reasons about the shape of the command text, so every
+# equivalent spelling of the same write is a separate hole. Enumerating those
+# spellings is what keeps failing — see #123 for the argument-resolution fix.
+echo "=== Quoting and flag placement (#123) ==="
+# The boundary in PROTECTED_DIRS_RE wanted `/` or end-of-line straight after
+# `.claude`; a closing quote sat there instead. Quoting a short bare directory
+# name is the single most natural thing to type.
+assert_decision "cd single-quoted target"            "cd '.claude' && echo pwned > settings.json"         "ask"
+assert_decision "cd double-quoted target"            'cd ".claude" && echo pwned > settings.json'         "ask"
+assert_decision "cd quoted plugin dir"               "cd '.claude-plugin' && echo x > plugin.json"        "ask"
+# NOT asserted: `echo x > '.claude/settings.json'`. It passes with quote-stripping
+# ablated, because redirect matching already tolerated surrounding quotes — so it
+# cannot tell "feature present" from "feature absent". Same vacuous shape as the
+# `printf`/`mv` cases dropped in the first round. The `cd` cases above are what
+# actually exercise quote-stripping.
+# Destination not last, and destination followed by a flag.
+assert_decision "cp -t with destination first"       "cp -t .claude/hooks/ require-jj-new.sh"             "ask"
+assert_decision "cp with trailing flag"              "cp require-jj-new.sh .claude/hooks/require-jj-new.sh -v" "ask"
+# Quoting must not turn ordinary work noisy.
+assert_decision "quoted ordinary redirect"           "echo x > 'notes.txt'"                               "silent"
+assert_decision "cd quoted ordinary dir"             "cd 'src' && echo x > foo.txt"                       "silent"
+
+# ---- Targets the gate cannot read statically (#123, third review round) ----
+# Routes 1 and 3 captured a single whitespace-delimited token, so the space
+# inside `$(echo .claude)` truncated the capture before the protected substring
+# was ever reached. Route 2 was immune purely by accident — the previous round's
+# "any argument counts" change made it capture the whole segment instead.
+#
+# These are not merely missed: `echo` and `cd` are on the Tier-1 safelist below,
+# so a miss stops being "no opinion" and becomes an explicit approve. That
+# amplifier is what turned each of these rounds' gaps into a full bypass.
+echo "=== Targets the gate cannot read statically (#123) ==="
+assert_decision "command substitution in cd"         "cd \$(echo .claude) && echo pwned > settings.json"  "ask"
+assert_decision "command substitution in redirect"   "echo pwned > \$(echo .claude/settings.json)"        "ask"
+assert_decision "backticks in redirect"              "echo pwned > \`echo .claude/settings.json\`"        "ask"
+# A write whose target is only known at runtime cannot be checked at all, so it
+# must not be auto-approved on the strength of its leading verb.
+assert_decision "variable redirect target"           "echo x > \$OUT"                                     "ask"
+assert_decision "variable write-verb target"         "tee \$LOGFILE"                                      "ask"
+# ...but a dynamic value on the SOURCE side, written to a literal target, is
+# ordinary work and must stay quiet.
+assert_decision "dynamic source, literal target"     "echo \$VERSION > version.txt"                       "silent"
+# ANSI-C quoting spells `.` as \056, so the protected substring never appears and
+# no expansion keyword does either. Found while sweeping AFTER the third review
+# round fixed command substitution — i.e. the enumeration had already failed
+# again. The rule is therefore not "these expansion forms" but "any \$ in a write
+# target means the target cannot be read", which is a property rather than a list.
+assert_decision "ansi-c quoted target"               "echo x > \$'\\056claude/settings.json'"             "ask"
 
 # ---- Summary ----
 echo ""

--- a/plugins/permission-gateway/tests/test-protected-paths-parity.sh
+++ b/plugins/permission-gateway/tests/test-protected-paths-parity.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The protected-path set exists TWICE: once in gate-config-writes.sh (which sees
+# Write/Edit) and once in permission-gate.sh (which sees Bash). They were
+# duplicated on purpose — a shared file would itself be a bypass target, and one
+# more thing needing a gate — but duplication buys that safety with a drift risk,
+# and drift here is silent. Widening one copy while leaving the other narrower
+# reopens #123 on whichever tool the stale copy handles, and every existing test
+# stays green because each suite exercises only its own script.
+#
+# This lint is the thing that fails instead. It compares the two regexes
+# literally; it does not re-derive either from the other, because a corpus taken
+# from the artifact under test cannot detect that artifact's drift.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GATE="$SCRIPT_DIR/../scripts/permission-gate.sh"
+CONFIG_GATE="$SCRIPT_DIR/../scripts/gate-config-writes.sh"
+
+pass=0
+fail=0
+
+# Pull the first single-quoted group that starts with the permission-gate token
+# out of each file. Anchored on the token rather than on a line number or a
+# variable name so that moving or renaming either copy does not quietly stop the
+# lint from finding it.
+extract_re() {
+  grep -oE "'\(permission-gate[^']*\)'" "$1" | head -1 | sed "s/^'//;s/'$//"
+}
+
+gate_re=$(extract_re "$GATE" || true)
+config_re=$(extract_re "$CONFIG_GATE" || true)
+
+# An empty extraction means the lint lost track of its own target — that must
+# fail loudly rather than compare "" with "" and report parity.
+if [ -z "$gate_re" ]; then
+  echo "  FAIL: no protected-path regex found in permission-gate.sh — lint cannot see its target"
+  fail=$((fail + 1))
+else
+  echo "  PASS: found protected-path regex in permission-gate.sh"
+  pass=$((pass + 1))
+fi
+
+if [ -z "$config_re" ]; then
+  echo "  FAIL: no protected-path regex found in gate-config-writes.sh — lint cannot see its target"
+  fail=$((fail + 1))
+else
+  echo "  PASS: found protected-path regex in gate-config-writes.sh"
+  pass=$((pass + 1))
+fi
+
+if [ -n "$gate_re" ] && [ -n "$config_re" ]; then
+  if [ "$gate_re" = "$config_re" ]; then
+    echo "  PASS: the two protected-path regexes are identical"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: protected-path regexes have drifted"
+    echo "        permission-gate.sh     : $gate_re"
+    echo "        gate-config-writes.sh  : $config_re"
+    fail=$((fail + 1))
+  fi
+fi
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
Reduces the Bash bypass surface at protected config paths. **Does not close #123** — see "Why this is not a fix" below.

## The gap

`gate-config-writes.sh` guards the files that decide what the gateway enforces, but it is registered on `Write` and `Edit` only. `Bash` goes to `permission-gate.sh`, whose redirect check exempted relative targets by design.

Measured against the real gate before this change:

```
echo pwned > .claude/settings.json               -> (no output, exit 0)
cat /dev/null > .claude/hooks/require-jj-new.sh  -> (no output, exit 0)
```

No decision at all — not `ask`, not `deny`. #97 sharpened it: `.claude/settings.json` now carries the `Bash(git *)` deny rule and all five hook registrations, and is tracked, making it the enforcement surface for every fresh clone and every `jj workspace`.

## What this adds

Four routes to a protected path now return a decision: redirect targets (`>` and `>>`), write verbs naming the file as an argument (`tee`, `cp`, `dd`, `install`, `truncate`), a `cd` into a protected directory followed by a write to a bare filename, and any write whose target cannot be read statically. Matching runs on a quote-stripped, separator-normalized copy and captures whole command segments rather than single tokens.

Only writes count. `cat .claude/settings.json` and `grep -r x .claude/hooks/` stay silent — a gate that fires on ordinary inspection gets tuned out.

## Why this is not a fix

Three review rounds each found a **new class of full silent bypass**:

| Round | Class found |
|---|---|
| 1 | relative paths, `cd` then a bare filename, `.claude//` and `.claude/./` |
| 2 | quoted directory names (`cd '.claude'`), `cp -t DEST src`, `cp a b -v` |
| 3 | command substitution (`> $(echo .claude/settings.json)`) |

And a sweep run immediately after round 3's fix found ANSI-C quoting (`> $'\056claude/settings.json'`) still open. Enumerating spellings is not converging, and this PR does not claim it has.

**What turns each gap into a bypass is the Tier-1 safelist, not the gap itself.** It approves on the leading verb alone, and `echo`, `cat`, `cd` and `cp` are all on it — so an unrecognised spelling does not degrade to "no opinion", it degrades to an explicit approve several dozen lines later. Every bypass found reached the filesystem through that amplifier.

Route 4 targets the amplifier directly: a target containing any `$` or backtick cannot be read, so it costs a prompt rather than an approval. That rule keys on a **property** rather than a list precisely because the enumerated form (`$(`, `${`, `$NAME`) is what ANSI-C quoting walked straight through.

Constructs not recognised specifically — `pushd`, a subshell, a `cd` via variable — fall through to the Tier-2 catch-all, which still asks. Weaker wording, not a bypass.

## Two deliberate reversals

- **cp/install no longer treat the last argument as the destination.** That precision was not safely reachable: `cp -t .claude/hooks/ f` puts the destination first, `cp a b -v` puts a flag last, and both were silent — and silent means *approved* for a Tier-1 verb. Flag parsing (`-t`, `--target-directory=`, `-T`, `-vt`) is open-ended, with every unhandled form another silent approve. Any argument now counts, so copying a protected file elsewhere prompts. The assertion was flipped from `silent` to `ask` with the rationale recorded beside it.
- **The `quoted redirect target` assertion was dropped.** Ablating only the quote-stripping clause showed it still passes, because redirect matching already tolerated surrounding quotes — it could not distinguish feature present from feature absent. Same vacuous shape as the `printf`/`mv` cases dropped in round 1.

## Test harness bug

`run_gate` built its JSON payload by string interpolation, so any command containing a double quote produced **invalid JSON** → ERR trap → `ask`. Every assertion expecting `ask` could pass for the wrong reason, and double-quoted commands were inexpressible. It now builds the payload with `jq -Rc`. No existing assertion changed result, verified independently.

## Verification

- Every new `ask` assertion was watched failing — silent — before its fix, and passes after. Ablation was run per-feature, not just whole-block, which is what caught the vacuous quoted-redirect case.
- The `silent` assertions are anti-overreach guards and stay silent in both directions by design.
- `test-protected-paths-parity.sh` holds the two copies of the protected-path set identical — they are duplicated deliberately, since a shared file would itself be a bypass target. Mutation-tested both directions (drifted set, missing set), with its exit code confirmed to reach the suite runner rather than being masked by a pipeline.
- 178 assertions, 21 suites green.

## Recommendation

Land as surface reduction — it is strictly safer than the current state, and the amplifier fix is the durable part. Keep #123 open for real argument resolution, and consider the reviewer's alternative: have the Tier-1 safelist fail closed to a Tier-2 ask whenever any protected-path route reports it could not fully evaluate the command, so future gaps degrade to a prompt by construction rather than by enumeration.
