### PR TITLE
fix(agent-helpers-jj): jjcheckpoint must snapshot — its restore point excluded live edits

### DIFF
--- a/plugins/agent-helpers-jj/.claude-plugin/plugin.json
+++ b/plugins/agent-helpers-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-helpers-jj",
   "description": "Machine-level jj (Jujutsu) query shortcuts for agents — read-only helpers that bake in --ignore-working-copy so concurrent workspaces don't race",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/agent-helpers-jj/README.md
+++ b/plugins/agent-helpers-jj/README.md
@@ -11,13 +11,27 @@ would otherwise race on.
 | `jjctx` | one JSON object | current change (orientation) |
 | `jjstack` | JSONL | local changes ahead of trunk |
 | `jjconflicts` | exit code | 0 = clean, 1 = conflicts (printed), >1 = jj error |
-| `jjcheckpoint` | short op id | for a kaisen ledger `start-op` |
+| `jjcheckpoint` | short op id | restore point — pass to `jj op restore` later |
 
-These are **structural** queries — they read committed / op-log state, where
-`--ignore-working-copy` is strictly correct. Two working-copy helpers
-(`jjclean`, `jjfiles`) were considered and cut: under `--ignore-working-copy`
-they report the last *snapshot*, not live edits, so they'd give stale answers
-to "am I clean / what changed?". For that, use plain `jj status` / `jj diff`.
+The first three are **structural** queries — they read committed / op-log state,
+where `--ignore-working-copy` is strictly correct, and they may be polled
+repeatedly from inside concurrent workspaces without perturbing the shared op
+log. Two working-copy helpers (`jjclean`, `jjfiles`) were considered and cut:
+under `--ignore-working-copy` they report the last *snapshot*, not live edits,
+so they'd give stale answers to "am I clean / what changed?". For that, use
+plain `jj status` / `jj diff`.
+
+**`jjcheckpoint` is the deliberate exception: it snapshots.** It is not a query
+— its output is a restore target, and kaisen restores to it to abort a run. With
+`--ignore-working-copy` it returned the op *before* the working copy was
+snapshotted, so the id named a state predating any edit not yet snapshotted, and
+`Write`/`Edit` do not snapshot. Restoring to such an id dropped those edits
+silently. Measured and pinned in `tests/test-jj-agent-helpers.sh`; the same trap
+is documented in `commit-commands-jj`'s `/finish` and `/abandon`.
+
+Take it immediately before anything destructive, and recover with
+`jj op restore <id>` — adding `--what repo` if the discard also deleted a pushed
+bookmark, otherwise jj keeps believing the remote still has it.
 
 ## Install
 

--- a/plugins/agent-helpers-jj/scripts/jj-agent-helpers.sh
+++ b/plugins/agent-helpers-jj/scripts/jj-agent-helpers.sh
@@ -10,7 +10,10 @@
 #
 # --ignore-working-copy: read-only queries must never snapshot the working copy
 # (a snapshot writes a new operation to the shared op-log, the serialization
-# point concurrent jj workspaces race on).
+# point concurrent jj workspaces race on). That covers the three QUERY helpers,
+# which may be called repeatedly from inside concurrent workspaces.
+#
+# jjcheckpoint is deliberately the exception — see its own note below.
 
 # jjctx — current change as one JSON object (orientation)
 jjctx() { jj --ignore-working-copy log -r @ --no-graph -T 'json(self) ++ "\n"'; }
@@ -34,5 +37,18 @@ jjconflicts() {
   return "$rc"
 }
 
