### PR TITLE
test(commit-commands-jj): lint Git→jj table cells too; link the upstream command table

### DIFF
--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests — requires project-setup-jj",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/README.md
+++ b/plugins/commit-commands-jj/README.md
@@ -602,6 +602,11 @@ claude plugins add ./plugins/commit-commands-jj
 
 ## jj Concepts for Git Users
 
+The table below is a short orientation for the concepts these commands rely on. For a **command-by-command** mapping, use jj's own [git command table](https://docs.jj-vcs.dev/latest/git-command-table/) — it is more complete, carries a Notes column, and tracks jj releases. Two things it does not cover that matter here:
+
+- **`jj undo` is sequential.** It reverses whatever the *latest* operation happens to be, so once any other command has run it reverses that instead — silently, while reporting success. Prefer `jj op revert <op-id>`, or an op id captured before the change. See `/undo` and `/abandon`.
+- **Deleting a pushed bookmark is recoverable only with care.** A bare `jj op restore` also restores remote-tracking refs, leaving jj convinced the remote still has the branch; the next push answers `Nothing changed.` over an empty remote. Use `jj op restore <id> --what repo`, then re-push. See `/finish`.
+
 | Git | jj |
 |---|---|
 | staging area | No equivalent — working copy IS a commit |

--- a/plugins/commit-commands-jj/tests/test-command-invocations.sh
+++ b/plugins/commit-commands-jj/tests/test-command-invocations.sh
@@ -96,50 +96,83 @@ if [ "$inj_total" -eq 0 ]; then
   bad "no !-injected commands found — the extractor broke, so this half is vacuous"
 fi
 
+# -------------------------------------------- shared check for static sources
+# Validates one `jj ...` string: the subcommand resolves, and every LONG flag is
+# accepted. Short flags are skipped — ambiguous to attribute without a real
+# parser; the injected half covers them by execution.
+#
+# Always emits a row for the subcommand itself, even when there are no flags.
+# Most table cells are bare (`jj abandon`, `jj status`), so without that they
+# would be silently checked-but-unrecorded and the vacuity guards below could
+# not tell "nothing to check" from "extractor broke".
+#
+# Shared by both static extractors so they cannot drift apart. Appends
+# tab-separated rows to $3; never sets counters, because callers run it inside
+# pipelines where a subshell would lose them.
+check_invocation() {   # $1 = label   $2 = command string   $3 = outfile
+  ci_label="$1"; ci_out="$3"
+  ci_line=${2%%#*}                          # drop trailing comments
+  # shellcheck disable=SC2086
+  set -- $ci_line
+  [ "${1:-}" = jj ] || return 0
+  shift
+  [ $# -gt 0 ] || return 0
+
+  # Derive the subcommand split rather than hardcoding a list: prefer the
+  # two-word form when jj actually accepts it.
+  ci_sub="$1"
+  if [ $# -ge 2 ]; then
+    case "$2" in
+      -*) : ;;
+      *) if jj "$1" "$2" --help >/dev/null 2>&1; then ci_sub="$1 $2"; shift; fi ;;
+    esac
+  fi
+  shift
+
+  # shellcheck disable=SC2086
+  if ! ci_help=$(jj $ci_sub --help 2>&1); then
+    printf 'FAIL\t%s: `jj %s` is not a jj subcommand\n' "$ci_label" "$ci_sub" >> "$ci_out"
+    return 0
+  fi
+  printf 'ok\t%s: jj %s exists\n' "$ci_label" "$ci_sub" >> "$ci_out"
+
+  for tok in "$@"; do
+    case "$tok" in
+      --) break ;;
+      --*)
+        ci_flag=${tok%%=*}
+        if printf '%s' "$ci_help" | grep -q -- "$ci_flag"; then
+          printf 'ok\t%s: jj %s accepts %s\n' "$ci_label" "$ci_sub" "$ci_flag" >> "$ci_out"
+        else
+          printf 'FAIL\t%s: jj %s does NOT accept %s\n' "$ci_label" "$ci_sub" "$ci_flag" >> "$ci_out"
+        fi ;;
+    esac
+  done
+}
+
 # ------------------------------------------------------ 2. fenced example flags
-# Long flags only; short flags are ambiguous to attribute without a full parser.
-# Write results to a file: the loop is fed by a pipeline, so counters set inside
-# it would be lost in the subshell.
 : > "$TMPROOT/fenced"
 for f in "$CMDS"/*.md; do
   fname=$(basename "$f")
   awk '/^[[:space:]]*```/{i=!i;next} i' "$f" | grep -E '^[[:space:]]*jj ' | sed 's/^[[:space:]]*//' |
   while IFS= read -r line; do
