### PR TITLE
fix(commit-commands-jj): drop two git-shaped rituals jj makes unnecessary (#132, #135)

### DIFF
--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests — requires project-setup-jj",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/README.md
+++ b/plugins/commit-commands-jj/README.md
@@ -119,7 +119,7 @@ Finishes development work by presenting a menu of completion options and executi
    - **Push and create PR:** warns about non-target ancestor changes that would be swept into the PR, creates a bookmark if needed (or uses `jj git push --change <target>` for a quick anonymous push), pushes with `jj git push --bookmark`, and opens the PR with `gh pr create`
    - **Squash into trunk:** fetches, rebases the change onto trunk, and folds it in with `jj squash --into trunk()`
    - **Keep as-is:** reports the change ID and stops — no cleanup
-   - **Discard:** requires typed confirmation, then runs `jj abandon`
+   - **Discard:** records a restore point from the op log, runs `jj abandon`, and hands back the exact `jj op restore <id>` that undoes it
 4. For push, squash, and discard, cleans up the jj workspace if running in a non-default one (`jj workspace forget`)
 
 **Usage:**
@@ -141,7 +141,7 @@ Finishes development work by presenting a menu of completion options and executi
 
 **Features:**
 - Never force-pushes — uses `jj git push` only
-- Requires typed confirmation before discarding work (recoverable via `/undo`)
+- Makes discarding recoverable rather than gating it — captures an op id first, then reports `jj op restore <id>`
 - Detects and warns about ancestor changes not part of the target work before pushing
 - After a PR merges, abandons the now-landed local ancestor changes as part of cleanup
 - Does not run tests or reviews — finishing work is its own concern
@@ -482,11 +482,9 @@ Lists all tags in the repository with JSON-structured output.
 Cleans up stale local bookmarks and workspaces (replaces `/clean_gone` from the Git plugin).
 
 **What it does:**
-1. Fetches latest remote state with `jj git fetch`
-2. Lists all bookmarks to find those deleted on the remote
-3. Lists workspaces to find stale ones
-4. Deletes stale bookmarks with `jj bookmark delete`
-5. Forgets stale workspaces with `jj workspace forget`
+1. Fetches latest remote state with `jj git fetch` — which is also the entire bookmark cleanup, since fetch drops the local bookmark whose remote counterpart was deleted
+2. Lists workspaces to find stale ones
+3. Forgets stale workspaces with `jj workspace forget`
 
 **Usage:**
 ```bash
@@ -499,15 +497,14 @@ Cleans up stale local bookmarks and workspaces (replaces `/clean_gone` from the 
 /clean_stale
 
 # Claude will:
-# - Fetch latest remote state
-# - Find bookmarks deleted on remote
-# - Remove stale bookmarks and workspaces
+# - Fetch latest remote state (bookmarks deleted on the remote go with it)
+# - Find and forget stale workspaces
 # - Report what was cleaned up
 ```
 
 **Features:**
-- jj auto-prunes remote tracking refs during fetch (no `--prune` needed)
-- Handles both bookmarks and workspaces
+- jj auto-prunes remote tracking refs during fetch (no `--prune` needed, and no follow-up `jj bookmark delete` — there is nothing left to delete)
+- Handles the half jj does *not* do for you: workspaces registered to directories that no longer exist
 - Reports if no cleanup was needed
 
 **When to use:**
@@ -540,7 +537,7 @@ claude plugins add ./plugins/commit-commands-jj
 
 ### Using `/finish`
 - Use when work is complete and tested — it presents the completion options rather than assuming one
-- Get typed confirmation before discarding; `/undo` can still recover it immediately after
+- Discarding is recoverable: it records an op id before abandoning and gives you `jj op restore <id>`, which stays correct even after later operations
 - Prefer this over `/commit-push-pr` when you also want the squash-into-trunk, keep, or discard paths
 
 ### Using `/new`
@@ -598,9 +595,9 @@ claude plugins add ./plugins/commit-commands-jj
 - For tag details, follow up with `/show <tag-name>`
 
 ### Using `/clean_stale`
-- Run periodically to keep your bookmark list clean
-- Especially useful after merging multiple PRs
-- Safe to run — only removes bookmarks already deleted remotely
+- Mostly worth running for the workspace half — the bookmark half is what `jj git fetch` already does on its own
+- Especially useful after deleting workspace directories by hand
+- Safe to run — it prunes only what the remote already deleted, and forgets only workspaces you point it at
 
 ## jj Concepts for Git Users
 

--- a/plugins/commit-commands-jj/commands/clean_stale.md
+++ b/plugins/commit-commands-jj/commands/clean_stale.md
@@ -1,51 +1,59 @@
 ---
-description: Cleans up stale bookmarks and workspaces in a jj repository by fetching latest remote state and removing bookmarks deleted on the remote.
-allowed-tools: Bash(jj bookmark:*), Bash(jj workspace:*), Bash(jj git fetch:*)
+description: Cleans up a jj repository by fetching remote state — which prunes bookmarks deleted on the remote — and forgetting stale workspaces.
+allowed-tools: Bash(jj bookmark list:*), Bash(jj workspace:*), Bash(jj git fetch:*)
 ---
 
 **CRITICAL: This is a jj (Jujutsu) plugin. You MUST NOT use ANY raw git commands — not even for context discovery. This includes git checkout, git commit, git diff, git log, git status, git add, git branch, git remote, git rev-parse, git config, git show, git fetch, git pull, git push, git merge, git rebase, git stash, git reset, git tag, or any other `git` invocation. Do not run `ls .git`, `git log`, `git remote -v` or similar to detect repo state. Always use jj equivalents (jj log, jj status, jj diff, etc.). The only exceptions are `jj git` subcommands (e.g. `jj git push`, `jj git fetch`) and `gh` CLI for GitHub operations.**
 
 ## Context
 
-- Current bookmarks (JSON): !`jj bookmark list --all -T 'json(self) ++ "\n"'`
+- Bookmarks **before** the fetch (JSON): !`jj bookmark list --all -T 'json(self) ++ "\n"'`
 - Current workspaces: !`jj workspace list`
 
 ## Your Task
 
-You need to execute the following commands to clean up stale local bookmarks and workspaces in a jj repository.
+Clean up a jj repository. There are two halves and they are not symmetric: **the
+bookmark half is one command, and the workspace half is the only part that needs
+you to find anything.**
 
 ## Commands to Execute
 
-1. **First, fetch the latest remote state**
-   Execute this command:
+1. **Fetch the latest remote state — this *is* the bookmark cleanup**
    ```bash
    jj git fetch
    ```
 
-   Note: jj automatically prunes deleted remote tracking refs during fetch — no `--prune` flag needed.
+   `jj git fetch` prunes deleted remote-tracking refs *and* drops the local
+   bookmark that tracked them. There is no `--prune` flag because there is
+   nothing to opt into, and there is **no follow-up `jj bookmark delete`** —
+   after this step no stale bookmark remains to find.
 
-2. **List all bookmarks to find stale ones**
-   Execute this command:
-   ```bash
-   jj bookmark list --all -T 'json(self) ++ "\n"'
+   Its output names what went, so read it rather than re-deriving it:
+   ```
+   bookmark: feature-gone@origin [deleted] untracked
    ```
 
-   Look for local bookmarks whose remote counterpart has been deleted. These appear as bookmarks that exist locally but have no corresponding remote tracking bookmark, or bookmarks marked as deleted on remote.
+   **Do not go hunting for "local bookmarks whose remote was deleted."** That is
+   the `git fetch --prune` + `git branch -d` habit, and jj does not need it.
+   Running `jj bookmark delete <name>` on a bookmark fetch already removed just
+   prints `Warning: No matching bookmarks for names: <name>` and exits 0 —
+   a no-op that reads like a successful cleanup.
 
-3. **List workspaces to find stale ones**
-   Execute this command:
+   If fetch also reports `Abandoned N commits that are no longer reachable`,
+   that is jj dropping commits the deleted bookmark was the only path to. Work
+   that was merged into trunk stays reachable and is **not** abandoned.
+
+2. **List workspaces to find stale ones**
    ```bash
    jj workspace list
    ```
 
-4. **Delete stale bookmarks**
-   For each stale bookmark found in step 2, execute:
-   ```bash
-   jj bookmark delete <bookmark-name>
-   ```
+   This half is real work. A workspace whose directory has been deleted stays
+   registered indefinitely — no ordinary jj command clears it, and nothing in
+   step 1 touches it.
 
-5. **Forget stale workspaces**
-   For each stale workspace found in step 3 (other than the default workspace), execute:
+3. **Forget stale workspaces**
+   For each stale workspace found in step 2 (other than the default workspace):
    ```bash
    jj workspace forget <workspace-name>
    ```
@@ -54,9 +62,11 @@ You need to execute the following commands to clean up stale local bookmarks and
 
 After executing these commands, you will:
 
-- Have the latest remote state fetched
-- Identify and remove local bookmarks that were deleted on the remote
-- Identify and forget any stale workspaces
-- Provide feedback on which bookmarks and workspaces were cleaned up
+- Have the latest remote state fetched, with bookmarks deleted on the remote
+  already pruned as part of that fetch
+- Have identified and forgotten any stale workspaces
+- Report what was cleaned up — for bookmarks, that is whatever the fetch output
+  named (compare against the pre-fetch list in Context if you want the delta)
 
-If no stale bookmarks or workspaces are found, report that no cleanup was needed.
+If the fetch pruned nothing and no stale workspaces are found, report that no
+cleanup was needed.

--- a/plugins/commit-commands-jj/commands/finish.md
+++ b/plugins/commit-commands-jj/commands/finish.md
@@ -203,21 +203,59 @@ Keeping change <change-id>. No cleanup performed.
 
 ### Option 4: Discard
 
-**Confirm first:**
-```
-This will permanently discard:
-- Change <change-id>: <description>
-- <N> files changed
+`jj abandon` is **not** the destructive act it is in git. The operation log holds
+the pre-abandon state, and `jj op restore` returns to it exactly — including
+files that were never committed. Your job is to preserve that property and hand
+it to the user, not to gate the discard behind a typed keyword.
 
-Type 'discard' to confirm. (Recoverable via /undo)
-```
+1. **Capture the restore point before touching anything:**
+   ```bash
+   jj op log -n 1 --no-graph -T 'id.short()'
+   ```
+   `jj op log` snapshots the working copy before it reports, so the id it
+   returns already covers the current state. **Do not add
+   `--ignore-working-copy`** — it skips that snapshot and hands back a restore
+   point that predates the most recent edits, which is exactly the work about to
+   be discarded.
 
-Wait for exact confirmation.
+2. **State what is going, and whether a copy survives anywhere.** Read the
+   target's bookmarks from Context — do not assert either line below without
+   having looked:
+   ```
+   Discarding <change-id>: <description> — <N> files changed.
+   Not pushed; this is the only copy.        # no bookmark, or bookmark never pushed
+   Pushed as <bookmark>; the remote still has it.   # a pushed bookmark exists
+   ```
 
-If confirmed:
-```bash
-jj abandon <target>
-```
+3. **Abandon:**
+   ```bash
+   jj abandon <target>
+   ```
+   This also drops the local bookmark. **Pushing that deletion is a second,
+   separate act of destruction** — `jj git push --deleted` (or pushing the
+   deleted bookmark) removes the remote's copy, which for pushed work was the
+   only surviving one. Do it only if the user asked for the branch to be gone
+   from the remote too, and say plainly that you did.
+
+4. **Hand back the exact recovery command**, with the id from step 1 — not a
+   bare pointer to `/undo`, which only reaches the *last* operation and is wrong
+   as soon as anything else runs.
+
+   Work that was never pushed:
+   ```
+   If you want it back: jj op restore <id>
+   ```
+
+   **If you deleted a pushed bookmark, `--what repo` is not optional.** A bare
+   `jj op restore` also restores remote-tracking refs, so jj starts believing
+   the remote still holds the branch. The next `jj git push` then answers
+   `Nothing changed.` while the remote stays empty — silent loss behind a
+   success message. `jj op restore --help` says it outright: *"Do not restore
+   these if you'd like to push after the undo."*
+   ```
+   If you want it back: jj op restore <id> --what repo
+   then re-publish:     jj git push --bookmark <name>
+   ```
 
 Then: Workspace cleanup (Step 4).
 
@@ -255,7 +293,8 @@ If in the default workspace, no cleanup needed.
 
 - **Never use raw git commands.** Always jj equivalents.
 - **Never force-push.** Use `jj git push` only.
-- **Get typed confirmation for discard.** Always remind that `/undo` can recover.
+- **Make discard recoverable; don't gate it.** Capture `jj op log -n 1 --no-graph -T 'id.short()'` before abandoning, then hand back `jj op restore <id>`. A typed-confirmation prompt is a git habit — in jj the op log is the safety net, and it works whether or not anyone was asked.
+- **If the discard removed a pushed bookmark from the remote, the recovery command is `jj op restore <id> --what repo`.** The bare form restores remote-tracking refs too, and the following `jj git push` reports `Nothing changed.` over a remote that is still empty.
 - **Don't auto-remove worktree directories.** Let the WorktreeRemove hook handle it.
 - **Keep it focused.** This skill finishes work. It does not run tests or do reviews — those are the caller's responsibility.
 

--- a/plugins/commit-commands-jj/tests/test-command-prose-claims.sh
+++ b/plugins/commit-commands-jj/tests/test-command-prose-claims.sh
@@ -43,11 +43,13 @@ R() { r_root="$1"; shift; ( cd "$r_root/cwd" && env -i PATH="$PATH" \
     XDG_CONFIG_HOME="$r_root/home/.config" TMPDIR="${TMPDIR:-/tmp}" \
     TERM=dumb "$@" ); }
 
-# --- clean_stale.md:25 — "jj automatically prunes ... no --prune flag needed"
+# --- clean_stale.md — "There is no --prune flag because there is nothing to opt
+# into". No line number: the claim has already moved once (it was :25), and a
+# stale pointer in a failure message costs more than it saves.
 if jj git fetch --help 2>&1 | grep -q -- '--prune'; then
-  bad "clean_stale.md:25 says no --prune is needed, but jj git fetch now HAS --prune"
+  bad "clean_stale.md says no --prune is needed, but jj git fetch now HAS --prune"
 else
-  ok "jj git fetch has no --prune flag (clean_stale.md:25 is accurate)"
+  ok "jj git fetch has no --prune flag (clean_stale.md is accurate)"
 fi
 
 # --- No command may recommend `jj git push --allow-new`; it was removed.
@@ -90,6 +92,75 @@ else
   ok "jj git fetch auto-removes a stale tracked bookmark (clean_stale.md steps 2/4 remain vestigial, #132)"
 fi
 
+# --- ...and the prose must keep saying so (#132). The assertion above proves jj
+# does the work; this one proves clean_stale.md has not grown the redundant step
+# back. Only *executable* instructions count — the file legitimately names
+# `jj bookmark delete` in prose to warn the model off it, so this looks solely
+# inside fenced code blocks.
+CMDS="$(cd "$(dirname "$0")/.." && pwd)/commands"
+fenced() { awk '/^[[:space:]]*```/{inb=!inb; next} inb' "$1"; }
+if fenced "$CMDS/clean_stale.md" | grep -q 'jj bookmark delete'; then
+  bad "clean_stale.md executes 'jj bookmark delete' again — jj git fetch already removed it (#132)"
+else
+  ok "clean_stale.md prescribes no redundant 'jj bookmark delete' (#132)"
+fi
+
+# --- finish.md Option 4 (#135). The gate that demanded a typed 'discard' fired
+# 2 of 13 measured runs; the prose now promises the thing that fired 3/3 —
+# capture an op id, abandon, hand back `jj op restore <id>`. Two claims ride on
+# that, and both are asserted here:
+#
+#   default   an id captured with `jj op log -n 1 --no-graph -T 'id.short()'`
+#             restores the abandoned change, INCLUDING an edit jj had not yet
+#             snapshotted (op log snapshots before it reports).
+#   ignore-wc adding --ignore-working-copy skips that snapshot and yields a
+#             restore point predating the last edits — the trap the prose warns
+#             about.
+#
+# Run as a two-arm comparison on purpose: a lone "restore works" check would
+# still pass if the flag stopped mattering, and finish.md's warning would rot
+# unnoticed. Arms must disagree.
+for mode in default ignore-wc; do
+  fr=$(new_repo)
+  R "$fr" jj git init . >/dev/null 2>&1
+  printf 'base\n' > "$fr/cwd/README.md"
+  R "$fr" jj describe -m "Initial commit" >/dev/null 2>&1
+  R "$fr" jj bookmark create main -r @ >/dev/null 2>&1
+  R "$fr" jj new main >/dev/null 2>&1
+  R "$fr" jj describe -m "Experimental spike" >/dev/null 2>&1
+  R "$fr" jj log -r @ >/dev/null 2>&1          # settle the op log...
+  printf 'late\n' > "$fr/cwd/late.txt"         # ...then edit, unsnapshotted
+
+  if [ "$mode" = ignore-wc ]; then
+    cp_id=$(R "$fr" jj op log -n 1 --no-graph --ignore-working-copy -T 'id.short()')
+  else
+    cp_id=$(R "$fr" jj op log -n 1 --no-graph -T 'id.short()')
+  fi
+
+  if [ -z "$cp_id" ]; then
+    bad "jj op log -n 1 --no-graph -T 'id.short()' rendered nothing — finish.md Option 4 step 1 is broken ($mode)"
+    continue
+  fi
+
+  tgt=$(R "$fr" jj log -r @ --no-graph --ignore-working-copy -T 'change_id.short()')
+  R "$fr" jj abandon "$tgt" >/dev/null 2>&1
+  R "$fr" jj op restore "$cp_id" >/dev/null 2>&1
+
+  if [ "$mode" = default ]; then
+    if [ -e "$fr/cwd/late.txt" ]; then
+      ok "jj op restore recovers an abandoned change incl. unsnapshotted edits (finish.md Option 4)"
+    else
+      bad "jj op restore did NOT recover the abandoned work — finish.md Option 4 promises it does (#135)"
+    fi
+  else
+    if [ -e "$fr/cwd/late.txt" ]; then
+      bad "--ignore-working-copy no longer costs the latest edits — finish.md's step-1 warning is now wrong (#135)"
+    else
+      ok "capturing with --ignore-working-copy loses the latest edits (finish.md's warning holds)"
+    fi
+  fi
+done
+
 # --- `jj git init` COLOCATES BY DEFAULT on 0.43. Any future eval scaffold or
 # tooling that relies on git being unusable in the work tree must pass
 # --no-colocate; a plain init does NOT hide the git dir. Pinned because a
@@ -108,6 +179,73 @@ if [ -e "$c2/cwd/$dg" ]; then
 else
   ok "'jj git init --no-colocate' produces a non-colocated repo"
 fi
+
+# --- finish.md Option 4, PUSHED case. Measured 2026-08-01: given a pushed
+# spike and "get rid of this work", 3 of 3 agents abandoned locally AND pushed
+# the bookmark deletion, destroying the remote's copy — then offered a bare
+# `jj op restore <id>` as the recovery path. That bare form is WRONG here: it
+# restores remote-tracking refs as well, so jj believes the remote still holds
+# the bookmark and the next push answers "Nothing changed." over an empty
+# remote. Silent loss behind a success message. `--what repo` is the fix, and
+# jj's own help says so ("Do not restore these if you'd like to push after the
+# undo").
+#
+# Two arms, because the whole point is that they differ: if a future jj made
+# the bare form safe, a one-armed check would keep passing and the prose would
+# rot in the harmful direction.
+# The bare remote MUST live outside the work tree. With origin.git inside it,
+# jj tracks the remote's own files as content and `jj op restore` restores the
+# remote itself — both arms then "succeed" and the assertion silently inverts.
+# Measured: that scaffold reports LANDED/LANDED, the correct one EMPTY/LANDED.
+for mode in bare what-repo; do
+  pr=$(new_repo)
+  R "$pr" jj git init . --no-colocate >/dev/null 2>&1
+  ( cd "$pr" && env -i PATH="$PATH" HOME="$pr/home" TERM=dumb git init --bare --quiet origin.git )
+  R "$pr" jj git remote add origin "$pr/origin.git" >/dev/null 2>&1
+  printf 'base\n' > "$pr/cwd/README.md"
+  R "$pr" jj describe -m "Initial commit" >/dev/null 2>&1
+  R "$pr" jj bookmark create main -r @ >/dev/null 2>&1
+  R "$pr" jj git push --bookmark main >/dev/null 2>&1
+  R "$pr" jj new main >/dev/null 2>&1
+  printf 'spike\n' > "$pr/cwd/spike.txt"
+  R "$pr" jj describe -m "Pushed spike" >/dev/null 2>&1
+  R "$pr" jj bookmark create pushed-spike -r @ >/dev/null 2>&1
+  R "$pr" jj git push --bookmark pushed-spike >/dev/null 2>&1
+
+  op=$(R "$pr" jj op log -n 1 --no-graph -T 'id.short()')
+  t=$(R "$pr" jj log -r @ --no-graph -T 'change_id.short()')
+  R "$pr" jj abandon "$t" >/dev/null 2>&1
+  R "$pr" jj git push --deleted >/dev/null 2>&1   # destroy the remote copy
+
+  if [ "$mode" = what-repo ]; then
+    R "$pr" jj op restore "$op" --what repo >/dev/null 2>&1
+  else
+    R "$pr" jj op restore "$op" >/dev/null 2>&1
+  fi
+  R "$pr" jj git push --bookmark pushed-spike >/dev/null 2>&1
+
+  # Ground truth is the REMOTE, not jj's belief about it.
+  if ( env -i PATH="$PATH" HOME="$pr/home" TERM=dumb \
+       git --git-dir="$pr/origin.git" show-ref --quiet refs/heads/pushed-spike ); then
+    landed=yes
+  else
+    landed=no
+  fi
+
+  if [ "$mode" = what-repo ]; then
+    if [ "$landed" = yes ]; then
+      ok "jj op restore --what repo lets a deleted pushed bookmark be re-pushed (finish.md Option 4)"
+    else
+      bad "jj op restore --what repo no longer restores a pushed bookmark — finish.md's recovery command is wrong (#135)"
+    fi
+  else
+    if [ "$landed" = yes ]; then
+      bad "a BARE jj op restore now re-publishes fine — finish.md's --what repo warning has become wrong (#135)"
+    else
+      ok "a bare jj op restore leaves the remote empty and the re-push a no-op (finish.md's warning holds)"
+    fi
+  fi
+done
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 test "$FAIL" -eq 0


### PR DESCRIPTION
## Summary

Two measured defects in `commit-commands-jj` command prose, fixed together because they share one diagnosis: **a git habit encoded as prose in a tool that does not need it.** Both were found independently — one offline at $0.00, one across three instruments — and neither is a deletion; `docs/eval-triage-2026-07.md` §5 stands.

### #132 — `clean_stale.md`'s bookmark half was vestigial

Steps 2 and 4 told the model to list bookmarks, find those whose remote counterpart was deleted, and delete each one. Step 1's own fetch has already done it. Re-verified on jj 0.43.0 while writing this:

```
--- 'jj git fetch' output ---
bookmark: feature-gone@origin [deleted] untracked
Abandoned 1 commits that are no longer reachable

--- follow-up delete on that same name ---
Warning: No matching bookmarks for names: feature-gone
No bookmarks to delete.        (exit 0)
```

A no-op that reads like a successful cleanup. The steps are gone; the fetch step now explains what it already did and tells the model to read the fetch output rather than re-derive it. `allowed-tools` narrowed from `Bash(jj bookmark:*)` to `Bash(jj bookmark list:*)` — the command no longer needs delete authority, so it no longer has it.

**The workspace half is untouched and now labelled as the real work.** A workspace whose directory was deleted stays registered forever and `jj workspace forget` is the only remedy.

### #135 — `finish.md` Option 4's typed-confirmation gate

The gate fired **2 of 13** measured runs across an eval, subagents with the skill reachable, and four fresh interactive sessions in auto mode. What fired **3/3** interactively, unprompted and never asked for by the prose, was a different safety pattern: record a checkpoint, then hand back the restore id.

Per the issue's option 2, the prose now describes the behaviour that happens reliably instead of prescribing the one that does not — capture an op id, state what is going, abandon, return `jj op restore <id>`. This is sound precisely because jj is not git here: `jj abandon` is reversible from the op log.

Verified round trip, including an edit jj had not yet snapshotted:

```
captured: db15b1a66ac5
jj abandon  -> spike.txt gone from disk
jj op restore db15b1a66ac5 -> spike.txt back, change restored
```

One trap surfaced while verifying and is now warned about in the prose: `jj op log` snapshots the working copy before reporting, so adding `--ignore-working-copy` hands back a restore point predating the latest edits — precisely the work about to be discarded. Measured both ways: with the flag the late edit is **lost**, without it **recovered**.

## What else changed

- `README.md` carried the same two claims in five places (`/finish` steps, `/finish` features, `/clean_stale` steps, `/clean_stale` features, and both "when to use" sections). All updated — otherwise the fix would have been half-shipped.
- `plugin.json` 0.13.0 to 0.14.0, required for any byte under `plugins/<name>/` (#84).

## Test plan

- [x] Three new assertions in `test-command-prose-claims.sh`, all **mutation-tested** — green on the first run proves nothing:
  - `clean_stale.md` grows an executable `jj bookmark delete` back → FAIL, exit 1. Control: the same string in *prose* (where the file legitimately names it to warn the model off) stays green. The check reads only fenced code blocks.
  - default capture arm silently gains `--ignore-working-copy` → FAIL, exit 1.
  - `--ignore-working-copy` arm loses its flag → FAIL, exit 1. Run as a two-arm comparison on purpose: a lone "restore works" check would still pass if the flag stopped mattering, and the warning would rot unnoticed.
- [x] `test-command-prose-claims.sh`: 9 passed, 0 failed.
- [x] All 19 suites pass under `/bin/bash`.
- [x] Version gate exercised with a real base tree (`BASE_DIR` at a checkout of trunk, not `.`): exit 0 as bumped, and exit 1 against a control base already at 0.14.0.
- [x] Every jj flag in the new prose checked against `--help` on 0.43.0, not memory: `jj op log` `-n` / `--no-graph` / `-T`, and `jj op restore <operation>`.

## Notes

- The stale-line-number reference `clean_stale.md:25` in the pre-existing `--prune` assertion is dropped — that claim has now moved once, and a stale pointer in a failure message costs more than it saves.
- Issue #132's body points at `tests/test-eval-case-observables.sh` for the pin; no such file exists. The assertion lives in `test-command-prose-claims.sh` (the triage doc has it right). Correcting the issue body separately.
- The third deliverable from this pass — auditing the other 14 commands for the same pattern — is deliberately **not** in this PR and is filed as a follow-up.

Closes #132
Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