-# jjcheckpoint — current operation id (for a kaisen ledger start-op)
-jjcheckpoint() { jj --ignore-working-copy op log -n1 --no-graph -T 'id.short()'; }
+# jjcheckpoint — a RESTORE POINT: the op id to hand to `jj op restore` later.
+#
+# This one MUST snapshot, so it is the only helper without --ignore-working-copy.
+# Its consumer is kaisen's ledger `start-op`, and kaisen restores to it to abort
+# a run ("the run's whole-repo checkpoint" — kaisen SKILL.md). With the flag,
+# `jj op log` reports the op BEFORE the current working copy is snapshotted, so
+# the id names a state that predates any edit not yet snapshotted — and
+# Write/Edit tools do not snapshot. Measured: restoring to such an id loses
+# those edits silently. Pinned by test-jj-agent-helpers.sh.
+#
+# The race-safety argument does not apply here: a checkpoint is taken once at a
+# run boundary and capturing the working copy IS the point, whereas the query
+# helpers are polled from inside concurrent workspaces where a snapshot would
+# perturb the shared op log.
+jjcheckpoint() { jj op log -n1 --no-graph -T 'id.short()'; }

--- a/plugins/agent-helpers-jj/templates/jj-agent-helpers-claudemd.md
+++ b/plugins/agent-helpers-jj/templates/jj-agent-helpers-claudemd.md
@@ -1,3 +1,5 @@
 <!-- BEGIN jj-agent-helpers (agent-helpers-jj) -->
-**jj query helpers** (structural, read-only; all use `--ignore-working-copy`, safe under concurrent workspaces): `jjctx` current change (one JSON object) · `jjstack` local changes vs trunk (JSONL) · `jjconflicts` (exit 0 = clean, 1 = conflicts) · `jjcheckpoint` op id
+**jj query helpers** (structural, read-only; use `--ignore-working-copy`, safe under concurrent workspaces): `jjctx` current change (one JSON object) · `jjstack` local changes vs trunk (JSONL) · `jjconflicts` (exit 0 = clean, 1 = conflicts)
+
+**`jjcheckpoint`** — op id to hand to `jj op restore` later. Unlike the three above it **does** snapshot the working copy, deliberately: a restore point that excluded your unsnapshotted edits would lose them silently on restore. Take it immediately before anything destructive; recover with `jj op restore <id>` (add `--what repo` if the discard also deleted a pushed bookmark, or jj will believe the remote still has it).
 <!-- END jj-agent-helpers -->

--- a/plugins/agent-helpers-jj/tests/test-jj-agent-helpers.sh
+++ b/plugins/agent-helpers-jj/tests/test-jj-agent-helpers.sh
@@ -55,21 +55,62 @@ if jjconflicts; then ok "jjconflicts exits 0 when clean"; else bad "jjconflicts(
 # jjconflicts: broken env (not a jj repo) -> non-zero, NOT a false clean
 ( cd "$WORK" && jjconflicts >/dev/null 2>&1 ) && bad "jjconflicts(non-repo)" "returned clean outside a jj repo" || ok "jjconflicts non-zero outside a jj repo"
 
-# race-safety invariant (behavioral): the helpers must NOT snapshot the working
-# copy, so they must create no new operations — even when the working copy is
-# dirty (an unsnapshotted edit that a plain jj command would snapshot into a new op).
+# race-safety invariant (behavioral): the three QUERY helpers must NOT snapshot
+# the working copy, so they must create no new operations — even when the working
+# copy is dirty (an unsnapshotted edit a plain jj command would snapshot).
+#
+# jjcheckpoint is excluded on purpose and asserted the opposite way below: it is
+# a restore point, not a query, so it MUST snapshot.
 echo dirty > uncommitted.txt
 ops() { jj --ignore-working-copy op log --no-graph -T 'id.short() ++ "\n"' | grep -c .; }
 before="$(ops)"
 jjctx >/dev/null 2>&1 || true
 jjstack >/dev/null 2>&1 || true
 jjconflicts >/dev/null 2>&1 || true
+after="$(ops)"
+if [ "$before" = "$after" ]; then ok "query helpers create no operations (no working-copy snapshot)"; else bad "invariant" "op count $before -> $after (a query helper snapshotted)"; fi
+
+# jjcheckpoint MUST snapshot — the inverse of the invariant above.
+before="$(ops)"
 jjcheckpoint >/dev/null 2>&1 || true
 after="$(ops)"
