### PR TITLE
test(commit-commands-jj): lint every jj invocation the commands contain (#142)

### DIFF
--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests — requires project-setup-jj",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/tests/test-command-invocations.sh
+++ b/plugins/commit-commands-jj/tests/test-command-invocations.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Every jj invocation this plugin's commands contain must still be valid.
+#
+# Sibling to test-command-prose-claims.sh, and deliberately different in kind:
+# that suite asserts BEHAVIOUR ("fetch already pruned the bookmark") by running
+# jj; this one asserts the invocations EXIST — breadth, not depth.
+#
+# Why it exists (#142): prose rots silently. The file still reads
+# authoritatively while naming a flag jj removed, and nothing surfaces it until
+# a user is misled. `jj git push --allow-new` was reached for three separate
+# times in this project by trusting recall; it does not exist in 0.43.0. Evals
+# cannot catch this class — the model routes around a bad flag and still scores
+# well.
+#
+# Two sources, because commands carry invocations in two places:
+#
+#   1. !-injected Context commands. These AUTO-EXECUTE on every invocation of
+#      the command, so a bad flag breaks it immediately. They contain no
+#      placeholders, so they are checked by RUNNING them — which also validates
+#      the -T templates, something --help cannot see. 16 of 16 command files
+#      have at least one.
+#   2. Fenced code examples. These contain <placeholders> and cannot be run, so
+#      their long flags are checked against `jj <sub> --help`.
+#
+# bash 3.2 safe: no globstar, no associative arrays, no mapfile. Counts are
+# accumulated through a FILE, not a pipeline — `... | while` runs in a subshell
+# and silently loses them (the #84 lint shipped that bug inside its own fix).
+set -uo pipefail
+
+CMDS="$(cd "$(dirname "$0")/.." && pwd)/commands"
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+if ! command -v jj >/dev/null 2>&1; then
+  printf 'FAIL - jj must be installed to verify command invocations\n'
+  printf '0 passed, 1 failed\n'
+  exit 1
+fi
+
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# ---------------------------------------------------------------- seeded repo
+# Sandbox HOME so the developer's own ~/.config/jj is never read or written
+# (#118: a scaffold once truncated it). Non-colocated so nothing can silently
+# fall back to git. A remote exists so trunk() resolves; @- , a bookmark, a tag
+# and real file content exist so log/diff/show/tag have something to render.
+R="$TMPROOT/repo"
+mkdir -p "$R/home/.config/jj" "$R/cwd"
+printf '[user]\nname = "test"\nemail = "test@example.com"\n\n[ui]\npaginate = "never"\neditor = "true"\n' \
+  > "$R/home/.config/jj/config.toml"
+J() { ( cd "$R/cwd" && env -i PATH="$PATH" HOME="$R/home" USERPROFILE="$R/home" \
+        XDG_CONFIG_HOME="$R/home/.config" TMPDIR="${TMPDIR:-/tmp}" TERM=dumb "$@" ); }
+
+( cd "$R" && env -i PATH="$PATH" HOME="$R/home" TERM=dumb git init --bare --quiet origin.git )
+J jj git init . --no-colocate       >/dev/null 2>&1
+J jj git remote add origin "$R/origin.git" >/dev/null 2>&1
+printf 'base\n' > "$R/cwd/README.md"
+J jj describe -m "Initial commit"   >/dev/null 2>&1
+J jj bookmark create main -r @      >/dev/null 2>&1
+J jj git push --bookmark main       >/dev/null 2>&1
+J jj new main                       >/dev/null 2>&1
+printf 'feature\n' >  "$R/cwd/feature.txt"
+printf 'more\n'    >> "$R/cwd/README.md"
+J jj describe -m "Add feature"      >/dev/null 2>&1
+( cd "$R" && env -i PATH="$PATH" HOME="$R/home" TERM=dumb git --git-dir=origin.git tag v1.0 ) >/dev/null 2>&1
+J jj git fetch                      >/dev/null 2>&1
+
+if ! J jj status >/dev/null 2>&1; then
+  bad "could not seed the throwaway repo — the checks below would be vacuous"
+  printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+  exit 1
+fi
+
+# ------------------------------------------------ 1. injected Context commands
+# Distinct across all command files; each is run verbatim in the seeded repo.
+grep -ohE '!`jj [^`]+`' "$CMDS"/*.md 2>/dev/null \
+  | sed 's/^!`//;s/`$//' | sort -u > "$TMPROOT/injected"
+
+inj_total=0
+while IFS= read -r cmd; do
+  [ -n "$cmd" ] || continue
+  inj_total=$((inj_total+1))
+  if out=$( cd "$R/cwd" && env -i PATH="$PATH" HOME="$R/home" USERPROFILE="$R/home" \
+            XDG_CONFIG_HOME="$R/home/.config" TMPDIR="${TMPDIR:-/tmp}" TERM=dumb \
+            /bin/sh -c "$cmd" 2>&1 ); then
+    ok "Context command runs: $cmd"
+  else
+    bad "Context command FAILED: $cmd -- $(printf '%s' "$out" | head -1)"
+  fi
+done < "$TMPROOT/injected"
+
+if [ "$inj_total" -eq 0 ]; then
+  bad "no !-injected commands found — the extractor broke, so this half is vacuous"
+fi
+
+# ------------------------------------------------------ 2. fenced example flags
+# Long flags only; short flags are ambiguous to attribute without a full parser.
+# Write results to a file: the loop is fed by a pipeline, so counters set inside
+# it would be lost in the subshell.
+: > "$TMPROOT/fenced"
+for f in "$CMDS"/*.md; do
+  fname=$(basename "$f")
+  awk '/^[[:space:]]*```/{i=!i;next} i' "$f" | grep -E '^[[:space:]]*jj ' | sed 's/^[[:space:]]*//' |
+  while IFS= read -r line; do
+    line=${line%%#*}                       # drop trailing comments
+    # shellcheck disable=SC2086
+    set -- $line
+    shift                                   # drop "jj"
+    [ $# -gt 0 ] || continue
+
+    # Derive the subcommand split rather than hardcoding a list: prefer the
+    # two-word form when jj actually accepts it.
+    sub="$1"
+    if [ $# -ge 2 ]; then
+      case "$2" in
+        -*) : ;;
+        *) if jj "$1" "$2" --help >/dev/null 2>&1; then sub="$1 $2"; shift; fi ;;
+      esac
+    fi
+    shift
+
+    # shellcheck disable=SC2086
+    if ! help=$(jj $sub --help 2>&1); then
+      printf 'FAIL\t%s: `jj %s` is not a jj subcommand\n' "$fname" "$sub" >> "$TMPROOT/fenced"
+      continue
+    fi
+
+    for tok in "$@"; do
+      case "$tok" in
+        --) break ;;
+        --*)
+          flag=${tok%%=*}
+          if printf '%s' "$help" | grep -q -- "$flag"; then
+            printf 'ok\t%s: jj %s accepts %s\n' "$fname" "$sub" "$flag" >> "$TMPROOT/fenced"
+          else
+            printf 'FAIL\t%s: jj %s does NOT accept %s\n' "$fname" "$sub" "$flag" >> "$TMPROOT/fenced"
+          fi ;;
+      esac
+    done
+  done
+done
+
+# `wc -l`, not `grep -c .`: on an empty file grep prints "0" AND exits 1, so a
+# `|| printf 0` fallback concatenates to "00" and the -eq test below misfires —
+# leaving this guard silently unable to fire. Caught by mutation testing.
+fen_total=$(wc -l < "$TMPROOT/fenced" | tr -d ' ')
+while IFS= read -r row; do
+  [ -n "$row" ] || continue
+  case "$row" in
+    ok*)   ok   "$(printf '%s' "$row" | cut -f2-)" ;;
+    FAIL*) bad  "$(printf '%s' "$row" | cut -f2-)" ;;
+  esac
+done < "$TMPROOT/fenced"
+
+if [ "$fen_total" -eq 0 ]; then
+  bad "no fenced jj invocations found — the extractor broke, so this half is vacuous"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+test "$FAIL" -eq 0


