### PR TITLE
docs(readme): fix a dead test path and record the command-prose eval limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,11 @@ Two verification layers cover this repo, doing different jobs:
 | Layer | Question it answers | Where | Gating |
 |---|---|---|---|
 | 1 — evals | Does a plugin change what the **model** does? | `plugins/<name>/evals/<case>/` | none — run by hand |
-| 2 — shell tests | Do the **scripts** behave? | `plugins/<name>/tests/test-*.sh`, `.github/tests/` | CI, every push |
+| 2 — shell tests | Do the **scripts** behave, and does the **prose** still describe reality? | `plugins/<name>/tests/test-*.sh`, `.github/tests/` | CI, every push |
 
-Layer 2 is the gate. The eval suite gates nothing — it is a measurement instrument, run deliberately, to answer what a deterministic test cannot: whether the prose and hooks a plugin ships actually move model behaviour. Each case runs under `--ablation with-without` (plugin loaded vs. not), and the **delta between the two arms is the result**. A case whose arms score the same measured nothing, however green it looks.
+Layer 2 is the gate. It covers two distinct questions, and the second one is easy to overlook: besides asserting that scripts behave, it asserts that the **command prose has not rotted**. Prose fails silently — a command file still reads authoritatively while naming a flag jj removed, or describing behaviour jj no longer has, and nothing surfaces it until a user is misled. Two suites in `plugins/commit-commands-jj/tests/` do that job: `test-command-invocations.sh` runs or `--help`-checks every `jj` invocation the 16 commands contain, and `test-command-prose-claims.sh` asserts the jj *behaviours* the prose claims by exercising them in throwaway repos.
+
+The eval suite gates nothing — it is a measurement instrument, run deliberately, to answer what a deterministic test cannot: whether the prose and hooks a plugin ships actually move model behaviour. Each case runs under `--ablation with-without` (plugin loaded vs. not), and the **delta between the two arms is the result**. A case whose arms score the same measured nothing, however green it looks. **For hooks that works and is demonstrated below; for command prose it does not — see the limit in Measured results before writing a command case.**
 
 ### Running it
 
