### PR TITLE
project-setup-jj: make the session briefing and the statusline reach jj workspaces

### DIFF
--- a/.claude/hooks/statusline-jj.sh
+++ b/.claude/hooks/statusline-jj.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# jj-aware statusline for Claude Code — Synthwave powerline edition
+# Receives JSON session data on stdin, outputs a single status line
+#
+# Layout (powerline badges with  transitions):
+#   Model  bookmark  change-id  description  TRUNK  N%  2x  status  ⚙ countdown
+#
+# Requires: Nerd Font / powerline-patched font, 24-bit true color terminal
+# Palette: Synthwave — all bg+fg pairs meet WCAG AA contrast
+
+set -euo pipefail
+
+# ── Synthwave palette (24-bit true color) ──
+# Each role has: BG (background), FG (text), SF (separator = bg color as foreground)
+#
+# Model (identity) — lavender #a78bfa / text #1e1035
+MDL_BG=$'\033[48;2;167;139;250m'  MDL_FG=$'\033[38;2;30;16;53m'    MDL_SF=$'\033[38;2;167;139;250m'
+# Healthy (status/context) — electric cyan #22d3ee / text #083344
+HLT_BG=$'\033[48;2;34;211;238m'   HLT_FG=$'\033[38;2;8;51;68m'     HLT_SF=$'\033[38;2;34;211;238m'
+# Muted (metadata/no intent) — dark slate #3b3557 / text #9590ad
+MUT_BG=$'\033[48;2;59;53;87m'     MUT_FG=$'\033[38;2;149;144;173m'  MUT_SF=$'\033[38;2;59;53;87m'
+# Attention (caution) — coral #fb7185 / text #4c0519
+ATT_BG=$'\033[48;2;251;113;133m'  ATT_FG=$'\033[38;2;76;5;25m'     ATT_SF=$'\033[38;2;251;113;133m'
+# Special (promo) — hot pink #f472b6 / text #500724
+SPC_BG=$'\033[48;2;244;114;182m'  SPC_FG=$'\033[38;2;80;7;36m'     SPC_SF=$'\033[38;2;244;114;182m'
+
+R=$'\033[0m'
+SEP=$'\uE0B0'
+
+# Map bg escape → separator fg (same RGB, 48→38)
+bg2fg() {
+  case "$1" in
+    "$MDL_BG") printf '%s' "$MDL_SF" ;;
+    "$HLT_BG") printf '%s' "$HLT_SF" ;;
+    "$MUT_BG") printf '%s' "$MUT_SF" ;;
+    "$ATT_BG") printf '%s' "$ATT_SF" ;;
+    "$SPC_BG") printf '%s' "$SPC_SF" ;;
+    *)         printf '%s' "$R" ;;
+  esac
+}
+
+# Render SEG_TXT/SEG_BG/SEG_FG arrays as powerline bar
+render() {
+  local out="" count=${#SEG_TXT[@]} cur_fg
+  for (( i=0; i<count; i++ )); do
+    out+="${SEG_BG[$i]}${SEG_FG[$i]}${SEG_TXT[$i]}"
+    cur_fg=$(bg2fg "${SEG_BG[$i]}")
+    if (( i + 1 < count )); then
+      out+="${SEG_BG[$((i+1))]}${cur_fg}${SEP}"
+    else
+      out+="${R}${cur_fg}${SEP}${R}"
+    fi
+  done
+  printf '%s' "$out"
+}
+
+input=$(cat)
+
+# Session info from stdin JSON
+MODEL=$(echo "$input" | jq -r '.model.display_name // "unknown"')
+PCT=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
+
+# Quick bail if not a jj repo
+if ! jj root --ignore-working-copy >/dev/null 2>&1; then
+  SEG_TXT=(" $MODEL "); SEG_BG=("$MDL_BG"); SEG_FG=("$MDL_FG")
+  SEG_TXT+=(" ${PCT}% "); SEG_BG+=("$HLT_BG"); SEG_FG+=("$HLT_FG")
+  render
+  exit 0
+fi
+
+# Cache: only re-query jj if repo state changed
+# Stores raw pipe-delimited values for segment building
+CACHE_FILE="/tmp/statusline-jj-$$-cache"
+JJ_DIR="$(jj root --ignore-working-copy 2>/dev/null)/.jj"
+CACHE_KEY="$(stat -f '%m' "$JJ_DIR/repo" 2>/dev/null || echo "0")"
+
+if [ -f "$CACHE_FILE" ] && [ "$(head -1 "$CACHE_FILE")" = "$CACHE_KEY" ]; then
+  IFS='|' read -r BOOKMARK CHANGE_ID DESC TRUNK_LABEL TRUNK_CLR < <(tail -1 "$CACHE_FILE") || true
+else
+  CHANGE_ID=$(jj log --ignore-working-copy -r @ --no-graph -T 'self.change_id().short(8)' 2>/dev/null || echo "")
+  DESC=$(jj log --ignore-working-copy -r @ --no-graph -T 'description.first_line()' 2>/dev/null || echo "")
+  BOOKMARK=$(jj log --ignore-working-copy -r @ --no-graph -T 'bookmarks' 2>/dev/null || echo "")
+
+  # Trunk state
+  ON_TRUNK=$(jj log --ignore-working-copy -r '@ & trunk()' --no-graph -T '"yes"' 2>/dev/null || echo "")
+  if [ "$ON_TRUNK" = "yes" ]; then
+    TRUNK_LABEL="@trunk"; TRUNK_CLR="healthy"
+  else
+    AHEAD=$(jj log --ignore-working-copy -r '(trunk()..@) ~ empty()' --no-graph -T '"x"' 2>/dev/null | wc -c | tr -d ' ')
+    if [ "$AHEAD" -gt 0 ] 2>/dev/null; then
+      TRUNK_LABEL="+${AHEAD}"; TRUNK_CLR="attention"
+    else
+      ALL=$(jj log --ignore-working-copy -r 'trunk()..@' --no-graph -T '"x"' 2>/dev/null | wc -c | tr -d ' ')
+      if [ "$ALL" -gt 0 ] 2>/dev/null; then
+        TRUNK_LABEL="@trunk"; TRUNK_CLR="healthy"
+      else
+        TRUNK_LABEL="⎇"; TRUNK_CLR="attention"
+      fi
+    fi
+  fi
+
+  # Detect if trunk bookmark needs pushing (local ahead of origin)
+  for _bm in main master; do
+    _ct=$( (jj log --ignore-working-copy -r "${_bm} ~ ${_bm}@origin" --no-graph -T '"x"' 2>/dev/null || true) | wc -c | tr -d ' ')
+    if [ "${_ct:-0}" -gt 0 ] 2>/dev/null; then
+      TRUNK_LABEL="${TRUNK_LABEL}*"; TRUNK_CLR="attention"
+      break
+    fi
+  done
+
+  [ -n "$DESC" ] && DESC=$(echo "$DESC" | cut -c1-30)
+
+  printf '%s\n%s' "$CACHE_KEY" "${BOOKMARK}|${CHANGE_ID}|${DESC}|${TRUNK_LABEL}|${TRUNK_CLR}" > "$CACHE_FILE"
+fi
+
+# Map trunk color key → palette role
+case "${TRUNK_CLR:-healthy}" in
+  healthy)   TRUNK_BG="$HLT_BG"; TRUNK_FG="$HLT_FG" ;;
+  attention) TRUNK_BG="$ATT_BG"; TRUNK_FG="$ATT_FG" ;;
+  *)         TRUNK_BG="$MUT_BG"; TRUNK_FG="$MUT_FG" ;;
+esac
+
+# Context % → healthy / attention gradient
+if [ "$PCT" -ge 70 ] 2>/dev/null; then
+  PCT_BG="$ATT_BG"; PCT_FG="$ATT_FG"
+else
+  PCT_BG="$HLT_BG"; PCT_FG="$HLT_FG"
+fi
+
+# Claude status via summary API (cached 5 min, single fetch)
+SUMMARY_CACHE="/tmp/statusline-claude-summary"
+SUMMARY_JSON=""
+if [ -f "$SUMMARY_CACHE" ]; then
+  CACHE_MTIME=$(stat -f '%m' "$SUMMARY_CACHE" 2>/dev/null || echo "0")
+  NOW=$(date +%s)
+  AGE=$(( NOW - CACHE_MTIME ))
+  if [ "$AGE" -lt 300 ]; then
+    SUMMARY_JSON=$(cat "$SUMMARY_CACHE" 2>/dev/null || echo "")
+  fi
+fi
+if [ -z "$SUMMARY_JSON" ]; then
+  SUMMARY_JSON=$(curl -sf --max-time 2 "https://status.claude.com/api/v2/summary.json" 2>/dev/null || echo "")
+  if [ -n "$SUMMARY_JSON" ]; then
+    printf '%s' "$SUMMARY_JSON" > "$SUMMARY_CACHE"
+  fi
+fi
+
+STATUS_SYM="?"; STATUS_BG="$MUT_BG"; STATUS_FG="$MUT_FG"; STATUS_LBL=""
+MAINT_TXT=""; MAINT_BG=""; MAINT_FG=""
+if [ -n "$SUMMARY_JSON" ]; then
+  # 1. Model-specific incident check
+  MODEL_SHORT=$(echo "$MODEL" | sed 's/^Claude //' | sed 's/ ([^)]*)//')
+  MODEL_INCIDENT=""
+  if [ "$MODEL_SHORT" != "unknown" ]; then
+    MODEL_INCIDENT=$(echo "$SUMMARY_JSON" | jq -r --arg m "$MODEL_SHORT" \
+      '[.incidents[] | select(.name | ascii_downcase | contains($m | ascii_downcase))] | .[0].impact // ""' 2>/dev/null || echo "")
+  fi
+
+  if [ -n "$MODEL_INCIDENT" ]; then
+    case "$MODEL_INCIDENT" in
+      critical) STATUS_SYM="↯" ;;
+      major)    STATUS_SYM="⚠" ;;
+      *)        STATUS_SYM="▲" ;;
+    esac
+    STATUS_BG="$ATT_BG"; STATUS_FG="$ATT_FG"
+    STATUS_LBL=$(echo "$MODEL_SHORT" | sed 's/ .*//')  # e.g. "Opus", "Sonnet"
+  else
+    # 2. Claude Code component status
+    CC_STATUS=$(echo "$SUMMARY_JSON" | jq -r \
+      '.components[] | select(.name == "Claude Code") | .status' 2>/dev/null || echo "unknown")
+    case "$CC_STATUS" in
+      operational)          STATUS_SYM="✓"; STATUS_BG="$HLT_BG"; STATUS_FG="$HLT_FG" ;;
+      degraded_performance) STATUS_SYM="▲"; STATUS_BG="$ATT_BG"; STATUS_FG="$ATT_FG"; STATUS_LBL="CC" ;;
+      partial_outage)       STATUS_SYM="⚠"; STATUS_BG="$ATT_BG"; STATUS_FG="$ATT_FG"; STATUS_LBL="CC" ;;
+      major_outage)         STATUS_SYM="↯"; STATUS_BG="$ATT_BG"; STATUS_FG="$ATT_FG"; STATUS_LBL="CC" ;;
+      *)                    STATUS_SYM="?"; STATUS_BG="$MUT_BG"; STATUS_FG="$MUT_FG" ;;
+    esac
+  fi
+
+  # 3. Maintenance countdown
+  MAINT_TIME=$(echo "$SUMMARY_JSON" | jq -r '.scheduled_maintenances[0].scheduled_for // ""' 2>/dev/null || echo "")
+  if [ -n "$MAINT_TIME" ]; then
+    MAINT_EPOCH=$(TZ=UTC date -jf '%Y-%m-%dT%H:%M:%S' "${MAINT_TIME%%.*}" '+%s' 2>/dev/null || echo "0")
+    NOW=${NOW:-$(date +%s)}
+    DIFF=$(( MAINT_EPOCH - NOW ))
+    MAINT_BG="$ATT_BG"; MAINT_FG="$ATT_FG"
+    if [ "$DIFF" -gt 86400 ]; then
+      MAINT_TXT="⚙ $((DIFF / 86400))d"
+    elif [ "$DIFF" -gt 3600 ]; then
+      MAINT_TXT="⚙ $((DIFF / 3600))h"
+    elif [ "$DIFF" -gt 60 ]; then
+      MAINT_TXT="⚙ $((DIFF / 60))m"
+    elif [ "$DIFF" -gt 0 ]; then
+      MAINT_TXT="⚙ <1m"
+    else
+      MAINT_TXT="⚙ now"
+    fi
+  fi
+fi
+
+# ── Build segment arrays (ordered left → right) ──
+SEG_TXT=(); SEG_BG=(); SEG_FG=()
+
+SEG_TXT+=(" $MODEL ");    SEG_BG+=("$MDL_BG"); SEG_FG+=("$MDL_FG")
+
+[ -n "$BOOKMARK" ] && {
+  SEG_TXT+=(" $BOOKMARK "); SEG_BG+=("$MDL_BG"); SEG_FG+=("$MDL_FG")
+}
+
+[ -n "${CHANGE_ID:-}" ] && {
+  SEG_TXT+=(" $CHANGE_ID "); SEG_BG+=("$HLT_BG"); SEG_FG+=("$HLT_FG")
+}
+
+if [ -n "${DESC:-}" ]; then
+  SEG_TXT+=(" $DESC ");       SEG_BG+=("$SPC_BG"); SEG_FG+=("$SPC_FG")
+else
+  SEG_TXT+=(" (no intent) "); SEG_BG+=("$MUT_BG"); SEG_FG+=("$MUT_FG")
+fi
+
+SEG_TXT+=(" ${TRUNK_LABEL:-@trunk} "); SEG_BG+=("${TRUNK_BG}"); SEG_FG+=("${TRUNK_FG}")
+SEG_TXT+=(" ${PCT}% ");                SEG_BG+=("$PCT_BG");      SEG_FG+=("$PCT_FG")
+
+# 2x promo: March 13–28, 2026 — weekends + weekdays outside 8am–2pm ET
+DAY_NUM=$(date +%d | sed 's/^0//')
+DOW=$(date +%u)  # 1=Mon..7=Sun
+HOUR_ET=$(TZ=America/New_York date +%H | sed 's/^0//')
+if [ "$(date +%Y-%m)" = "2026-03" ] && [ "$DAY_NUM" -ge 13 ] && [ "$DAY_NUM" -le 28 ]; then
+  if [ "$DOW" -ge 6 ] || [ "$HOUR_ET" -lt 8 ] || [ "$HOUR_ET" -ge 14 ]; then
+    SEG_TXT+=(" 2x "); SEG_BG+=("$SPC_BG"); SEG_FG+=("$SPC_FG")
+  fi
+fi
+
+STATUS_TXT=" $STATUS_SYM${STATUS_LBL:+ $STATUS_LBL} "
+SEG_TXT+=("$STATUS_TXT"); SEG_BG+=("$STATUS_BG"); SEG_FG+=("$STATUS_FG")
+
+[ -n "$MAINT_TXT" ] && {
+  SEG_TXT+=(" $MAINT_TXT "); SEG_BG+=("$MAINT_BG"); SEG_FG+=("$MAINT_FG")
+}
+
+render

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -58,5 +58,9 @@
     "deny": [
       "Bash(git *)"
     ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "sh -c 'p=\"${CLAUDE_PROJECT_DIR:-$(jj root --ignore-working-copy 2>/dev/null || pwd)}\"; exec \"$p/.claude/hooks/statusline-jj.sh\"'"
   }
 }