-if [ "$before" = "$after" ]; then ok "helpers create no operations (no working-copy snapshot)"; else bad "invariant" "op count $before -> $after (a helper snapshotted)"; fi
+if [ "$before" != "$after" ]; then ok "jjcheckpoint snapshots (op count $before -> $after)"; else bad "jjcheckpoint" "created no operation with a dirty working copy — it is not capturing live edits"; fi
 
-# defense in depth: the flag is literally present in the script
-if grep -q -- '--ignore-working-copy' "$HELPERS"; then ok "script carries --ignore-working-copy"; else bad "flag" "missing from script"; fi
+# THE ONE THAT MATTERS: a checkpoint must survive a destructive op and bring the
+# working copy back — including edits made with Write/Edit, which never snapshot.
+# With --ignore-working-copy this silently returned a pre-edit state (measured
+# 2026-08-02); the second arm below proves the flag is what breaks it, so a jj
+# change that made the flag harmless would surface here rather than rot.
+for arm in shipped with-the-flag; do
+  ( cd "$WORK" && rm -rf cp && jj git init cp >/dev/null 2>&1 && cd cp \
+    && jj describe -m base >/dev/null 2>&1 \
+    && jj new >/dev/null 2>&1 \
+    && printf 'committed\n' > tracked.txt \
+    && jj describe -m work >/dev/null 2>&1 \
+    && printf 'live edit\n' > tracked.txt \
+    && printf 'new file\n'  > untracked.txt \
+    && if [ "$arm" = shipped ]; then cp_id="$(jjcheckpoint)"
+       else cp_id="$(jj --ignore-working-copy op log -n1 --no-graph -T 'id.short()')"; fi \
+    && tgt="$(jj log -r @ --no-graph -T 'change_id.short()')" \
+    && jj abandon "$tgt" >/dev/null 2>&1 \
+    && jj op restore "$cp_id" >/dev/null 2>&1 \
+    && [ -f untracked.txt ] && grep -q 'live edit' tracked.txt ) && recovered=yes || recovered=no
+
+  if [ "$arm" = shipped ]; then
+    [ "$recovered" = yes ] \
+      && ok "jjcheckpoint restore point recovers live (unsnapshotted) edits" \
+      || bad "jjcheckpoint" "restoring to its id LOST edits made since the last snapshot"
+  else
+    [ "$recovered" = no ] \
+      && ok "the --ignore-working-copy form loses those edits (why jjcheckpoint omits the flag)" \
+      || bad "arm" "--ignore-working-copy no longer costs live edits — the rationale in the script is stale"
+  fi
+done
+
+# defense in depth: the flag is present for the query helpers, and absent from
+# jjcheckpoint. A blanket grep would pass if the flag crept back onto it.
+if grep -q -- 'jjctx() {.*--ignore-working-copy' "$HELPERS"; then ok "jjctx carries --ignore-working-copy"; else bad "flag" "missing from jjctx"; fi
+if grep -q -- 'jjcheckpoint() {.*--ignore-working-copy' "$HELPERS"; then bad "jjcheckpoint" "--ignore-working-copy crept back — its restore point will exclude live edits"; else ok "jjcheckpoint does not carry --ignore-working-copy"; fi
 
 # drift guard: catalog names == public function names (exclude private _jjq)
 defined="$(grep -Eo '^(jj[a-z]+)\(\)' "$HELPERS" | sed 's/()//' | sort -u)"


### PR DESCRIPTION
## Summary

`jjcheckpoint` was `jj --ignore-working-copy op log -n1 …`, which returns the op id **before** the working copy is snapshotted. Its output is a restore target, so the id named a state predating any edit not yet snapshotted — and `Write`/`Edit` never snapshot. **Restoring to it dropped those edits silently.**