@@ -156,9 +158,19 @@ The runner emits one TSV row per case — `name / score / score_without / delta 
 
 ### Measured results
 
-Tranche 1 (issue #79) is written up in **[docs/eval-triage-2026-07.md](docs/eval-triage-2026-07.md)** — what shipped, what was cut and why, and three runner gaps found but left unfixed. Two cases ship today, both under `plugins/commit-commands-jj/evals/`, both at Δ +1.00, and they now exercise **different** branches of `block-raw-git.sh`. `hook-blocks-git-internals` did not: its name promised the internals branch while its `git rev-parse HEAD` prompt was answered by the raw-git branch, which returns first (§1.1). Issue #103 repointed it at a dot-git path, narrowed its grader to wording the raw-git branch cannot produce, and re-measured at Δ +1.00 — so the triage document's §1.1 finding is resolved, not still open. A third case measured Δ 0.00 and was cut; its assertions now live in `plugins/commit-commands-jj/tests/test-block-raw-git-gating.sh`, where they are deterministic and free.
+Tranche 1 (issue #79) is written up in **[docs/eval-triage-2026-07.md](docs/eval-triage-2026-07.md)** — what shipped, what was cut and why, and three runner gaps found but left unfixed. Two cases ship today, both under `plugins/commit-commands-jj/evals/`, both at Δ +1.00, and they now exercise **different** branches of `block-raw-git.sh`. `hook-blocks-git-internals` did not: its name promised the internals branch while its `git rev-parse HEAD` prompt was answered by the raw-git branch, which returns first (§1.1). Issue #103 repointed it at a dot-git path, narrowed its grader to wording the raw-git branch cannot produce, and re-measured at Δ +1.00 — so the triage document's §1.1 finding is resolved, not still open. A third case measured Δ 0.00 and was cut; its assertions now live in `plugins/project-setup-jj/tests/test-block-raw-git.sh`, where they are deterministic and free.
 
-Read the triage document before authoring a case. Its §3 is the prompting-and-grading recipe that was measured to work; its §2 is three separate mechanisms that make a case report green while measuring nothing.
+### The limit: command prose cannot be measured on this harness
+
+Tranche 2 is written up in **[docs/eval-command-triage-2026-07.md](docs/eval-command-triage-2026-07.md)**, and its headline is a negative result worth knowing before spending anything.
+
+**Both shipped cases exercise a hook. No eval case can measure a `commit-commands-jj` *command*.** Under this harness the plugin's commands register as slash_commands contributing **zero skills**, and `SlashCommand` is not grantable — so the command's prose never enters the model's context and every case reads `NO_GAP` by construction, whatever the prose says. The obvious unblocking (ship the commands as skills) was **refuted by measurement**, not merely untried: they are already `Skill`-invocable in a real session, and fresh agents given a natural-language task ignored them anyway. Issues #104 and #133 are closed on that basis.
+
+What works instead is cheaper and needs no harness: dispatch agents at throwaway repos, grade from **repo state** rather than from what the agent narrates, and pin each finding as a mutation-tested assertion in layer 2. That route found and fixed real defects in `finish.md` (#137) and `abandon.md` (#139).
+
+One further measurement shapes how much any command-prose fix is worth: **a command auto-invokes roughly 1 request in 6**, and the rate tracks how closely the request's wording matches the command's `description:` field. A command whose prose is perfect but which never fires contributes nothing.
+
+Read both triage documents before authoring a case. Tranche 1's §3 is the prompting-and-grading recipe that was measured to work; its §2 is three separate mechanisms that make a case report green while measuring nothing. Tranche 2's §2 and §7 carry the command-prose limit above and the instrument constraints behind it.
 
 Failure taxonomy informed by netresearch/jujutsu-workflow-skill (MIT AND CC-BY-SA-4.0); cases independently authored.
 


### PR DESCRIPTION
## Summary

Three fixes to the root `README.md`, one of which was the README actively pointing readers at a dead end.

### 1. A dead file path

The Evals section cited `plugins/commit-commands-jj/tests/test-block-raw-git-gating.sh` as the home of the cut third case's assertions. **That file does not exist.** They live in `plugins/project-setup-jj/tests/test-block-raw-git.sh` (151 assertions).

The same stale filename was also in #99, which is now closed — it had outlived two documents.

### 2. The layer table understated layer 2

It described layer 2 as answering *"Do the **scripts** behave?"* That is no longer the whole job. `test-command-prose-claims.sh` and `test-command-invocations.sh` do not test scripts — they test **prose**, which is a different question: *do the docs still describe reality?* That is ~47 assertions the table did not account for, and it is the layer that grew most this week.

Layer 2's row now covers both, with a short paragraph naming the two suites and why the prose half exists: prose fails silently — a command file still reads authoritatively while naming a flag jj removed, and nothing surfaces it until a user is misled.

### 3. The Evals section described a capability without its measured limit

It said evals answer "whether the prose and hooks a plugin ships actually move model behaviour." For **hooks** that is true and demonstrated — both shipped cases are hook cases at Δ +1.00. For **command prose** it has been refuted: under this harness the plugin's commands register as slash_commands contributing zero skills, `SlashCommand` is not grantable, so the prose never enters context and every case reads `NO_GAP` by construction. The obvious unblocking (ship commands as skills) was refuted by measurement rather than left untried — they are already `Skill`-invocable in a real session and fresh agents ignored them anyway. #104 and #133 are closed on that basis.

Someone following the old section to write a command case would have spent real money rediscovering a closed question. `docs/eval-command-triage-2026-07.md` — the tranche-2 write-up carrying all of this — was also not linked from anywhere in the README.

The new subsection states the limit, links the document, points at what works instead (dispatch agents at throwaway repos, grade from repo state, pin findings as mutation-tested layer-2 assertions — the route that produced #137 and #139), and records the measurement that bounds the value of any command-prose fix: **a command auto-invokes roughly 1 request in 6**, tracking how closely the request's wording matches the command's `description:`.

## Test plan

- [x] **Every file path cited in the README resolves** — checked by extracting each backticked `plugins/…`, `docs/…`, `.github/…` path and each markdown link, then testing for existence. All pass; this is what surfaced the dead path in the first place.
- [x] `test-readme-no-version.sh`: 5 passed, 0 failed.
- [x] All 20 suites pass under `/bin/bash`.
- [x] No version bump needed — root `README.md` is not under `plugins/<name>/`, so #84's gate does not apply.

Docs only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