--- a/docs/plugin-coverage-map-2026-08.md
+++ b/docs/plugin-coverage-map-2026-08.md
@@ -13,12 +13,23 @@ per `docs/eval-triage-2026-07.md` §5, nothing here is grounds for deleting a pl
 | `commit-commands-jj` | 333 | **yes** — 117 checks | 15 behavioural assertions | frequent |
 | `workspace-jj` | 83 | no | 3 suites | occasional |
 | `peer-review-jj` | 34 | no | 1 suite | occasional |
-| `project-setup-jj` | 21 | no | 4 suites (hook: 151 assertions) | load-bearing |
+| `project-setup-jj` | 21 | no | 5 suites (hook: 151 assertions) | load-bearing |
 | `agent-helpers-jj` | 8 | no | 2 suites (12 assertions) | constant |
 
 **146 jj invocations across four plugins are unvalidated.** Nothing catches a
 removed flag in any of them — the class that reached for `jj git push --allow-new`
 three separate times.
+
+**Update 2026-08-13:** one instance of that class is now closed, in a
+script rather than in markdown. `test-jj-session-start.sh` lints every `jj` call
+site in the SessionStart hook and fails if any but the repo probe and the single
+snapshot point drops `--ignore-working-copy`. It is worth reading before
+generalising the markdown lint, for a reason that only showed up under mutation:
+the *behavioural* check (count operations written to the op log) could NOT see
+the dropped flag, because the earlier `jj status` had already snapshotted and
+the second snapshot found nothing to write. A removed flag is invisible to
+behaviour whenever something else already did the work — only reading the source
+catches it.
 
 The lint that closes this is `plugins/commit-commands-jj/tests/test-command-invocations.sh`.
 It hardcodes `CMDS="$(dirname $0)/../commands"`, which is the only thing scoping

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/README.md
+++ b/plugins/project-setup-jj/README.md
@@ -6,7 +6,7 @@ Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a s
 
 When starting a new Claude Code project that uses jj, there's no automated way to set up jj workflow enforcement. This plugin adds a `/project-setup` command that configures everything in one step:
 
