### PR TITLE
fix(permission-gateway): normalize paths in the Write/Edit gate, and make the parity lint behavioural (#123)

### DIFF
--- a/plugins/permission-gateway/.claude-plugin/plugin.json
+++ b/plugins/permission-gateway/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "permission-gateway",
   "description": "Tiered permission gateway — auto-approves safe commands, blocks dangerous ones, escalates edge cases to human",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/permission-gateway/scripts/gate-config-writes.sh
+++ b/plugins/permission-gateway/scripts/gate-config-writes.sh
@@ -42,6 +42,23 @@ set -euo pipefail
 input=$(cat)
 file_path=$(echo "$input" | jq -r '.tool_input.file_path // ""')
 
+# Normalize before matching, exactly as permission-gate.sh does (#123). A literal
+# substring test reads only the path as WRITTEN, so `.claude//settings.json` and
+# `.claude/./settings.json` name the same file while matching nothing. That was
+# fixed on the Bash side and never propagated here, leaving this gate — the
+# original "gate the gate" — bypassable through the Write tool.
+#
+# The parity lint did not catch it, because the two copies of the regex are
+# genuinely identical; only one side normalized its input. Textual parity is not
+# behavioural parity, which is why that lint now feeds paths to both gates and
+# compares decisions instead of diffing regex strings.
+#
+# Quotes first, then separators. The `/./` substitution runs twice because a
+# global substitution resumes after each replacement and so skips the overlap in
+# `/././`.
+file_path=$(printf '%s' "$file_path" \
+  | sed -e "s/['\"]//g" -e 's|/\./|/|g' -e 's|/\./|/|g' -e 's|//*|/|g')
+
 # Check if the write target is a protected file.
 #
 # The match is run OUTSIDE an `if` condition, and its three outcomes are handled

--- a/plugins/permission-gateway/tests/test-gate-config-writes.sh
+++ b/plugins/permission-gateway/tests/test-gate-config-writes.sh
@@ -75,6 +75,26 @@ assert_ask "gateway local rules"             ".claude/permission-gateway.local.m
 # The evaluation engine itself, and this guard, whose path contains
 # "permission-gateway" and therefore matches "permission-gate".
 assert_ask "the evaluation engine"           "plugins/permission-gateway/scripts/permission-gate.sh"
+
+# --- Path spellings (#123) ---
+# A literal substring test reads only the path as WRITTEN. `permission-gate.sh`
+# learned this over four review rounds and normalizes before matching; this gate
+# holds a byte-identical copy of the regex and did NOT, so the same file reached
+# the filesystem ungated through the Write tool.
+#
+# The parity lint did not catch it: it compares the two regexes as strings, and
+# they ARE identical. Textual parity is not behavioural parity when only one side
+# normalizes its input — which is why that lint is now behavioural too.
+assert_ask "double slash"                    ".claude//settings.json"
+assert_ask "dot segment"                     ".claude/./settings.json"
+assert_ask "double slash in hooks"           ".claude//hooks//require-jj-new.sh"
+assert_ask "dot segment in hooks"            ".claude/./hooks/require-jj-new.sh"
+assert_ask "repeated dot segments"           ".claude/././settings.json"
+assert_ask "quoted path"                     "'.claude/settings.json'"
+assert_ask "absolute with double slash"      "/Users/me/proj/.claude//settings.json"
+# Normalizing must not start gating unrelated files.
+assert_passthrough "unprotected double slash" "src//app.js"
+assert_passthrough "unprotected dot segment"  "src/./app.js"
 assert_ask "this guard itself"               "plugins/permission-gateway/scripts/gate-config-writes.sh"
 # Matching is case-insensitive (grep -qi); a case-shifted path must not slip by.
 assert_ask "case-insensitive match"          "/Users/me/.CLAUDE/Settings.json"

--- a/plugins/permission-gateway/tests/test-protected-paths-parity.sh
+++ b/plugins/permission-gateway/tests/test-protected-paths-parity.sh
@@ -2,16 +2,24 @@
 set -euo pipefail
 
 # The protected-path set exists TWICE: once in gate-config-writes.sh (which sees
-# Write/Edit) and once in permission-gate.sh (which sees Bash). They were
-# duplicated on purpose — a shared file would itself be a bypass target, and one
-# more thing needing a gate — but duplication buys that safety with a drift risk,
-# and drift here is silent. Widening one copy while leaving the other narrower
-# reopens #123 on whichever tool the stale copy handles, and every existing test
-# stays green because each suite exercises only its own script.
+# Write/Edit) and once in permission-gate.sh (which sees Bash). They are
+# duplicated on purpose — a shared sourced file would itself be a bypass target,
+# and one more thing needing a gate — but that buys safety with a drift risk, and
+# drift here is silent.
 #
-# This lint is the thing that fails instead. It compares the two regexes
-# literally; it does not re-derive either from the other, because a corpus taken
-# from the artifact under test cannot detect that artifact's drift.
+# THIS LINT USED TO COMPARE THE TWO REGEXES AS STRINGS, AND THAT WAS NOT ENOUGH.
+# It stayed green while `.claude//settings.json` was gated on the Bash side and
+# ungated through the Write tool, because the two regexes were genuinely
+# identical — only one side normalized its input before matching. Textual parity
+# is not behavioural parity. The behavioural half below is the load-bearing one;
+# the textual half is kept because it localizes a different failure (someone
+# editing one copy) to the line that caused it.
+#
+# The corpus is written from the CONCEPT — "files that decide which commands are
+# approved, which are blocked, and which hooks run" — plus the spellings a shell
+# accepts for the same file. It is deliberately NOT derived from either matcher,
+# because a corpus taken from the artifact under test cannot detect that
+# artifact's drift.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 GATE="$SCRIPT_DIR/../scripts/permission-gate.sh"
@@ -20,45 +28,111 @@ CONFIG_GATE="$SCRIPT_DIR/../scripts/gate-config-writes.sh"
 pass=0
 fail=0
 
-# Pull the first single-quoted group that starts with the permission-gate token
-# out of each file. Anchored on the token rather than on a line number or a
-# variable name so that moving or renaming either copy does not quietly stop the
-# lint from finding it.
+# --- Behavioural parity ------------------------------------------------------
+# Same file, both tools. A write to a protected path must require confirmation
+# whichever tool the caller reaches for; a gate is worth nothing if the other
+# door is open.
+
+# Pass-through is EMPTY STDOUT, not a JSON document saying "allow" — so the
+# empty case has to be handled in shell. Piping nothing into `jq '... // "none"'`
+# yields nothing at all: jq never runs its filter on a document that isn't there,
+# and the default never fires.
+write_decision() {
+  local out
+  out=$(jq -nc --arg p "$1" '{tool_input:{file_path:$p}, tool_name:"Write", hook_event_name:"PreToolUse"}' \
+    | bash "$CONFIG_GATE" 2>/dev/null) || true
+  [ -n "$out" ] || { echo none; return; }
+  printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // "malformed"' 2>/dev/null || echo malformed
+}
+
+bash_decision() {
+  local out
+  out=$(jq -nc --arg c "echo x > $1" '{tool_input:{command:$c}, tool_name:"Bash", hook_event_name:"PreToolUse"}' \
+    | bash "$GATE" 2>/dev/null) || true
+  [ -n "$out" ] || { echo none; return; }
+  printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // "malformed"' 2>/dev/null || echo malformed
+}
+
+echo "=== Behavioural parity: a protected path must be gated via BOTH tools ==="
+while IFS= read -r p; do
+  [ -n "$p" ] || continue
+  case "$p" in \#*) continue ;; esac
+  w=$(write_decision "$p")
+  b=$(bash_decision "$p")
+  if [ "$w" = "ask" ] && [ "$b" = "ask" ]; then
+    pass=$((pass + 1))
+    echo "  PASS: $p"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL: $p — Write gate said '$w', Bash gate said '$b' (both must be 'ask')"
+  fi
+done <<'PATHS'
+.claude/settings.json
+.claude/settings.local.json
+.claude/hooks/require-jj-new.sh
+.claude/hooks/jj-session-start.sh
+.claude/scripts/statusline-jj.sh
+.claude-plugin/plugin.json
+.claude/permission-gateway.local.md
+plugins/permission-gateway/scripts/permission-gate.sh
+./.claude/settings.json
+/Users/me/project/.claude/settings.json
+.claude//settings.json
+.claude/./settings.json
+.claude/././settings.json
+.claude//hooks//require-jj-new.sh
+.claude/./hooks/require-jj-new.sh
+/Users/me/project/.claude//hooks/require-jj-new.sh
+PATHS
+
+# Ordinary files must stay ungated on the Write side. The Bash side is NOT
+# asserted here: it matches a deliberately broader fragment set (a bare
+# `settings.json` counts) because it cannot see which argument is a path, so it
+# over-asks by design. Over-asking is a prompt; under-asking is a bypass, and
+# only one of those is worth a lint.
+echo "=== Ordinary files stay ungated on the Write side ==="
+while IFS= read -r p; do
+  [ -n "$p" ] || continue
+  w=$(write_decision "$p")
+  if [ "$w" = "none" ]; then
+    pass=$((pass + 1))
+    echo "  PASS: $p"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL: $p — expected pass-through on the Write gate, got '$w'"
+  fi
+done <<'PATHS'
+src/app.js
+README.md
+package.json
+src//app.js
+src/./app.js
+docs/settings.md
+.github/workflows/test.yml
+PATHS
+
+# --- Textual parity ----------------------------------------------------------
+# Kept as a second, cheaper signal. It cannot detect a normalization difference —
+# that is what the behavioural half above is for — but it names the exact line
+# when someone widens one copy of the regex and not the other.
+echo "=== Textual parity: the two regexes are still identical ==="
 extract_re() {
   grep -oE "'\(permission-gate[^']*\)'" "$1" | head -1 | sed "s/^'//;s/'$//"
 }
-
 gate_re=$(extract_re "$GATE" || true)
 config_re=$(extract_re "$CONFIG_GATE" || true)
 
-# An empty extraction means the lint lost track of its own target — that must
-# fail loudly rather than compare "" with "" and report parity.
-if [ -z "$gate_re" ]; then
-  echo "  FAIL: no protected-path regex found in permission-gate.sh — lint cannot see its target"
+if [ -z "$gate_re" ] || [ -z "$config_re" ]; then
+  echo "  FAIL: could not find the protected-path regex in one or both scripts — the lint lost its target"
   fail=$((fail + 1))
-else
-  echo "  PASS: found protected-path regex in permission-gate.sh"
+elif [ "$gate_re" = "$config_re" ]; then
+  echo "  PASS: identical in both scripts"
   pass=$((pass + 1))
-fi
-
-if [ -z "$config_re" ]; then
-  echo "  FAIL: no protected-path regex found in gate-config-writes.sh — lint cannot see its target"
+else
+  echo "  FAIL: protected-path regexes have drifted"
+  echo "        permission-gate.sh    : $gate_re"
+  echo "        gate-config-writes.sh : $config_re"
   fail=$((fail + 1))
-else
-  echo "  PASS: found protected-path regex in gate-config-writes.sh"
-  pass=$((pass + 1))
-fi
-
-if [ -n "$gate_re" ] && [ -n "$config_re" ]; then
-  if [ "$gate_re" = "$config_re" ]; then
-    echo "  PASS: the two protected-path regexes are identical"
-    pass=$((pass + 1))
-  else
-    echo "  FAIL: protected-path regexes have drifted"
-    echo "        permission-gate.sh     : $gate_re"
-    echo "        gate-config-writes.sh  : $config_re"
-    fail=$((fail + 1))
-  fi
 fi
 
 echo ""


### PR DESCRIPTION
The last known-live instance of #123's class, on the tool nobody had attacked.

## The bypass

`.claude//settings.json` and `.claude/./settings.json` name the same file as `.claude/settings.json`, and a literal substring test reads only the path as *written*. `permission-gate.sh` learned that over four review rounds and normalizes before matching. `gate-config-writes.sh` holds a **byte-identical copy of the regex** and did not.

Measured through the real hook payload:

| tool | path | before |
|---|---|---|
| Write | `.claude//settings.json` | *empty stdout, exit 0* |
| Write | `.claude/./settings.json` | *empty stdout, exit 0* |
| Bash | `echo x > .claude//settings.json` | `ask` (fixed in #124) |

So the gate-the-gate — the guard the whole feature is named for — was bypassable through `Write` while the same write was correctly gated through `Bash`. The fix is a straight port of the normalization already running and tested on the Bash side.

## The parity lint didn't catch it, and that's the more important half

It compared the two regexes **as strings**. They are genuinely identical. Only one side normalized its input. Textual parity is not behavioural parity — and I had been reading that lint as guaranteeing the latter across two PRs.

It now feeds the same path to **both** gates and compares decisions: a protected path must be gated whichever tool the caller reaches for, because a gate is worth nothing if the other door is open. The textual check stays as a cheaper second signal — it can't see a normalization difference, but it names the exact line when someone widens one copy of the regex and not the other.

**Proved by mutation, and the mutation is the point.** With the normalization removed, the behavioural half fails on six paths while the textual half still reports *"identical in both scripts"* — the exact false-confidence scenario, reproduced and now caught. Exit code confirmed to reach the suite runner rather than being masked by a pipeline.

## Corpus

Written from the **concept** — files that decide which commands are approved, which are blocked, and which hooks run — plus the spellings a shell accepts for the same file. Deliberately not derived from either matcher, since a corpus taken from the artifact under test cannot detect that artifact drifting.

Ordinary files are asserted ungated on the **Write side only**. The Bash side matches a deliberately broader fragment set (a bare `settings.json` counts) because it cannot see which argument is a path, so it over-asks by design. Over-asking is a prompt; under-asking is a bypass, and only one of those is worth a lint.

## Also

A bug in the lint itself: pass-through is *empty stdout*, not a JSON document, so `jq -r '... // "none"'` never fired its default — jq doesn't run a filter on a document that isn't there. Every ordinary-file assertion was comparing `""` against `"none"`. Handled in shell now.

22 suites green.

## Effect on #123

This was the last instance of the class I know of. With it fixed, the residual on the Bash side collapses to: a command can only reach a protected path silently if it has no redirect, no substitution, and every leading verb on the audited read allowlist — which by construction cannot write. So the open question narrows from "is shape matching exhaustive" (unfalsifiable) to "is the allowlist audit correct" (finite and re-checkable). See the issue for the close argument.
