### PR TITLE
chore: drop hand-written README version sections, and lint against them (#112)

### DIFF
--- a/.github/tests/test-readme-no-version.sh
+++ b/.github/tests/test-readme-no-version.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A plugin's version lives in exactly one place: `.claude-plugin/plugin.json`.
+#
+# That field is machine-checked — #84 fails a PR red if any byte under
+# `plugins/<name>/` changes without the manifest version moving — so it is
+# trustworthy on every release. A version restated by hand in the README has
+# none of that: nothing reads it, nothing checks it, and #84 guarantees the
+# manifest moves without it, so the copy drifts by construction on every single
+# release.
+#
+# It is not a hypothetical. All three READMEs that carried this section claimed
+# `1.0.0` while their manifests read 0.11.0, 0.10.0 and 0.1.3 — and no plugin has
+# ever been at 1.0.0, so the value was never correct, not merely stale. Half the
+# plugins never had the section at all, so removing it also settles a convention
+# the repo was applying inconsistently.
+#
+# This lint keys on the HEADING, not on any semver-looking text: a README may
+# legitimately say "requires jj 0.43.0", and a lint that fires on that would be
+# turned off.
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+pass=0
+fail=0
+
+readmes=$(find "$REPO_ROOT/plugins" -mindepth 2 -maxdepth 2 -name README.md | sort)
+count=$(printf '%s\n' "$readmes" | grep -c . || true)
+
+# A glob that matches nothing passes by doing nothing — the #82 failure. Zero
+# READMEs means this lint lost its target, not that the repo is clean.
+if [ "$count" -eq 0 ]; then
+  echo "  FAIL: found no plugin READMEs — the lint cannot see its target"
+  echo ""
+  echo "=== Results: 0 passed, 1 failed ==="
+  exit 1
+fi
+echo "  checking $count plugin README(s)"
+
+while IFS= read -r readme; do
+  [ -n "$readme" ] || continue
+  rel=${readme#"$REPO_ROOT"/}
+  hits=$(grep -niE '^#{1,6}[[:space:]]*version[[:space:]]*$' "$readme" || true)
+  if [ -n "$hits" ]; then
+    fail=$((fail + 1))
+    echo "  FAIL: $rel declares a version section by hand"
+    printf '        %s\n' "$hits"
+    echo "        The manifest is the only source of truth; #84 keeps it honest."
+  else
+    pass=$((pass + 1))
+    echo "  PASS: $rel"
+  fi
+done <<EOF
+$readmes
+EOF
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi

--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/README.md
+++ b/plugins/commit-commands-jj/README.md
@@ -630,7 +630,3 @@ claude plugins add ./plugins/commit-commands-jj
 ## Author
 
 [muloka](https://github.com/muloka)
-
-## Version
-
-1.0.0

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/README.md
+++ b/plugins/project-setup-jj/README.md
@@ -118,7 +118,3 @@ Running `/project-setup` multiple times is safe. It will:
 ## Author
 
 [muloka](https://github.com/muloka)
-
-## Version
-
-1.0.0

--- a/plugins/workspace-jj/.claude-plugin/plugin.json
+++ b/plugins/workspace-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workspace-jj",
   "description": "Wave-based parallel orchestration with spec review gates for jj (Jujutsu) repositories",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/workspace-jj/README.md
+++ b/plugins/workspace-jj/README.md
@@ -109,7 +109,3 @@ See [design spec](../../docs/specs/2026-07-15-kaisen-rename-and-collision-design
 ## Author
 
 [muloka](https://github.com/muloka)
-
-## Version
-
-1.0.0


### PR DESCRIPTION
Closes #112.

## The defect

Three plugin READMEs ended with a hand-written `## Version` section:

| README | claimed | manifest |
|---|---|---|
| `commit-commands-jj` | 1.0.0 | **0.11.0** |
| `project-setup-jj` | 1.0.0 | **0.10.0** |
| `workspace-jj` | 1.0.0 | **0.1.3** |

No plugin has ever been at 1.0.0 — every manifest is pre-1.0. These were scaffolding leftovers that were never correct, not values that drifted by a release. Two of them drifted further earlier today when #121 and #122 bumped their manifests.

## Removed rather than corrected

A version restated by hand has nothing keeping it honest, and #84 *guarantees* the manifest moves on every release that touches a plugin — so a hand-written copy drifts by construction. Correcting the numbers would only reset a clock that is certain to run again.

The manifest is the single source of truth and is already machine-checked. Half the plugins (`agent-helpers-jj`, `peer-review-jj`, `permission-gateway`) never carried the section at all, so removing it also settles a convention the repo was applying inconsistently.

## The lint

`.github/tests/test-readme-no-version.sh` keeps it gone. Two deliberate choices:

- **Keys on the heading, not on semver-looking text.** A README may legitimately say "requires jj 0.43.0", and a lint that fires on that gets switched off.
- **Fails when it finds zero READMEs.** A glob that matches nothing otherwise passes by doing nothing — the #82 failure mode. Zero means the lint lost its target, not that the repo is clean.

## Verification

- **Non-vacuous by construction.** On its first run it failed on exactly the three known-bad READMEs and passed the three clean ones — it discriminates, rather than merely failing everything.
- **Mutation-checked** afterwards by re-adding a deeper `### Version` heading, which it also catches (exit 1), confirming the pattern is not pinned to `##`.
- 22 suites green (the runner's glob auto-discovers the new one).
- All three touched plugins carry a manifest bump, so `require-version-bump` is satisfied: 0.11.0→0.11.1, 0.10.0→0.10.1, 0.1.3→0.1.4.