-- **SessionStart hook** — shows current jj change, status, and workflow reminder when a session starts
+- **SessionStart hook** — shows the current jj change, the local stack (`trunk()..@`), conflicts, workspaces, status and workflow reminder when a session starts
 - **PreToolUse guard hook** — advises Claude to run `jj new` before editing into a non-empty change (informational — does not block)
 - **PreCompact hook** — snapshots the working copy before context compaction so `jj undo` / `jj op restore` can always reach the pre-compaction state
 - **CLAUDE.md template** — slim jj VCS policy directive
@@ -66,14 +66,22 @@ On every session start, you'll see:
 ```
 == jj Session Context ==
 
-Current change:
-<current change details>
+Current change (@):
+<current change as JSON>
+
+Local stack (trunk()..@):
+<changes ahead of trunk, JSON lines — or "(none — @ is at trunk)">
+
+Conflicts: none            # or "CONFLICTS PRESENT" + the conflicted paths
+
+Workspaces:
+<jj workspace list — which workspace @ belongs to, and who else is live>
 
 Working copy status:
 <modified/added files>
 
-Repository config (JSON):
-<repository config>
+Identity:
+<user.email>
 
 == jj Workflow Reminder ==
 - Use `jj new` to start a fresh change before making edits

--- a/plugins/project-setup-jj/README.md
+++ b/plugins/project-setup-jj/README.md
@@ -54,7 +54,7 @@ This creates/updates the following in your project:
 | `.claude/hooks/jj-workspace-create.sh` | WorktreeCreate hook — creates jj workspace for worktree isolation |
 | `.claude/hooks/jj-workspace-remove.sh` | WorktreeRemove hook — cleans up jj workspace |
 | `.claude/settings.json` | Hooks (SessionStart, PreToolUse, PreCompact, WorktreeCreate, WorktreeRemove) + the `Bash(git *)` deny floor — **commit this**, it is what makes fresh clones and jj workspaces enforce the rules (#97) |
-| `.claude/settings.local.json` | Personal settings: jj/gh allow-list, and `statusLine` if `/statusline-jj-setup` is used |
+| `.claude/settings.local.json` | Personal settings: jj/gh allow-list. **Not** the statusline — that lives in the tracked `settings.json` so jj workspaces inherit it |
 | `CLAUDE.md` | jj VCS policy directive (created or updated) |
 
 **Restart Claude Code** after running `/project-setup` for the SessionStart hook to take effect.
@@ -98,13 +98,15 @@ Two more commands manage a jj-aware statusline, independent of `/project-setup`:
 /statusline-jj-setup
 ```
 
