### PR TITLE
docs(project-setup-jj): warn that --ignore-working-copy hides your own edits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- jj-project-setup:start hash:be4e280a -->
+<!-- jj-project-setup:start hash:d01c702b -->
 ## VCS — jj (Jujutsu)
 
 This project uses **jj (Jujutsu)** as its VCS. Never use raw git commands. Use jj equivalents instead (e.g. `jj log`, `jj status`, `jj diff`). The only exceptions are `jj git` subcommands (e.g. `jj git push`) and the `gh` CLI for GitHub operations.
@@ -10,6 +10,7 @@ In jj, the working copy IS a commit. There is no uncommitted state. Never ask "w
 - **Hand revisions between steps as change IDs, not commit IDs.** A change ID (`kouorrnv`) survives `jj squash`, `jj describe` and every other rewrite; a commit ID (`92ef691b`) is replaced by each one, so a value captured before an edit is stale after it. Read one with `jj log -r <rev> --no-graph -T 'change_id.short()'`. Commit IDs are fine for a one-shot query or an immutable record — not for anything held across a step.
 - **`jj abandon` re-parents `@` onto the abandoned change's parent.** After abandoning work that was merged upstream, `@` lands on the *pre-merge* base and every merged file reads as reverted on disk. Fix with `jj new trunk()`. The work is safe; the working copy is looking at the wrong revision.
 - **Abandoning `@` always leaves a fresh empty change.** You cannot end up with no working copy, so don't chase the new empty change you just created.
+- **`--ignore-working-copy` skips the snapshot, so it hides edits you just made.** It is correct for background and concurrent tooling — the `jjctx`/`jjstack`/`jjconflicts` helpers bake it in — and wrong for reviewing your own work: `jj diff --from 'trunk()' --to @ --stat` with the flag can omit your most recent edits and still read as a complete answer. Drop it whenever the answer depends on the current working copy. Unlike the two above, this one fails quietly.
 
 ### Superpowers overrides
 

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/templates/CLAUDE.md.template
+++ b/plugins/project-setup-jj/templates/CLAUDE.md.template
@@ -1,4 +1,4 @@
-<!-- jj-project-setup:start hash:be4e280a -->
+<!-- jj-project-setup:start hash:d01c702b -->
 ## VCS — jj (Jujutsu)
 
 This project uses **jj (Jujutsu)** as its VCS. Never use raw git commands. Use jj equivalents instead (e.g. `jj log`, `jj status`, `jj diff`). The only exceptions are `jj git` subcommands (e.g. `jj git push`) and the `gh` CLI for GitHub operations.
@@ -10,6 +10,7 @@ In jj, the working copy IS a commit. There is no uncommitted state. Never ask "w
 - **Hand revisions between steps as change IDs, not commit IDs.** A change ID (`kouorrnv`) survives `jj squash`, `jj describe` and every other rewrite; a commit ID (`92ef691b`) is replaced by each one, so a value captured before an edit is stale after it. Read one with `jj log -r <rev> --no-graph -T 'change_id.short()'`. Commit IDs are fine for a one-shot query or an immutable record — not for anything held across a step.
 - **`jj abandon` re-parents `@` onto the abandoned change's parent.** After abandoning work that was merged upstream, `@` lands on the *pre-merge* base and every merged file reads as reverted on disk. Fix with `jj new trunk()`. The work is safe; the working copy is looking at the wrong revision.
 - **Abandoning `@` always leaves a fresh empty change.** You cannot end up with no working copy, so don't chase the new empty change you just created.
+- **`--ignore-working-copy` skips the snapshot, so it hides edits you just made.** It is correct for background and concurrent tooling — the `jjctx`/`jjstack`/`jjconflicts` helpers bake it in — and wrong for reviewing your own work: `jj diff --from 'trunk()' --to @ --stat` with the flag can omit your most recent edits and still read as a complete answer. Drop it whenever the answer depends on the current working copy. Unlike the two above, this one fails quietly.
 
 ### Superpowers overrides
 


### PR DESCRIPTION
Adds one gotcha to the `/project-setup` CLAUDE.md template, and syncs this repo's own installed copy.

## The hazard

`jj diff --ignore-working-copy` skips the working-copy snapshot, so it does not show edits made since the last one. While preparing #128 it reported a **16-file** diffstat where the truth was **17** — a PR would have shipped believed to be missing two files that were in fact present.

It belongs in that section because of *how* it fails. The two bullets above it are loud: after `jj abandon` re-parents `@`, files visibly revert on disk and you go looking. This one hands back a well-formed, plausible, wrong answer and gives no signal at all.

It is also disproportionately an agent hazard. The `jjctx` / `jjstack` / `jjconflicts` / `jjcheckpoint` helpers all bake the flag in — correctly, since they are background queries that must not race concurrent workspaces — and the habit transfers to hand-written `jj diff` calls, where it is wrong. The existing documentation reinforces exactly half of that: it introduces the flag as "safe under concurrent workspaces" with no counterpart warning.

## Scope

One bullet. No behaviour change, no new lint.

Deliberately **not** included: a `jj rebase -r` vs `-s` note that came up in the same discussion. It did not survive checking — the change being rebased was a leaf, so `-s` would have behaved identically, and the real rule ("rebase the surviving child, not the merged parent") is already covered by the existing post-merge guidance. A subtly-wrong rule stated authoritatively in CLAUDE.md is worse than no rule, which is the same reasoning behind `.github/tests/test-jj-recommendations.sh`.

## Hash marker

The template body is hash-pinned (#86/#87): `/project-setup` skips the CLAUDE.md update when the installed marker matches the template's, so editing the body without recomputing means the change reaches nobody while the command reports "already up to date". This repo's own CLAUDE.md was stale for four months for exactly that reason.

Marker recomputed `be4e280a` → `d01c702b`, and the guard was watched failing before it was updated rather than assumed to work:

```
FAIL: template hash is stale: marker says be4e280a, body hashes to d01c702b
0 passed, 1 failed  (exit 1)
```

then after recomputing:

```
PASS: template hash d01c702b matches its body
1 passed, 0 failed  (exit 0)
```

## Verification

- Template body and this repo's installed `CLAUDE.md` body verified **byte-identical** after the edit, so the dogfooded copy is genuinely current rather than merely bumped.
- **18 suites, 0 failures** under `/bin/bash`.
- `project-setup-jj` bumped 0.10.2 → 0.10.3 (#84, CI-enforced — any byte under `plugins/<name>/` needs it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