-    line=${line%%#*}                       # drop trailing comments
-    # shellcheck disable=SC2086
-    set -- $line
-    shift                                   # drop "jj"
-    [ $# -gt 0 ] || continue
+    check_invocation "$fname fenced" "$line" "$TMPROOT/fenced"
+  done
+done
 
-    # Derive the subcommand split rather than hardcoding a list: prefer the
-    # two-word form when jj actually accepts it.
-    sub="$1"
-    if [ $# -ge 2 ]; then
-      case "$2" in
-        -*) : ;;
-        *) if jj "$1" "$2" --help >/dev/null 2>&1; then sub="$1 $2"; shift; fi ;;
-      esac
-    fi
-    shift
-
-    # shellcheck disable=SC2086
-    if ! help=$(jj $sub --help 2>&1); then
-      printf 'FAIL\t%s: `jj %s` is not a jj subcommand\n' "$fname" "$sub" >> "$TMPROOT/fenced"
-      continue
-    fi
-
-    for tok in "$@"; do
-      case "$tok" in
-        --) break ;;
-        --*)
-          flag=${tok%%=*}
-          if printf '%s' "$help" | grep -q -- "$flag"; then
-            printf 'ok\t%s: jj %s accepts %s\n' "$fname" "$sub" "$flag" >> "$TMPROOT/fenced"
-          else
-            printf 'FAIL\t%s: jj %s does NOT accept %s\n' "$fname" "$sub" "$flag" >> "$TMPROOT/fenced"
-          fi ;;
-      esac
-    done
+# ------------------------------------------- 3. Git → jj translation table cells
+# Every command file carries a `| git ... | jj ... |` block, and the plugin
+# README carries a conceptual one. These are markdown table cells — neither
+# fenced nor !-injected — so nothing checked them until #144's review noticed.
+# 26 distinct invocations live here.
+: > "$TMPROOT/tables"
+for f in "$CMDS"/*.md "$CMDS/../README.md"; do
+  [ -f "$f" ] || continue
+  fname=$(basename "$f")
+  grep -hoE '^\|[^|]*\|[[:space:]]*`jj [^`]+`' "$f" 2>/dev/null \
+    | sed 's/.*`jj /jj /; s/`$//' |
+  while IFS= read -r line; do
+    check_invocation "$fname table" "$line" "$TMPROOT/tables"
   done
 done
 
@@ -147,16 +180,24 @@ done
 # `|| printf 0` fallback concatenates to "00" and the -eq test below misfires —
 # leaving this guard silently unable to fire. Caught by mutation testing.
 fen_total=$(wc -l < "$TMPROOT/fenced" | tr -d ' ')
+tbl_total=$(wc -l < "$TMPROOT/tables" | tr -d ' ')
+
+cat "$TMPROOT/fenced" "$TMPROOT/tables" > "$TMPROOT/static"
 while IFS= read -r row; do
   [ -n "$row" ] || continue
   case "$row" in
     ok*)   ok   "$(printf '%s' "$row" | cut -f2-)" ;;
     FAIL*) bad  "$(printf '%s' "$row" | cut -f2-)" ;;
   esac
-done < "$TMPROOT/fenced"
+done < "$TMPROOT/static"
 
+# Guard each extractor separately: a combined count stays healthy while one
+# source silently stops matching.
 if [ "$fen_total" -eq 0 ]; then
-  bad "no fenced jj invocations found — the extractor broke, so this half is vacuous"
+  bad "no fenced jj invocations found — that extractor broke, so this source is vacuous"
+fi
+if [ "$tbl_total" -eq 0 ]; then
+  bad "no Git-to-jj table invocations found — that extractor broke, so this source is vacuous"
 fi
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

Prompted by spotting jj's own [git command table](https://docs.jj-vcs.dev/latest/git-command-table/) and asking whether ours is better. It isn't — and checking turned up a coverage gap in the lint shipped two PRs ago.

### The lint had a third blind spot

`test-command-invocations.sh` (#143) reads two sources: fenced code blocks and `!`-injected Context commands. Every command file also carries a **`| git … | jj … |` translation table**, and the plugin README carries a conceptual one. Table cells are neither fenced nor injected, so **26 distinct jj invocations across 15 files were unchecked**.

They are all valid on jj 0.43.0 — verified before writing the extractor, so this is prevention, not a fix. Coverage goes **32 → 117 checks** (18 injected, 37 fenced, 62 table).

The per-source check is now a shared `check_invocation()` function so the two static extractors cannot drift apart. It also **emits a row for the subcommand itself**, not only for flags: most table cells are bare (`jj abandon`, `jj status`), and without that they would be checked-but-unrecorded, leaving the vacuity guards unable to distinguish "nothing to check" from "extractor broke".

Each extractor now has its **own** vacuity guard. A combined count would stay healthy while one source silently stopped matching.

### We are not competing with the upstream table

Theirs is ~60 mappings in one maintained page with a Notes column, organised by workflow, tracking jj releases. Ours is 54 rows fragmented across 15 files — but it does a different job: a 4-row block sitting in the model's context at the moment it runs that command, which is prompt material rather than documentation.

So `README.md` now **links** the upstream table rather than duplicating it, and calls out the two things it does not cover that this plugin has measured:

- **`jj undo` is sequential** — it reverses whatever the *latest* operation is, so once anything else has run it reverses that instead, silently, while reporting success. Upstream maps "undo the last operation" → `jj undo` with no such caveat. This is the defect #139 fixed in `abandon.md`.
- **Deleting a pushed bookmark** — a bare `jj op restore` also restores remote-tracking refs, so jj believes the remote still has the branch and the next push answers `Nothing changed.` over an empty remote. Upstream covers neither remote branch deletion nor `git reflog`. This is #137's finding.

## Test plan

- [x] 117 checks pass; all 20 suites pass under `/bin/bash`.
- [x] **Mutation-tested, four ways, all exit 1** — two of them needed re-running after their anchors missed, which the harness reported as `!! NOT APPLIED` rather than as a pass:
  - table cell names `jj evlog` → `is not a jj subcommand`
  - table cell cites `jj diff --stats` → `does NOT accept --stats` (also caught by the injected half, independently)
  - table extractor iterates nothing → `no Git-to-jj table invocations found`
  - fenced extractor matches nothing → `no fenced jj invocations found` (proves the guards are independent)
- [x] Table contents validated against `--help` **before** writing the extractor: 26/26 valid. The first run of that probe reported 13 failures, all artifacts of a stray trailing backtick in the probe's own `sed` — fixed and re-run before drawing any conclusion.
- [x] Version gate with a real base tree: exit 0 bumped, exit 1 on an unbumped control.

`plugin.json` 0.16.0 → 0.17.0 (#84).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