### PR DESCRIPTION
## Summary

Adds `tests/test-command-invocations.sh` — 32 checks that every `jj` invocation in `commit-commands-jj`'s 16 command files is still valid on the installed jj.

**Up front: this found no existing bugs.** All 32 pass on jj 0.43.0. It is a PR-time guard against a class that has already recurred, not a fix for something broken today. #142 is framed as though stale flags might already be present; they are not, and the honest value is regression prevention.

The class it guards: `jj git push --allow-new` was reached for **three separate times** in this project by trusting recall. It does not exist in 0.43.0. Prose rots silently — the file still reads authoritatively while naming a flag jj removed, and evals cannot catch it because the model routes around a bad flag and the case still scores well.

## Two sources, because the design assumption was wrong

#142 proposed extracting invocations from prose and checking them against `--help`. Measuring first showed commands carry invocations in **two** places, and the one that matters most is not the fenced examples:

| source | count | why it matters | how it's checked |
|---|---|---|---|
| `!`-injected Context commands | 18 distinct, **16/16 files have ≥1** | **auto-execute on every invocation** — a bad flag breaks the command immediately | **run verbatim** in a seeded repo |
| fenced code examples | 14 flag checks, only 4/16 files | model reads them; placeholders make them unrunnable | long flags vs `jj <sub> --help` |

