### PR TITLE
fix(permission-gateway): withhold Tier-1 auto-approval near protected paths (#123)

### DIFF
--- a/plugins/permission-gateway/.claude-plugin/plugin.json
+++ b/plugins/permission-gateway/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "permission-gateway",
   "description": "Tiered permission gateway — auto-approves safe commands, blocks dangerous ones, escalates edge cases to human",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/permission-gateway/README.md
+++ b/plugins/permission-gateway/README.md
@@ -38,7 +38,23 @@ Only writes are gated — reading or grepping a protected path stays silent, or 
 
 The Tier-1 safelist approves on the **leading verb alone**, and `echo`, `cat`, `cd` and `cp` are all on it. That means a protected-path check that fails to recognise a spelling does not degrade to "no opinion" — it degrades to an explicit approve, several dozen lines later. Every bypass found during review reached the filesystem through that amplifier rather than through the gap itself. Treating an unreadable target as a prompt is what stops an unrecognised shell construct from becoming an approval.
 
-**Known limit — this is shape matching, not argument resolution.** It reasons about the text of a command rather than the files that command would touch, and it cannot be proved exhaustive. Three review rounds each found a new class that slipped through: relative and `cd` path forms, then quoted directory names and `cp -t DEST src`, then command substitution — and a sweep immediately after the third fix found ANSI-C quoting (`$'\056claude/...'`) still open. Constructs it does not recognise specifically (`pushd`, a subshell, a `cd` via variable) fall through to the Tier-2 catch-all, which still asks: weaker wording, not a bypass. #123 remains open for resolving arguments properly.
+### The backstop: enumerate reads, not writes
+
+The routes above enumerate ways to **write**, and that list cannot be completed. Four rounds of adding shapes did not converge — relative and `cd` forms, then quoted directory names and `cp -t DEST src`, then command substitution, then ANSI-C quoting — and two classes were immune to the whole approach on principle. A glob means the path is only known after expansion, so `.claude/set*.json` never contains the literal `.claude/settings`. And *any* binary can be a write verb: `sponge` names its target in plain text, matches no route, and then `cat` satisfies the safelist.
+
+So the burden is inverted. The set of write commands is unbounded, but a **read allowlist** is finite and, crucially, fails in the safe direction: a verb nobody thought of is not on it, so it blocks. A command that names a protected path and is not purely a read loses Tier-1 auto-approval and falls through to Tier 2 for a prompt. A redirect counts as a write whatever the verb, since `echo` is a read command and `echo x > .claude/settings.json` is not a read.
+
+**The allowlist is therefore the security boundary, and each member needs auditing in its own right.** "Bounded and written down" is a claim about the set; it says nothing about whether the members are actually read-only. The first version of the list admitted a long tail of verbs that were not: `env` runs another program, so `env cp x .claude/settings.json` classified as a read and defeated the mechanism generically; `sed`'s `w` and `e` commands write and execute without `-i` or a redirect; `awk` has `system()`; `sort -o`, `uniq OUT`, `tree -o`, `xxd -r in out` and `file -C` all write a named file; `find -ok` is not the literal `-exec` an older rule matched; `fd -x` and `rg --pre` run programs.
+
+The admission rule is **any documented write or exec, not one that looks dangerous**. `file -C` compiles a magic file to `<name>.mgc` and cannot overwrite a hook by name, which is precisely why it is easy to wave through — it was caught by auditing the trimmed list, after review had already been round it. Every exclusion carries its reason beside the list in the script, so none gets helpfully added back.
+
+What the shape does buy is that the failure direction is right. Wrappers nobody enumerated — `nice`, `timeout`, `nohup`, `stdbuf`, `command`, `exec`, `busybox` — all prompt, because they were never on the allowlist. Only a wrongly-admitted member is dangerous.
+
+Nothing has to be named for this to hold, which is the point — the next unenumerated construct will not be named either. It closes shapes never written down anywhere: `ln -sf /evil .claude/settings.json` and `touch .claude/hooks/evil.sh` were both **silently auto-approved** before it existed, since `ln` and `touch` sit on the safelist.
+
+Reads stay silent: `cat .claude/settings.json`, `ls -la .claude/` and `grep -r x .claude/hooks/` are all untouched. That is the property the read-set is enumerated to preserve.
+
+**Remaining limit.** The route matching is still shape-based and still cannot be proved exhaustive; what changed is that a miss now degrades to a prompt rather than to an approval. The backstop governs the Tier-1 safelist specifically — the `.local.md` approve path runs earlier and is not covered, though those files are themselves protected, so reaching it needs a hand-written rule rather than a planted one. #123 tracks full argument resolution.
 
 The two copies of the protected-path set are held identical by `tests/test-protected-paths-parity.sh`; drift between them would silently reopen the gap on whichever tool the stale copy handles, with every other suite still green.
 

--- a/plugins/permission-gateway/scripts/permission-gate.sh
+++ b/plugins/permission-gateway/scripts/permission-gate.sh
@@ -80,6 +80,15 @@ log_decision() {
 # Each helper logs, then exits the script immediately with the decision.
 
 approve() {
+  # #123: the safelist below approves on the LEADING VERB alone, which is what
+  # turned every protected-path gap found in review into an explicit approve
+  # rather than merely "no opinion". If the command names a protected path and
+  # is not a pure read, withhold auto-approval and let it fall to a prompt.
+  # `auto_approve_blocked` is unset for callers that run before it is computed
+  # (the .local.md path), which leaves their behaviour unchanged.
+  if [ "${auto_approve_blocked:-}" = "1" ]; then
+    ask "Command names permission-gateway or hook configuration and is not a pure read — auto-approval withheld, human confirmation required."
+  fi
   log_decision "APPROVE"
   exit 0
 }
@@ -635,6 +644,113 @@ fi
 
 if [ -n "$protected_route" ]; then
   ask "Writing to permission-gateway or hook configuration via Bash ($protected_route) — requires human confirmation. This file controls which commands are auto-approved, blocked, or which hooks are active."
+fi
+
+# --- Fail closed rather than enumerate (#123) ---
+#
+# Everything above enumerates a way to WRITE, and that list cannot be completed.
+# Two classes proved it after four rounds of adding shapes: a glob means the path
+# is only known after expansion (`.claude/set*.json` never contains the literal
+# `.claude/settings`), and ANY binary can be a write verb — `sponge` names its
+# target in plain text, matches no route, and then `cat` satisfies the Tier-1
+# safelist below and the write is approved outright.
+#
+# So the burden is inverted here. The set of READ commands is bounded and
+# already written down; the set of write commands is not and never will be. A
+# command that names a protected path and is not purely a read is therefore
+# treated as a possible write and loses Tier-1 auto-approval, falling through to
+# Tier 2 for a prompt. Neither globs nor `sponge` have to be named for that to
+# hold — which is the whole point, since the next one will not be named either.
+#
+# A redirect counts as a write regardless of verb: `echo` is on the read list and
+# `echo x > .claude/settings.json` is still a write.
+#
+# Scope: this governs the Tier-1 safelist, which is where every bypass found in
+# review actually landed. The `.local.md` approve path runs earlier and is not
+# covered by it; those files are themselves protected (they match
+# PROTECTED_PATHS_RE), so reaching that path requires a rule the user wrote by
+# hand rather than one an injection could plant.
+PROTECTED_FRAGMENTS_RE='(\.claude|\.claude-plugin|permission-gate|settings\.json|settings\.local\.json)'
+
+# THIS LIST IS THE SECURITY BOUNDARY. A verb belongs here only if it can neither
+# write a file nor execute another program in ANY documented invocation — not
+# merely in its common one. "Bounded and written down" is a claim about the set;
+# it is worthless without an audit of each member, and the first version of this
+# list was wrong eight times over.
+#
+# Excluded, with the reason, so nobody helpfully adds one back:
+#   env      runs another program — `env cp x .claude/settings.json` classified
+#            as a read and defeated this entire mechanism generically
+#   sed      `w`/`W` write a file; GNU `e` executes a shell command (no -i, no >)
+#   awk      system(), `print > file`, and piping to "sh"
+#   sort     -o FILE
+#   uniq     takes an OUTPUT file as its second positional operand
+#   find     -exec/-execdir/-ok/-okdir/-delete/-fprintf/-fls  (the pre-existing
+#            rule matches only the literal -exec and -delete, so -ok slipped past)
+#   fd       -x/--exec
+#   tree     -o FILE
+#   rg       --pre runs a preprocessor program
+#   less     `!cmd` shell escape, and LESSOPEN
+#   more     same shell escape
+#   xxd      accepts an optional OUTFILE operand, so `xxd -r in out` writes
+#   jj       a VCS: `jj restore` rewrites working-copy files in place
+#   file     -C/--compile writes a <name>.mgc file. It cannot overwrite a hook
+#            by name, which is exactly why it is easy to wave through — the rule
+#            is "any documented write", not "a write that looks dangerous"
+#
+# Everything remaining reads its operands and writes only to stdout, so it can
+# reach a file solely through a redirect — which the caller checks separately.
+READONLY_VERBS_RE='^(ls|cat|head|tail|wc|grep|jq|echo|printf|pwd|which|whoami|date|stat|diff|tr|cut|basename|dirname|realpath|type|printenv|od|hexdump|column|cd)$'
+
+auto_approve_blocked=""
+frag_rc=0
+printf '%s' "$cmd_paths" | grep -qiE "$PROTECTED_FRAGMENTS_RE" || frag_rc=$?
+if [ "$frag_rc" -gt 1 ]; then
+  ask "Permission gateway: could not evaluate the command for protected paths (matcher error) and is failing closed. Human approval required."
+fi
+if [ "$frag_rc" -eq 0 ]; then
+  redir_rc=0
+  printf '%s' "$cmd_paths" | grep -qE '>' || redir_rc=$?
+  if [ "$redir_rc" -gt 1 ]; then
+    ask "Permission gateway: could not scan for a redirect (matcher error) and is failing closed. Human approval required."
+  fi
+  # A construct resolved at run time cannot be classified, and the classifier
+  # only ever reads the FIRST token of a segment — so a write nested in a command
+  # substitution, passed as a mere argument to an allowlisted verb, is never
+  # looked at. `echo $(cp x .claude/settings.json)` was silent, and so was the
+  # same trick wrapping `env`, a verb already excluded from the allowlist. No
+  # amount of auditing the verb list closes that: `echo` and `cat` are genuinely
+  # safe on their own, so the gap sits between the two mechanisms rather than
+  # inside either. This is Route 4's reasoning applied to the whole segment
+  # instead of only to the redirect and write-verb captures, which are both empty
+  # in that shape.
+  subst_rc=0
+  printf '%s' "$cmd_paths" | grep -qE '\$\(|`|\$\{' || subst_rc=$?
+  if [ "$subst_rc" -gt 1 ]; then
+    ask "Permission gateway: could not scan for command substitution (matcher error) and is failing closed. Human approval required."
+  fi
+  if [ "$redir_rc" -eq 0 ] || [ "$subst_rc" -eq 0 ]; then
+    auto_approve_blocked=1
+  else
+    # Leading verb of every pipeline/chain segment. If even one is not a known
+    # read, the command as a whole is not a pure read.
+    segment_verbs=$(printf '%s' "$cmd_paths" | tr ';|&' '\n' \
+      | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]].*$//' | grep -v '^$') || true
+    while IFS= read -r verb; do
+      [ -n "$verb" ] || continue
+      verb_rc=0
+      printf '%s' "$verb" | grep -qE "$READONLY_VERBS_RE" || verb_rc=$?
+      if [ "$verb_rc" -gt 1 ]; then
+        ask "Permission gateway: could not classify a command verb (matcher error) and is failing closed. Human approval required."
+      fi
+      if [ "$verb_rc" -ne 0 ]; then
+        auto_approve_blocked=1
+        break
+      fi
+    done <<EOF
+$segment_verbs
+EOF
+  fi
 fi
 
 # Redirect clobber — > (not >>) to paths outside project working directory

--- a/plugins/permission-gateway/tests/test-permission-gate.sh
+++ b/plugins/permission-gateway/tests/test-permission-gate.sh
@@ -516,6 +516,98 @@ assert_decision "dynamic source, literal target"     "echo \$VERSION > version.t
 # target means the target cannot be read", which is a property rather than a list.
 assert_decision "ansi-c quoted target"               "echo x > \$'\\056claude/settings.json'"             "ask"
 
+# ---- Fail closed instead of enumerating (#123) ----
+# Everything above enumerates a way to WRITE. That list cannot be completed:
+# globs mean the path is only known after expansion, and any binary at all can
+# be a write verb. Both classes below were still silent after four rounds of
+# adding shapes.
+#
+# So the burden is inverted. The set of READ commands is bounded and already
+# written down, so a command that mentions a protected path and is not purely a
+# read is treated as a possible write and loses Tier-1 auto-approval. That
+# closes both cases below without naming globs or `sponge`.
+echo "=== Fail closed rather than enumerate (#123) ==="
+# Glob: `.claude/set*.json` never contains the literal `.claude/settings`.
+assert_decision "glob in the directory"              "echo x > .clau*/settings.json"                      "ask"
+assert_decision "glob in the filename"               "echo x > .claude/set*.json"                         "ask"
+# The character class must break the LITERAL protected substring, or Route 1
+# catches it anyway and the assertion cannot tell this mechanism from that one.
+# `.claude/settings.js[o]n` was exactly that mistake: `.claude/settings` survives.
+assert_decision "glob via character class"           "echo x > .clau[d]e/settings.json"                   "ask"
+# `sponge` (moreutils) is a write verb that is not on any list and cannot be —
+# the command names the file in plain text, but no route fires, and the leading
+# `cat` then matches the Tier-1 safelist and approves the write outright.
+assert_decision "unknown write verb in a pipeline"   "cat .claude/hooks/x.sh | sed s/a/b/ | sponge .claude/hooks/x.sh" "ask"
+# NOT asserted: `frobnicate .claude/settings.json`. Any unrecognized verb already
+# falls to the Tier-2 catch-all regardless of the path — its paired control
+# ("unknown verb, no protected path") returns the same `ask`, so it cannot
+# isolate this mechanism. Vacuous in the same way as the round-1 `printf`/`mv`
+# cases.
+
+# ---- The read list IS the security boundary (#123, fourth review round) ----
+# The mechanism above is only as good as READONLY_VERBS_RE. Claiming "the read
+# set is bounded and written down" is not the same as auditing what each listed
+# verb can actually do, and the first version of that list was wrong eight times.
+#
+# `env` was the worst: its whole purpose is executing another program, so
+# `env <any-write-verb> <protected-path>` made the segment classify as a read.
+# One entry, and the entire mechanism had a generic escape hatch.
+#
+# The rest write files or run shell commands without any redirect, which is
+# exactly what the enclosing check scans for.
+echo "=== Read-verb list is the boundary (#123) ==="
+assert_decision "env wrapping a write verb"          "env cp /tmp/x .claude/settings.json"                "ask"
+assert_decision "env with an assignment"             "env FOO=1 tee .claude/settings.json < /dev/null"    "ask"
+assert_decision "sed w command writes a file"        "sed -n /x/w .claude/settings.json /dev/null"        "ask"
+assert_decision "awk system runs a shell"            "awk BEGIN{system(cp)} .claude/settings.json"        "ask"
+assert_decision "sort -o writes a file"              "sort -o .claude/settings.json /tmp/data"            "ask"
+assert_decision "uniq positional output file"        "uniq /tmp/data .claude/settings.json"               "ask"
+assert_decision "find -ok is not -exec"              "find .claude -ok rm {} ;"                           "ask"
+assert_decision "tree -o writes a file"              "tree -o .claude/settings.json"                      "ask"
+assert_decision "fd -x runs a command"               "fd -x cp {} .claude/settings.json"                  "ask"
+assert_decision "xxd -r takes an outfile"            "xxd -r /tmp/hex .claude/settings.json"              "ask"
+
+# A bare assignment prefix (no `env`) was already handled — kept as a control so
+# a future change cannot quietly make `env` the only guarded spelling.
+assert_decision "bare assignment prefix"             "FOO=1 cp /tmp/x .claude/settings.json"              "ask"
+# Found by auditing the TRIMMED list rather than by review — `file -C` compiles a
+# magic file and writes `<name>.mgc`, so `file` can create a file inside a
+# protected directory. It cannot overwrite a hook by name, which is why it is
+# easy to wave through; the audit rule is "any documented write", not "a write
+# that looks dangerous".
+assert_decision "file -C writes a magic file"        "file -C -m .claude/hooks/x"                         "ask"
+
+# ---- A read verb can carry a write inside its arguments (#123, fifth round) ----
+# The classifier reads the FIRST token of each `;|&`-split segment, so a write
+# nested in a command substitution — passed as a mere argument to an allowlisted
+# verb — is never looked at. `echo` and `cat` are genuinely safe on their own, so
+# no amount of auditing the verb list closes this: the gap is between the
+# mechanisms, not inside either one. It also smuggles verbs already excluded,
+# including `env`, which makes it strictly worse than any single list mistake.
+#
+# The rule mirrors Route 4's reasoning — a construct resolved at run time cannot
+# be classified — but applied to the whole segment instead of only to the
+# redirect and write-verb captures, which are both empty here.
+echo "=== A read verb carrying a write in its arguments (#123) ==="
+assert_decision "write nested in substitution"       "echo \$(cp /tmp/x .claude/settings.json)"           "ask"
+assert_decision "nested under cat"                   "cat \$(cp /tmp/x .claude/settings.json)"            "ask"
+assert_decision "nested in backticks"                "echo \`cp /tmp/x .claude/settings.json\`"           "ask"
+assert_decision "nested excluded verb (env)"         "echo \$(env cp /tmp/x .claude/settings.json)"       "ask"
+assert_decision "nested brace expansion"             "echo \${x} .claude/settings.json"                   "ask"
+# Substitution far from any protected path is ordinary work and stays silent.
+assert_decision "substitution, no protected path"    "echo \$(date) > build.log"                          "silent"
+
+# Reads of a protected path must STILL be silent — this is the property the
+# whole approach trades against, and the reason the read set is enumerated
+# rather than the write set.
+assert_decision "read a protected file"              "cat .claude/settings.json"                          "silent"
+assert_decision "grep a protected dir"               "grep -r foo .claude/hooks/"                         "silent"
+assert_decision "list a protected dir"               "ls -la .claude/"                                    "silent"
+assert_decision "read pipeline on protected file"    "cat .claude/settings.json | jq .hooks"              "silent"
+# ...and ordinary work far from any protected path is untouched.
+assert_decision "unknown verb, no protected path"    "frobnicate README.md"                               "ask"
+assert_decision "glob, no protected path"            "echo x > src/*.txt"                                 "silent"
+
 # ---- Summary ----
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="


### PR DESCRIPTION
Follows #124. Addresses the structural half of #123 — the part #124 explicitly did not claim to fix.

## The problem with #124's approach

Its routes enumerate ways to **write**, and that list cannot be completed. Four rounds of adding shapes did not converge (relative and `cd` forms → quoted directory names and `cp -t DEST src` → command substitution → ANSI-C quoting), and two classes were immune on principle:

| Shape | Why no write-route can catch it |
|---|---|
| `echo x > .claude/set*.json` | a glob's path is only known after expansion — the literal `.claude/settings` never appears |
| `cat f \| sed … \| sponge .claude/hooks/x.sh` | any binary can be a write verb; `sponge` matches no route, then `cat` satisfies the safelist |

Those are independent axes — the path set can't be matched literally, and the verb list can't be completed — so hardening either does nothing for the other.

## What actually made them bypasses

Not the gap: **the safelist**. It approves on the leading verb alone, so a miss did not degrade to "no opinion", it degraded to an *explicit approve* several dozen lines later.

## The change

Invert the burden. The set of **read** commands is bounded and already written down; the set of write commands is not and never will be. A command that names a protected path and is not purely a read loses Tier-1 auto-approval and falls through to Tier 2 for a prompt.

A redirect counts as a write whatever the verb — `echo` is a read command, and `echo x > .claude/settings.json` is not a read.

Implemented by gating `approve()` itself rather than its fourteen call sites, so the diff stays small and no future call site can forget the check.

## Verification

**Nothing has to be named for this to hold, which is the point.** Verified against eleven write shapes enumerated *nowhere* in the code or tests — `ln`, `curl -o`, `tar -C`, `unzip -d`, `ed`, `busybox sed -i`, `rsync`, `xz`, `ruby -e`, `touch`, `gzip` — all of which now ask.

**Two were live silent bypasses on trunk**, measured before/after against the merged script:

| | before | after |
|---|---|---|
| `ln -sf /evil .claude/settings.json` | *silent* | ask |
| `touch .claude/hooks/evil.sh` | *silent* | ask |

Both because `ln` and `touch` sit on the safelist. Neither was in any test; the backstop caught them without knowing about them.

**Reads stay silent** — the property the read-set is enumerated to preserve, asserted explicitly: `cat .claude/settings.json`, `ls -la .claude/`, `grep -r foo .claude/hooks/`, `cat .claude/settings.json | jq .hooks`.

Before/after decisions are otherwise identical across sampled ordinary work (`ls -la`, `npm test`, `cp src/a.js dist/b.js`, `echo hi > notes.txt`, `mkdir -p src/foo`). 189 assertions, 22 suites green.

## Scope and remaining limit

This governs the Tier-1 safelist, where every bypass found in review landed. The `.local.md` approve path runs earlier and is not covered — those files are themselves protected, so reaching it needs a rule written by hand rather than one an injection could plant.

Route matching is still shape-based and still cannot be proved exhaustive. What changed is that **a miss now degrades to a prompt instead of an approval**. That is the property that was missing, and it is why this is worth landing even though #123 stays open for full argument resolution.