-Copies `.claude/hooks/statusline-jj.sh` into the project and sets it as the `statusLine` command in `.claude/settings.local.json`. The statusline is a powerline-style bar showing the model, bookmark, change ID, change description, trunk-sync status, context-window percentage, and Anthropic service status.
+Copies `.claude/hooks/statusline-jj.sh` into the project and sets it as the `statusLine` command in the **tracked** `.claude/settings.json`. The statusline is a powerline-style bar showing the model, bookmark, change ID, change description, trunk-sync status, context-window percentage, and Anthropic service status.
+
+Both halves are tracked on purpose: a `claude -w` session runs in a jj workspace, which materialises only tracked files, so a statusline configured in the gitignored `.claude/settings.local.json` — or pointing at a script under the gitignored `.claude/scripts/` — silently disappears in every side thread. The configured command resolves the *live* workspace (`$CLAUDE_PROJECT_DIR`, falling back to `jj root`) rather than hardcoding an absolute path to the main checkout.
 
 ```
 /statusline-jj-remove
 ```
 
-Removes `statusline-jj.sh` and deletes the `statusLine` key from `.claude/settings.local.json`. It clears both `.claude/hooks/` and the legacy `.claude/scripts/`, so a project set up before the move can still uninstall cleanly.
+Removes `statusline-jj.sh` and deletes the `statusLine` key from **both** `.claude/settings.json` and `.claude/settings.local.json`. It clears both `.claude/hooks/` and the legacy `.claude/scripts/`, so a project set up before either move can still uninstall cleanly — and because both scopes apply, removing only one would leave the statusline running.
 
 ## Idempotent
 

--- a/plugins/project-setup-jj/commands/statusline-jj-remove.md
+++ b/plugins/project-setup-jj/commands/statusline-jj-remove.md
@@ -32,15 +32,21 @@ refuses a non-empty directory, so a script the user keeps there is never destroy
 rmdir "$(jj root)/.claude/scripts" 2>/dev/null || true
 ```
 
-### Step 3: Remove statusLine from settings
+### Step 3: Remove statusLine from BOTH settings files
 
-Read `.claude/settings.local.json`. If it has a `statusLine` key, remove it using `jq`:
+Setup writes `statusLine` to the tracked `.claude/settings.json`; older installs
+put it in `.claude/settings.local.json`. Both scopes apply, so removing only one
+leaves the statusline running and the uninstall silently ineffective — the same
+reason setup has to strip the local copy.
 
 ```bash