Measured against the shipped helper:

| | restore point | result |
|---|---|---|
| shipped `jjcheckpoint` | `b1bc767cf85d` | **edits LOST** — new file gone, edited file reverted to its pre-edit content |
| same call without the flag | `89fffec6fa2f` | edits recovered |

Fix is one flag. `jjcheckpoint` is now the only helper without `--ignore-working-copy`.

## Why the flag was right for the others and wrong here

The rationale in the script is sound for the three **query** helpers: they may be polled repeatedly from inside concurrent workspaces, where a snapshot writes to the shared op log. That argument does not transfer. A checkpoint is taken **once, at a run boundary**, and capturing the working copy *is the point*.

The decisive evidence is that its own documented consumer already avoids it. `jjcheckpoint` exists "for a kaisen ledger `start-op`", and kaisen treats `start-op` as a restore target:

> The ledger header's `start-op` is the run's whole-repo checkpoint. [To abort:] `jj op restore <start-op-id>` — `kaisen/SKILL.md`

…while computing it inline as `jj op log -n1 --no-graph -T 'id.short()'` — **without** the flag. So the helper was unfit for the one job it was built for, and the only consumer had independently worked around it.

Two working-copy helpers (`jjclean`, `jjfiles`) were cut during the original design for this exact hazard. `jjcheckpoint` was kept on the grounds that it "queries op-log state where the flag is strictly correct" — true of the *read*, but not of what the id is then used for.

## What changed

- **`scripts/jj-agent-helpers.sh`** — flag dropped from `jjcheckpoint` only; the shared header now scopes its rationale to the query helpers, and `jjcheckpoint` carries its own note explaining the exception.
- **`templates/jj-agent-helpers-claudemd.md`** — the catalog advertised it to every agent as a bare "op id". It now says it is a restore point, that it snapshots deliberately, and to add `--what repo` when the discard also deleted a pushed bookmark.
- **`README.md`** — same correction, with the measurement and the cross-reference to `/finish` and `/abandon`, which document the same trap.

## Test plan

- [x] `test-jj-agent-helpers.sh`: **12 passed, 0 failed** (was 9 assertions).
- [x] **The existing race-safety invariant asserted all four helpers never snapshot** — this change deliberately breaks that for one of them. It is now scoped to the three query helpers, with the inverse asserted for `jjcheckpoint`: it *must* create an operation when the working copy is dirty.
- [x] New round-trip test, **two arms**, so a jj change that made the flag harmless would surface rather than rot: unsnapshotted edits → checkpoint → `jj abandon` → `jj op restore`. Shipped form recovers them; the `--ignore-working-copy` form does not.
- [x] Grep guard is now per-function rather than blanket — a flag creeping back onto `jjcheckpoint` fails, where `grep -q -- '--ignore-working-copy' "$HELPERS"` would still have passed.
- [x] **Mutation-tested, both exit 1:** restoring the flag to `jjcheckpoint` → 3 failures including "restoring to its id LOST edits"; removing it from `jjctx` → the query invariant fires.
- [x] All 20 suites pass; version gate exercised with a real base tree from `trunk()`.

`plugin.json` 0.1.0 → 0.2.0 (#84).

## Upgrading — `claude plugin update` is NOT enough

This is the layer-3 case. The live copy is `~/.config/jj-agent-helpers/jj-agent-helpers.sh`, sourced from `~/.zshrc`, and a plugin update does not touch it. After merging:

1. `claude plugin marketplace update muloka-claude-plugins`
2. `claude plugin update agent-helpers-jj@muloka-claude-plugins`
3. **re-run `/agent-helpers-setup`** — this is the step that rewrites the installed script and the CLAUDE.md catalog block
4. restart the shell / Claude Code

Verify by content, not by version: `grep 'jjcheckpoint()' ~/.config/jj-agent-helpers/jj-agent-helpers.sh` must show no `--ignore-working-copy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