Running the injected half is strictly better than parsing `--help` for it: it also validates the `-T` templates, which `--help` cannot see. Several are non-trivial (`self.diff().stat().files().map(...)`, `escape_json()`), and a template error would break the command just as surely as a bad flag.

The seeded repo has a remote so `trunk()` resolves, plus `@-`, a bookmark, a tag and real file content so `log`/`diff`/`show`/`tag list` have something to render.

## Test plan

- [x] 32 checks pass; suite count 19 → 20, auto-discovered by CI's existing `test-*.sh` glob (verified).
- [x] **Mutation-tested, five ways** — all fail with exit 1 reaching the runner:
  - fenced example gains `--allow-new` → `jj git push does NOT accept --allow-new`
  - injected command gains a bogus flag → `Context command FAILED … unexpected argument`
  - fenced example names `jj wrkspace` → `is not a jj subcommand`
  - injected extractor matches nothing → `the extractor broke, so this half is vacuous`
  - fenced extractor matches nothing → same
- [x] **A mutation caught a bug in the lint itself.** The fenced-half vacuity guard could not fire: `grep -c .` on an empty file prints `0` *and* exits 1, so the `|| printf 0` fallback concatenated to `00` and the `-eq` test misfired. Had the extractor ever broken, the lint would have reported a clean pass over zero checks. Now uses `wc -l`, and the mutation fails as intended.
- [x] All 20 suites pass under `/bin/bash`.
- [x] Version gate exercised with a real base tree: exit 0 bumped, exit 1 on an unbumped control.

## Notes

- bash 3.2 safe. Counters accumulate through a **file**, not a pipeline — `… | while` runs in a subshell and silently loses them, which is the bug the #84 lint once shipped inside its own fix.
- Sandbox `HOME` for the seeded repo (#118), and `--no-colocate` so nothing can fall back to git.
- Subcommand splitting is **derived, not hardcoded**: it prefers the two-word form when `jj <a> <b> --help` actually succeeds, so new two-word subcommands need no list maintenance.
- Scope boundary: existence only. Behavioural claims stay in `test-command-prose-claims.sh`, which asserts them by running jj. Breadth here, depth there.
- Short flags (`-r`, `-T`, `-n`) are not attributed in the fenced half — ambiguous without a full parser. The injected half covers them by execution.

`plugin.json` 0.15.0 → 0.16.0 (#84).

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)