-jq 'del(.statusLine)' .claude/settings.local.json > .claude/settings.local.json.tmp && mv .claude/settings.local.json.tmp .claude/settings.local.json
+for f in .claude/settings.json .claude/settings.local.json; do
+  [ -f "$f" ] || continue
+  jq 'del(.statusLine)' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+done
 ```
 
-If no `statusLine` key exists, skip — nothing to remove.
+If neither file has a `statusLine` key, skip — nothing to remove.
 
 ### Step 4: Confirm to user
 

--- a/plugins/project-setup-jj/commands/statusline-jj-setup.md
+++ b/plugins/project-setup-jj/commands/statusline-jj-setup.md
@@ -7,7 +7,9 @@ allowed-tools: Bash(jj:*), Bash(cp:*), Bash(chmod:*), Bash(mkdir:*), Bash(rm:*),
 
 ## Your Task
 
-Install the jj-aware statusline script and configure it in this project's `.claude/settings.local.json`.
+Install the jj-aware statusline script and configure it in this project's **tracked** `.claude/settings.json`.
+
+**Why tracked, and why the command is not a plain path:** a `claude -w` session runs in a jj workspace, which materialises only *tracked* files. A statusline configured in `.claude/settings.local.json` (gitignored) and pointing at a script under `.claude/scripts/` (also gitignored) is simply absent there — the statusline silently disappears in every side thread. Both halves must be tracked, and the command must resolve the script relative to whichever workspace is live.
 
 ### Step 1: Detect context
 
@@ -37,28 +39,51 @@ rmdir "$(jj root)/.claude/scripts" 2>/dev/null || true
 
 `rmdir` refuses a non-empty directory, so this only cleans up when nothing else remains there.
 
-### Step 3: Update `.claude/settings.local.json`
+### Step 3: Verify `.claude/hooks/` is tracked
 
-Read the current `.claude/settings.local.json` (may not exist). Deep-merge the following configuration using `jq`, preserving all existing keys:
+The script only reaches a workspace if it is tracked. Check the project's
+`.gitignore` for a `!.claude/hooks/` negation under the `.claude/*` line. If the
+blanket form `.claude/` or `.claude/**` is used instead, no negation can work —
+tell the user to switch to `.claude/*` (the same requirement `/project-setup`
+enforces) or the statusline will keep vanishing in side threads.
 
-```json
-{
-  "statusLine": {
-    "type": "command",
-    "command": "<project-root>/.claude/hooks/statusline-jj.sh"
-  }
-}
+### Step 4: Update `.claude/settings.json` (tracked)
+
+Read the current `.claude/settings.json`. Deep-merge with `jq`, preserving all existing keys:
+
+```bash
+CMD='sh -c '"'"'p="${CLAUDE_PROJECT_DIR:-$(jj root --ignore-working-copy 2>/dev/null || pwd)}"; exec "$p/.claude/hooks/statusline-jj.sh"'"'"''
+jq --arg c "$CMD" '.statusLine = {type:"command", command:$c}' \
+  .claude/settings.json > .claude/settings.json.tmp && mv .claude/settings.json.tmp .claude/settings.json
 ```
 
-Replace `<project-root>` with the actual absolute path from `jj root`.
+Do **not** write an absolute `jj root` path here: this file is committed and
+shared, and an absolute path is both machine-specific and pinned to the main
+checkout. The command above resolves the live workspace instead — it prefers
+`$CLAUDE_PROJECT_DIR` when the harness exports it, and otherwise falls back to
+`jj root` from the current directory, which in a workspace is that workspace's
+own root. `--ignore-working-copy` keeps a statusline redraw from snapshotting.
 
 **Merge strategy:** If a `statusLine` key already exists, replace it. Preserve all other keys.
 
-### Step 4: Confirm to user
+### Step 5: Strip any `statusLine` from `.claude/settings.local.json`
+
+This step is **required, not cleanup.** Both files apply, and the local scope is
+the more specific one — a leftover `statusLine` there overrides the tracked one.
+The failure is deceptive: the statusline keeps working in the main checkout (so
+the install looks successful) while every workspace stays broken.
+
+```bash
+[ -f .claude/settings.local.json ] && \
+  jq 'del(.statusLine)' .claude/settings.local.json > .claude/settings.local.json.tmp && \
+  mv .claude/settings.local.json.tmp .claude/settings.local.json
+```
+
+### Step 6: Confirm to user
 
 Show:
-- Statusline script copied to `.claude/hooks/statusline-jj.sh`
-- `statusLine` config added to `.claude/settings.local.json`
+- Statusline script copied to `.claude/hooks/statusline-jj.sh` (tracked — commit it, or workspaces will not see it)
+- `statusLine` config added to `.claude/settings.json`, and removed from `.claude/settings.local.json` if present
 - **Restart Claude Code** for the statusline to appear
 
 The statusline shows: `[Model] bookmark-or-change-id description | N% ctx | $cost`

--- a/plugins/project-setup-jj/scripts/jj-session-start.sh
+++ b/plugins/project-setup-jj/scripts/jj-session-start.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 # SessionStart hook: Show jj context and workflow reminder
 # Outputs JSON with additionalContext for Claude Code
+#
+# What belongs in this briefing: it is the one payload EVERY session
+# reads, so it must answer the questions that change what an agent does next —
+# what is in my stack, am I in conflict, which workspace am I in — rather than
+# spend its budget on state that changes nothing. It used to emit the whole of
+# `jj config list` (four lines of hostname/username/identity) and none of the
+# three above. Identity survives the trim as `user.email` alone, because an eval
+# scaffold once truncated a caller's ~/.config/jj/config.toml and the wrong
+# author on every subsequent change was the symptom nobody saw.
+#
+# bash 3.2-safe (macOS): no globstar, no associative arrays. Note that under
+# `set -e` a bare `[ cond ] && var=x` at top level EXITS the script when cond is
+# false — every conditional below is written as if/then for that reason.
 
 set -euo pipefail
 
@@ -9,10 +22,43 @@ if ! jj root >/dev/null 2>&1; then
   exit 0
 fi
 
-# Gather jj context
-current_change=$(jj log -r @ --no-graph -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read current change)")
+# `jj status` runs FIRST and deliberately WITHOUT --ignore-working-copy: it is
+# the single snapshot point for this briefing. Every read after it carries the
+# flag, so (a) the whole briefing describes one consistent post-snapshot state
+# instead of a mix of pre- and post-, and (b) the hook writes at most one
+# operation to the op log — the serialization point concurrent jj workspaces
+# race on (see agent-helpers-jj/scripts/jj-agent-helpers.sh).
 working_status=$(jj status 2>/dev/null || echo "(unable to read status)")
-repo_config=$(jj config list -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read config)")
+
+current_change=$(jj --ignore-working-copy log -r @ --no-graph -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read current change)")
+
+# The local stack. Empty output means @ sits at trunk — say so, because a blank
+# section reads as "unknown" rather than "nothing there".
+stack=$(jj --ignore-working-copy log -r 'trunk()..@' --no-graph -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read stack)")
+if [ -z "$stack" ]; then
+  stack="(none — @ is at trunk)"
+fi
+
+# jj 0.43: `resolve --list` exits 0 (and lists) when conflicts exist, and exits
+# 2 ("No conflicts found at this revision") when clean. Distinguishing 2 from
+# any other non-zero exit stops the briefing reporting "none" out of a broken
+# environment — the same discipline as the jjconflicts helper.
+conflicts_out=$(jj --ignore-working-copy resolve --list 2>/dev/null) && conflicts_rc=0 || conflicts_rc=$?
+if [ "$conflicts_rc" -eq 0 ] && [ -n "$conflicts_out" ]; then
+  conflicts="CONFLICTS PRESENT — resolve these before further work:
+${conflicts_out}"
+elif [ "$conflicts_rc" -eq 0 ] || [ "$conflicts_rc" -eq 2 ]; then
+  conflicts="none"
+else
+  conflicts="(unable to check conflicts — jj exited ${conflicts_rc})"
+fi
+
+# @ and `jj root` are workspace-relative: which workspace this session is
+# attached to determines what @ even means, and a second live workspace means
+# another agent may be editing concurrently.
+workspaces=$(jj --ignore-working-copy workspace list 2>/dev/null || echo "(unable to read workspaces)")
+
+identity=$(jj --ignore-working-copy config list user.email -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read user.email)")
 
 # Escape string for JSON embedding
 escape_for_json() {
@@ -27,14 +73,22 @@ escape_for_json() {
 
 context="== jj Session Context ==
 
-Current change:
+Current change (@):
 ${current_change}
+
+Local stack (trunk()..@):
+${stack}
+
+Conflicts: ${conflicts}
+
+Workspaces:
+${workspaces}
 
 Working copy status:
 ${working_status}
 
-Repository config (JSON):
-${repo_config}
+Identity:
+${identity}
 
 == jj Workflow Reminder ==
 - Use \`jj new\` to start a fresh change before making edits

--- a/plugins/project-setup-jj/tests/test-jj-session-start.sh
+++ b/plugins/project-setup-jj/tests/test-jj-session-start.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Unit tests for the SessionStart briefing.
+#
+# The hook emits the only payload every session is guaranteed to read, so these
+# tests pin two things:
+#   1. CONTENT — it answers stack / conflicts / workspace, and does NOT go back
+#      to dumping all of `jj config list`. A briefing that silently loses the
+#      conflict line still emits valid JSON and still reads as "working".
+#   2. THE SNAPSHOT BUDGET — `jj status` is the one call allowed to snapshot;
+#      every other read carries --ignore-working-copy.
+#
+#      This needs BOTH a behavioural and a structural check, and the behavioural
+#      one alone is not enough. Measured while writing these tests: deleting
+#      --ignore-working-copy from a read that runs AFTER `jj status` keeps the
+#      op count at 1, because the first snapshot already captured the working
+#      copy and a second one finds nothing to write. So the op-count assertion
+#      pins the property that actually matters to concurrent workspaces — the
+#      briefing writes at most one operation — but it CANNOT see a dropped flag.
+#      The structural lint below is what catches that.
+
+#
+# bash 3.2-safe (macOS): no globstar, no associative arrays.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/../scripts/jj-session-start.sh"
+
+pass=0
+fail=0
+ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL: $1 — $2"; fail=$((fail+1)); }
+
+if [ ! -f "$HOOK" ]; then
+  echo "  FAIL: hook not found at $HOOK — nothing was checked"
+  exit 1
+fi
+
+# --- scratch jj repo, fully isolated from the caller's jj config ---
+# JJ_CONFIG is not a nicety: a sibling eval scaffold once truncated the caller's
+# real ~/.config/jj/config.toml, and every later change carried the wrong author.
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+export JJ_CONFIG="$WORK/jjconfig.toml"
+# trunk() is aliased to a local `main` bookmark so `trunk()..@` means what it
+# means in a real repo. Without an origin remote trunk() falls back to the root
+# commit, and every change in history would count as "the stack".
+#
+# immutable_heads() is emptied only so the empty-stack case can be reached at
+# all: jj refuses `jj edit trunk()` under the default immutable set, so @ can
+# never equal trunk and the stack is never empty. That branch is therefore rare
+# in practice — but it is what a briefing prints if a user does loosen the
+# immutable set, and a blank section there must not read as "unknown".
+cat > "$JJ_CONFIG" <<'CFG'
+[user]
+name = "test"
+email = "test@example.com"
+
+[revset-aliases]
+"trunk()" = "main"
+"immutable_heads()" = "none()"
+CFG
+cd "$WORK"
+jj git init repo >/dev/null 2>&1
+cd repo
+echo a > f.txt
+jj describe -m seed >/dev/null 2>&1
+jj bookmark create main -r @ >/dev/null 2>&1
+jj new -m work >/dev/null 2>&1
+
+# ctx -> the briefing's additionalContext string, or empty if the hook emitted
+# something that is not valid JSON.
+ctx() { bash "$HOOK" 2>/dev/null | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || true; }
+
+# ops -> current op-log depth. Carries --ignore-working-copy so that MEASURING
+# never adds the very operation being measured.
+ops() { jj --ignore-working-copy op log --no-graph -T 'id.short() ++ "\n"' 2>/dev/null | grep -c . || true; }
+
+# --- shape ---
+raw="$(bash "$HOOK" 2>/dev/null || true)"
+if printf '%s' "$raw" | jq -e '.hookSpecificOutput.hookEventName == "SessionStart"' >/dev/null 2>&1; then
+  ok "emits valid JSON with hookEventName SessionStart"
+else
+  bad "shape" "not valid SessionStart JSON: $raw"
+fi
+
+out="$(ctx)"
+if [ -z "$out" ]; then
+  bad "additionalContext" "empty — every content assertion below would be vacuous"
+fi
+
+# --- content: the three questions the old briefing could not answer ---
+case "$out" in
+  *"Local stack (trunk()..@):"*) ok "briefing carries the local stack" ;;
+  *) bad "stack" "no stack section in briefing" ;;
+esac
+case "$out" in
+  *"Conflicts: none"*) ok "briefing reports conflicts (clean repo -> none)" ;;
+  *) bad "conflicts" "no clean-conflict line in briefing" ;;
+esac
+case "$out" in
+  *"Workspaces:"*default:*) ok "briefing names the workspace" ;;
+  *) bad "workspaces" "no workspace section in briefing" ;;
+esac
+
+# The stack is `trunk()..@`, not all of history: it must carry the local change
+# and must NOT carry the trunk change it is measured against. A header with the
+# wrong revset behind it looks identical until you check both halves.
+if printf '%s' "$out" | grep -q '"description":"work'; then
+  ok "stack section carries the local change, not just a header"
+else
+  bad "stack contents" "local change absent from the stack section"
+fi
+if printf '%s' "$out" | grep -q '"description":"seed'; then
+  bad "stack revset" "trunk's own change leaked into the stack — revset is not trunk()..@"
+else
+  ok "stack excludes trunk itself"
+fi
+
+# --- content: identity trimmed to user.email, config trivia gone ---
+# Ask jj for the expected value rather than hardcoding the one this test wrote
+# into JJ_CONFIG. CI exports JJ_EMAIL, and an env value OUTRANKS the config file,
+# so a literal `test@example.com` here passes locally and fails on CI for a
+# reason that has nothing to do with the briefing.
+want_email=$(jj --ignore-working-copy config get user.email 2>/dev/null || echo "")
+# Scope the search to the Identity SECTION. Searching the whole briefing is
+# vacuous: every change's `json(self)` already embeds author.email, so deleting
+# the Identity section entirely still leaves the address in the payload and the
+# assertion passes. Verified by mutation — this check was green against a hook
+# with no Identity section at all before it was scoped.
+identity_section=$(printf '%s\n' "$out" | awk '/^Identity:/{f=1;next} /^[[:space:]]*$/{f=0} f')
+if [ -z "$want_email" ]; then
+  bad "identity" "could not read user.email at all — the assertion would be vacuous"
+elif [ -z "$identity_section" ]; then
+  bad "identity" "no Identity section in the briefing"
+elif printf '%s' "$identity_section" | grep -qF "$want_email"; then
+  ok "Identity section carries user.email ($want_email)"
+else
+  bad "identity" "Identity section present but without user.email — the field a clobbered config corrupts"
+fi
+case "$out" in
+  *operation.hostname*|*operation.username*)
+    bad "config trim" "briefing regressed to dumping all of jj config list" ;;
+  *) ok "config trivia (operation.hostname/username) stays out" ;;
+esac
+
+# --- empty stack is stated, not left blank ---
+jj edit main >/dev/null 2>&1
+out_at_trunk="$(ctx)"
+case "$out_at_trunk" in
+  *"(none — @ is at trunk)"*) ok "empty stack is stated explicitly" ;;
+  *) bad "empty stack" "blank stack section reads as unknown" ;;
+esac
+jj new -m work2 >/dev/null 2>&1   # back off trunk for the remaining cases
+
+# --- snapshot budget: one snapshot when dirty, none when clean ---
+echo dirty >> f.txt          # an unsnapshotted edit, as Write/Edit would leave
+before="$(ops)"
+bash "$HOOK" >/dev/null 2>&1
+after="$(ops)"
+delta=$((after - before))
+if [ "$delta" -eq 1 ]; then
+  ok "dirty working copy -> exactly one operation (jj status snapshots once)"
+else
+  bad "snapshot budget" "expected 1 new op on a dirty copy, got $delta — a read lost --ignore-working-copy"
+fi
+
+before="$(ops)"
+bash "$HOOK" >/dev/null 2>&1
+after="$(ops)"
+delta=$((after - before))
+if [ "$delta" -eq 0 ]; then
+  ok "clean working copy -> zero operations"
+else
+  bad "snapshot budget" "expected 0 new ops on a clean copy, got $delta"
+fi
+
+# --- structural: only the designated snapshot point may omit the flag ---
+# The op-count checks above cannot see this (see header), so read the source.
+# Allowed to run unflagged: `jj root` (the repo probe, before any read) and
+# `jj status` (the one snapshot point). Everything else must carry the flag.
+offenders=""
+flagged=0
+status_line=0
+first_read_line=0
+lineno=0
+while IFS= read -r line; do
+  lineno=$((lineno + 1))
+  case "$line" in
+    [[:space:]]*"#"*|"#"*) continue ;;      # comments discuss jj freely
+  esac
+  # Only real call sites, not the word "jj". The briefing's own reminder text
+  # says `jj new` / `jj diff`, and a substring match would flag the prose it is
+  # the hook's whole job to emit.
+  trimmed=$(printf '%s' "$line" | sed 's/^[[:space:]]*//')
+  invocation=0
+  case "$line" in
+    *'$(jj '*|*'! jj '*) invocation=1 ;;
+  esac
+  case "$trimmed" in
+    'jj '*) invocation=1 ;;
+  esac
+  if [ "$invocation" -eq 0 ]; then continue; fi
+  case "$line" in
+    *"--ignore-working-copy"*)
+      flagged=$((flagged + 1))
+      if [ "$first_read_line" -eq 0 ]; then first_read_line=$lineno; fi
+      continue ;;
+  esac
+  case "$line" in
+    *"jj root"*) continue ;;
+    *"jj status"*) status_line=$lineno; continue ;;
+  esac
+  offenders="$offenders  line $lineno: $line
+"
+done < "$HOOK"
+
+if [ -z "$offenders" ]; then
+  ok "every jj read except the probe and the snapshot point carries --ignore-working-copy"
+else
+  bad "flag discipline" "unflagged jj call(s) outside the snapshot point:
+$offenders"
+fi
+
+# Fail loudly if the structure this lint depends on vanished: a hook that no
+# longer contains the reads would sweep zero lines and report success.
+if [ "$flagged" -ge 4 ] && [ "$status_line" -gt 0 ]; then
+  ok "lint saw the expected shape ($flagged flagged reads + a snapshot point)"
+else
+  bad "lint shape" "expected >=4 flagged reads and a jj status line, saw $flagged and line $status_line"
+fi
+
+# Ordering: the snapshot must precede the flagged reads, or the briefing mixes
+# pre-snapshot and post-snapshot state within one payload.
+if [ "$status_line" -gt 0 ] && [ "$status_line" -lt "$first_read_line" ]; then
+  ok "snapshot point precedes every --ignore-working-copy read"
+else
+  bad "ordering" "jj status at line $status_line does not precede first flagged read at $first_read_line"
+fi
+
+# --- conflicts are surfaced, and loudly ---
+# Two siblings editing the same line, merged: @ is a conflicted merge commit.
+jj new 'trunk()' -m left >/dev/null 2>&1
+echo left > f.txt
+left="$(jj --ignore-working-copy log -r @ --no-graph -T 'change_id.short()')"
+jj new 'trunk()' -m right >/dev/null 2>&1
+echo right > f.txt
+right="$(jj --ignore-working-copy log -r @ --no-graph -T 'change_id.short()')"
+jj new "$left" "$right" >/dev/null 2>&1
+
+out_conflict="$(ctx)"
+case "$out_conflict" in
+  *"CONFLICTS PRESENT"*f.txt*) ok "conflicted @ is called out by name" ;;
+  *) bad "conflicts" "conflict not surfaced in briefing: $(printf '%s' "$out_conflict" | grep -i conflict || echo '<no conflict line>')" ;;
+esac
+
+# --- a broken environment must not read as clean ---
+# Outside a jj repo the hook exits silently (0, no output) rather than emitting a
+# briefing whose "Conflicts: none" would be a fabrication.
+cd "$WORK"
+rc=0
+outside="$(bash "$HOOK" 2>/dev/null)" || rc=$?
+if [ "$rc" -eq 0 ] && [ -z "$outside" ]; then
+  ok "outside a jj repo: silent exit 0, no fabricated briefing"
+else
+  bad "non-repo" "expected silent success, got rc=$rc out='$outside'"
+fi
+
+echo
+echo "$pass passed, $fail failed"
+test "$fail" -eq 0


