### PR TITLE
fix(commit-commands-jj): abandon.md's bare jj undo recovery is silently wrong (#138)

### DIFF
--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests — requires project-setup-jj",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/README.md
+++ b/plugins/commit-commands-jj/README.md
@@ -372,9 +372,10 @@ Undoes the last jj operation by restoring the repository to its previous state.
 Discards a jj change entirely, rebasing descendants onto its parent.
 
 **What it does:**
-1. Warns if the change has modifications that will be lost
-2. Runs `jj abandon` to discard the change
-3. Shows the result and reminds you about `/undo`
+1. Records a restore point from the op log before touching anything
+2. Warns if the change has modifications that will be lost
+3. Runs `jj abandon` to discard the change
+4. Shows the result and hands back the exact `jj op restore <id>` that reverses it
 
 **Usage:**
 ```bash
@@ -572,7 +573,7 @@ claude plugins add ./plugins/commit-commands-jj
 
 ### Using `/abandon`
 - Always check the diff before abandoning — modifications will be lost
-- Use `/undo` immediately if you abandoned by mistake
+- Recover with the `jj op restore <id>` it hands you, not with bare `jj undo` — `jj undo` reverses whatever the *latest* operation is, so once any other command has run it silently reverses that instead and reports success while the abandoned work stays gone
 - Descendants are rebased onto the parent, not deleted
 
 ### Using `/show`

--- a/plugins/commit-commands-jj/commands/abandon.md
+++ b/plugins/commit-commands-jj/commands/abandon.md
@@ -24,15 +24,38 @@ description: Discard a jj change (current or specified revision)
 
 In jj, `jj abandon` discards a change entirely. Descendants are rebased onto its parent. If you abandon the current working copy change, jj automatically creates a new empty change in its place.
 
-1. Check if the current change has modifications (from the diff stats/status above)
+1. **Capture the restore point before abandoning anything:**
+   ```bash
+   jj op log -n 1 --no-graph -T 'id.short()'
+   ```
+   `jj op log` snapshots the working copy before it reports, so this id already
+   covers the current state. Do **not** add `--ignore-working-copy` — it skips
+   that snapshot and returns a restore point predating the latest edits.
+2. Check if the current change has modifications (from the diff stats/status above)
    - If it does, warn the user that the change has uncommitted work that will be lost
-2. Run `jj abandon`
+3. Run `jj abandon`
    - If the user specified a revision, run `jj abandon <revision>` instead
-3. Show the result: `jj log --limit 5 --no-graph -T 'json(self) ++ "\n"'` and `jj status`
-4. Remind the user: run `/undo` if this was a mistake
+4. Show the result: `jj log --limit 5 --no-graph -T 'json(self) ++ "\n"'` and `jj status`
+5. **Hand back the id from step 1, not a bare `jj undo`:**
+   ```
+   If you want it back: jj op restore <id>
+   ```
 
 Notes:
-- Abandoning a change does NOT delete its content from the op log — it can be recovered with `jj undo`
+- Abandoning a change does NOT delete its content from the op log, so it stays
+  recoverable — but **say how with the captured id, not with bare `jj undo`.**
+  `jj undo` is *sequential*: it reverses whatever the most recent operation
+  happens to be. Immediately after the abandon that is the abandon, so it works.
+  Let one ordinary command run in between — a `jj describe`, anything — and it
+  reverses that instead, **reporting success while the abandoned work stays
+  gone.** `jj op restore <id>` names the target and says the same thing however
+  much has happened since. `/undo` is safe to point at because it runs
+  `jj op revert <op-id>` with an explicit id; bare `jj undo` is not the same thing
+- If the abandoned change carried a bookmark that had been **pushed**, the remote
+  still holds its copy — `jj abandon` does not touch the remote. Only a later
+  `jj git push --deleted` removes it, and recovering from *that* additionally
+  needs `jj op restore <id> --what repo`, because the bare form restores
+  remote-tracking refs and leaves jj believing the remote still has the branch
 - Descendants of the abandoned change are rebased onto its parent
 - If you abandon the working copy change (`@`), jj creates a new empty change automatically
 - To abandon multiple changes, use a revset: `jj abandon <revset>`

--- a/plugins/commit-commands-jj/tests/test-command-prose-claims.sh
+++ b/plugins/commit-commands-jj/tests/test-command-prose-claims.sh
@@ -247,5 +247,68 @@ for mode in bare what-repo; do
   fi
 done
 
+# --- abandon.md (#138): bare `jj undo` is SEQUENTIAL, so it is only a valid
+# recovery for an abandon if nothing else has run since. Measured 2026-08-01:
+# immediately after the abandon it works; let a single ordinary command run in
+# between and it reverses THAT instead — leaving the abandoned work gone while
+# printing "Undid operation ... / Restored to operation ... abandon commit",
+# which reads like success. The captured op id works either way.
+#
+# abandon.md used to say "it can be recovered with `jj undo`" while undo.md
+# warned against exactly that; the prose now names the id. Two arms, because
+# the claim IS the difference between them.
+for mode in immediate after-one-op; do
+  ar=$(new_repo)
+  R "$ar" jj git init . --no-colocate >/dev/null 2>&1
+  printf 'base\n' > "$ar/cwd/README.md"
+  R "$ar" jj describe -m "Initial" >/dev/null 2>&1
+  R "$ar" jj bookmark create main -r @ >/dev/null 2>&1
+  R "$ar" jj new main >/dev/null 2>&1
+  printf 'spike\n' > "$ar/cwd/spike.txt"
+  R "$ar" jj describe -m "Spike" >/dev/null 2>&1
+
+  a_op=$(R "$ar" jj op log -n 1 --no-graph -T 'id.short()')
+  a_t=$(R "$ar" jj log -r @ --no-graph -T 'change_id.short()')
+  R "$ar" jj abandon "$a_t" >/dev/null 2>&1
+  # TWO intervening ops, not one. With a single op, a second bare `jj undo`
+  # also recovers the abandon (undo is sequential), so the "captured id works"
+  # arm below would pass even if the id were replaced by an undo — proven by
+  # mutation. Two ops put the abandon out of reach of any single undo, which
+  # makes that arm actually discriminating.
+  if [ "$mode" = after-one-op ]; then
+    R "$ar" jj describe -m "unrelated" >/dev/null 2>&1
+    R "$ar" jj new >/dev/null 2>&1
+  fi
+  R "$ar" jj undo >/dev/null 2>&1
+
+  if [ "$mode" = immediate ]; then
+    if [ -e "$ar/cwd/spike.txt" ]; then
+      ok "bare 'jj undo' straight after an abandon does recover it"
+    else
+      bad "bare 'jj undo' no longer recovers an immediate abandon — abandon.md's note is wrong (#138)"
+    fi
+  else
+    if [ -e "$ar/cwd/spike.txt" ]; then
+      bad "bare 'jj undo' now survives an intervening command — abandon.md's sequential warning has gone stale (#138)"
+    else
+      ok "bare 'jj undo' after one intervening command recovers the WRONG op (abandon.md's warning holds)"
+    fi
+    # ...and the captured id still works, which is what the prose hands back.
+    R "$ar" jj op restore "$a_op" >/dev/null 2>&1
+    if [ -e "$ar/cwd/spike.txt" ]; then
+      ok "the op id captured before abandoning restores it regardless (abandon.md step 1)"
+    else
+      bad "jj op restore <captured id> failed to recover the abandon — abandon.md step 5 is wrong (#138)"
+    fi
+  fi
+done
+
+# --- undo.md recommends `jj op revert <op-id>`; it must still exist.
+if jj op revert --help >/dev/null 2>&1; then
+  ok "jj op revert exists (undo.md recommends it over bare jj undo)"
+else
+  bad "jj op revert is gone — undo.md recommends a command that no longer exists"
+fi
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 test "$FAIL" -eq 0


### PR DESCRIPTION
## Summary

`abandon.md` told the user to recover a discarded change with bare `jj undo`, while `undo.md` in the same plugin warns against exactly that. The advice is correct only if nothing else has run since the abandon; one ordinary command later it reverses the wrong operation **and reports success**.

Found by aiming, not by reading. A trigger measurement (#138) showed that the natural request *"I want to discard this change"* routes to `commit-commands-jj:abandon` **3/3**, not to `finish` — so #137's recovery fix landed on the command users don't reach for this task.

## The measurement

| | result |
|---|---|
| `jj undo` **immediately** after the abandon | recovers it — the existing advice works here |
| `jj undo` after **one** ordinary command (`jj describe`) | **does not recover it** |

The failure is silent. jj prints what reads like success:

```
Undid operation: 53237d8e855c ... describe commit ...
Restored to operation: 0669593156e7 ... abandon commit ...
```

"Restored to operation … abandon commit" means restored *to the state after* the abandon — the abandoned work is still gone. The captured op id recovers it either way.

This is the same root cause `undo.md:37-41` already documents: `jj undo` is **sequential**, reversing whatever the latest operation happens to be, so it says something different every time it runs.

## What changed

- **`abandon.md`** now captures a restore point first (`jj op log -n 1 --no-graph -T 'id.short()'`, with the `--ignore-working-copy` trap noted), and hands back `jj op restore <id>` instead of bare `jj undo`. The note explains why, and that `/undo` remains safe to point at because it runs `jj op revert <op-id>` with an explicit id — bare `jj undo` is not the same thing.
- Added the pushed-bookmark case: `jj abandon` does **not** touch the remote, so a pushed copy survives; only a later `jj git push --deleted` removes it, and recovering from that additionally needs `--what repo` (per #137).
- **`README.md`** — the `/abandon` steps and its "when to use" bullet carried the same claim.
- **`undo.md` is unchanged.** It was already correct; this PR brings `abandon.md` into line with it rather than the reverse.

## Test plan

- [x] Two new two-arm assertions in `test-command-prose-claims.sh` (immediate undo recovers / undo-after-intervening-ops does not / the captured id works regardless), plus a check that `jj op revert` still exists since `undo.md` recommends it.
- [x] **Mutation-tested, and the first version was caught as too weak.** Substituting a bare `jj undo` for the captured id initially still passed — with only one intervening op, a *second* undo also reaches the abandon. The arm now uses two intervening ops, which no single undo can span; both mutations then fail with exit 1:
  - remove the intervening commands → `FAIL … sequential warning has gone stale`
  - restore via bare undo instead of the captured id → `FAIL … abandon.md step 5 is wrong`
- [x] `test-command-prose-claims.sh`: 15 passed, 0 failed.
- [x] All 19 suites pass under `/bin/bash`.
- [x] Version gate exercised with a real base tree (`BASE_DIR` at a checkout of trunk): exit 0 bumped, exit 1 against an unbumped control.
- [x] Every flag verified against `--help` on jj 0.43.0, not memory.

## Scope note

An earlier read of this had `abandon.md` wedging the repo on pushed changes. That was wrong and is not claimed here: the wedge requires `jj git push --deleted` between the abandon and the undo, and **`/abandon` never pushes**. The defect is the silent wrong-operation recovery above.

`plugin.json` 0.14.0 → 0.15.0 (#84).

Refs #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