### PR DESCRIPTION
Two changes to `project-setup-jj`, both about a session getting the jj context it
is supposed to have — one in the main checkout, one in a `claude -w` workspace.

Version: `0.10.3` → `0.12.0`.

---

## 1. The SessionStart briefing answers stack, conflicts and workspace

The hook emits the one payload **every** session reads. It was emitting
`jj log -r @`, `jj status`, and the whole of `jj config list` — four lines of
hostname/username trivia — and answering none of the three questions that change
what an agent does next:

- what is in my stack (`trunk()..@`)
- am I in conflict
- which workspace am I in, and is anyone else live

All three were already computable — `agent-helpers-jj` has had `jjstack` /
`jjconflicts` for a while — they just were not wired into the one place
guaranteed to run. Idea borrowed from [agentjj](https://github.com/2389-research/agentjj)'s
`orient` command.

Identity survives the trim as `user.email` alone, rather than being dropped: an
eval scaffold once truncated a caller's `~/.config/jj/config.toml`, and the wrong
author on every later change was the symptom nobody noticed.

**Snapshot discipline.** `jj status` runs first and is the only unflagged call —
the single snapshot point. Every later read carries `--ignore-working-copy`, so
the briefing describes one consistent post-snapshot state and writes at most one
operation to the op log (the serialization point concurrent workspaces contend on).

**New suite:** `tests/test-jj-session-start.sh`, 16 assertions.

Every assertion was mutation-checked, and one mutation changed the design:

> Deleting `--ignore-working-copy` from a read that runs **after** `jj status`
> left the op count at 1 and the suite fully green — the first snapshot had
> already captured the working copy, so the second found nothing to write.

So the behavioural check *cannot* see a dropped flag; it only proves the
≤1-operation property. A structural lint over the hook's call sites was added to
catch it, verified red on both a dropped flag and an indented bare invocation,
plus an ordering check that the snapshot precedes the flagged reads.

That matters beyond this file: `docs/plugin-coverage-map-2026-08.md` claims
nothing in this repo catches a removed flag, and names generalising the markdown
lint as the fix — a purely behavioural generalisation would inherit the same
blind spot. Recorded there.

---

## 2. The statusline survives into jj workspaces

A `claude -w` session runs in a jj workspace, which materialises only **tracked**
files. Both halves of the statusline were untracked:

| half | was | `.gitignore` |
|---|---|---|
| config | `.claude/settings.local.json` | explicitly ignored |
| script | `.claude/scripts/statusline-jj.sh` | `.claude/*`, no negation |

Neither reached a workspace, so the statusline silently vanished in every side
thread.

The script was never the problem — it already resolves `jj root` from cwd, keys
its cache per workspace, handles `.jj/repo` being a pointer file in a workspace,
and uses `--ignore-working-copy` throughout. This is config reach only.

Both halves are now tracked, and the command resolves the **live** workspace
rather than hardcoding an absolute path into the main checkout:

```sh
sh -c 'p="${CLAUDE_PROJECT_DIR:-$(jj root --ignore-working-copy 2>/dev/null || pwd)}"; exec "$p/.claude/hooks/statusline-jj.sh"'
```

The fallback is not belt-and-braces. `CLAUDE_PROJECT_DIR` is documented for
*hooks*; for `statusLine` the docs specify stdin JSON and only `COLUMNS`/`LINES`
in the environment. Verified rendering from inside a real workspace with the
variable unset — it printed that workspace's own change id, not the main
checkout's.

**Setup now strips `statusLine` from `settings.local.json`, and remove deletes
from both files.** Required, not tidiness: both scopes apply and local is the
more specific one, so a leftover local key overrides the tracked one. The failure
is deceptive — the statusline keeps working in the main checkout, so the install
looks successful, while every workspace stays broken.

---

## Verification

All 12 suites green (5 `project-setup-jj` + 7 repo-level lints), plus the 9 other
plugin suites.

## Follow-up

#150 — nothing pins the install target, so a regression back to
`settings.local.json` would leave every suite green. `project-setup-jj` has no
prose lint at all, despite its commands being the ones that write settings files
into consumer projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)