### PR TITLE
perf(project-setup-jj): compact stack rendering in the session briefing

### DIFF
--- a/.claude/hooks/jj-session-start.sh
+++ b/.claude/hooks/jj-session-start.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 # SessionStart hook: Show jj context and workflow reminder
 # Outputs JSON with additionalContext for Claude Code
+#
+# What belongs in this briefing: it is the one payload EVERY session
+# reads, so it must answer the questions that change what an agent does next —
+# what is in my stack, am I in conflict, which workspace am I in — rather than
+# spend its budget on state that changes nothing. It used to emit the whole of
+# `jj config list` (four lines of hostname/username/identity) and none of the
+# three above. Identity survives the trim as `user.email` alone, because an eval
+# scaffold once truncated a caller's ~/.config/jj/config.toml and the wrong
+# author on every subsequent change was the symptom nobody saw.
+#
+# bash 3.2-safe (macOS): no globstar, no associative arrays. Note that under
+# `set -e` a bare `[ cond ] && var=x` at top level EXITS the script when cond is
+# false — every conditional below is written as if/then for that reason.
 
 set -euo pipefail
 
@@ -9,10 +22,57 @@ if ! jj root >/dev/null 2>&1; then
   exit 0
 fi
 
-# Gather jj context
-current_change=$(jj log -r @ --no-graph -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read current change)")
+# `jj status` runs FIRST and deliberately WITHOUT --ignore-working-copy: it is
+# the single snapshot point for this briefing. Every read after it carries the
+# flag, so (a) the whole briefing describes one consistent post-snapshot state
+# instead of a mix of pre- and post-, and (b) the hook writes at most one
+# operation to the op log — the serialization point concurrent jj workspaces
+# race on (see agent-helpers-jj/scripts/jj-agent-helpers.sh).
 working_status=$(jj status 2>/dev/null || echo "(unable to read status)")
-repo_config=$(jj config list -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read config)")
+
+current_change=$(jj --ignore-working-copy log -r @ --no-graph -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read current change)")
+
+# The local stack, one compact line per change. NOT `json(self)`: the stack is
+# for orientation — which changes am I carrying, are any empty or conflicted —
+# and the full object per change buys nothing beyond what the section above
+# already prints for @. The common case is a depth-1 stack, where a JSON stack
+# repeated @'s object verbatim, ~350 bytes of exact duplication in the one
+# payload whose whole justification is not spending budget on what changes
+# nothing. A 5-deep stack cost ~1.7KB; the same stack is ~250 bytes here.
+#
+# Empty output means @ sits at trunk — say so, because a blank section reads as
+# "unknown" rather than "nothing there".
+_stack_tmpl='self.change_id().short(8)'
+_stack_tmpl="$_stack_tmpl"' ++ if(current_working_copy, " @")'
+_stack_tmpl="$_stack_tmpl"' ++ if(empty, " [empty]", "")'
+_stack_tmpl="$_stack_tmpl"' ++ if(conflict, " [conflict]", "")'
+_stack_tmpl="$_stack_tmpl"' ++ if(bookmarks, " (" ++ bookmarks ++ ")", "")'
+_stack_tmpl="$_stack_tmpl"' ++ " " ++ if(description, description.first_line(), "(no description)") ++ "\n"'
+stack=$(jj --ignore-working-copy log -r 'trunk()..@' --no-graph -T "$_stack_tmpl" 2>/dev/null || echo "(unable to read stack)")
+if [ -z "$stack" ]; then
+  stack="(none — @ is at trunk)"
+fi
+
+# jj 0.43: `resolve --list` exits 0 (and lists) when conflicts exist, and exits
+# 2 ("No conflicts found at this revision") when clean. Distinguishing 2 from
+# any other non-zero exit stops the briefing reporting "none" out of a broken
+# environment — the same discipline as the jjconflicts helper.
+conflicts_out=$(jj --ignore-working-copy resolve --list 2>/dev/null) && conflicts_rc=0 || conflicts_rc=$?
+if [ "$conflicts_rc" -eq 0 ] && [ -n "$conflicts_out" ]; then
+  conflicts="CONFLICTS PRESENT — resolve these before further work:
+${conflicts_out}"
+elif [ "$conflicts_rc" -eq 0 ] || [ "$conflicts_rc" -eq 2 ]; then
+  conflicts="none"
+else
+  conflicts="(unable to check conflicts — jj exited ${conflicts_rc})"
+fi
+
+# @ and `jj root` are workspace-relative: which workspace this session is
+# attached to determines what @ even means, and a second live workspace means
+# another agent may be editing concurrently.
+workspaces=$(jj --ignore-working-copy workspace list 2>/dev/null || echo "(unable to read workspaces)")
+
+identity=$(jj --ignore-working-copy config list user.email -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read user.email)")
 
 # Escape string for JSON embedding
 escape_for_json() {
@@ -27,14 +87,22 @@ escape_for_json() {
 
 context="== jj Session Context ==
 
-Current change:
+Current change (@):
 ${current_change}
+
+Local stack (trunk()..@):
+${stack}
+
+Conflicts: ${conflicts}
+
+Workspaces:
+${workspaces}
 
 Working copy status:
 ${working_status}
 
-Repository config (JSON):
-${repo_config}
+Identity:
+${identity}
 
 == jj Workflow Reminder ==
 - Use \`jj new\` to start a fresh change before making edits

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/README.md
+++ b/plugins/project-setup-jj/README.md
@@ -70,7 +70,10 @@ Current change (@):
 <current change as JSON>
 
 Local stack (trunk()..@):
-<changes ahead of trunk, JSON lines — or "(none — @ is at trunk)">
+qnmwxqnp @ [empty] (no description)     # one compact line per change ahead of
+yxurtlwx (main) feat(...): ...          # trunk; markers for @, [empty],
+                                        # [conflict] and bookmarks.
+                                        # Or "(none — @ is at trunk)"
 
 Conflicts: none            # or "CONFLICTS PRESENT" + the conflicted paths
 

--- a/plugins/project-setup-jj/scripts/jj-session-start.sh
+++ b/plugins/project-setup-jj/scripts/jj-session-start.sh
@@ -32,9 +32,23 @@ working_status=$(jj status 2>/dev/null || echo "(unable to read status)")
 
 current_change=$(jj --ignore-working-copy log -r @ --no-graph -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read current change)")
 
-# The local stack. Empty output means @ sits at trunk — say so, because a blank
-# section reads as "unknown" rather than "nothing there".
-stack=$(jj --ignore-working-copy log -r 'trunk()..@' --no-graph -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read stack)")
+# The local stack, one compact line per change. NOT `json(self)`: the stack is
+# for orientation — which changes am I carrying, are any empty or conflicted —
+# and the full object per change buys nothing beyond what the section above
+# already prints for @. The common case is a depth-1 stack, where a JSON stack
+# repeated @'s object verbatim, ~350 bytes of exact duplication in the one
+# payload whose whole justification is not spending budget on what changes
+# nothing. A 5-deep stack cost ~1.7KB; the same stack is ~250 bytes here.
+#
+# Empty output means @ sits at trunk — say so, because a blank section reads as
+# "unknown" rather than "nothing there".
+_stack_tmpl='self.change_id().short(8)'
+_stack_tmpl="$_stack_tmpl"' ++ if(current_working_copy, " @")'
+_stack_tmpl="$_stack_tmpl"' ++ if(empty, " [empty]", "")'
+_stack_tmpl="$_stack_tmpl"' ++ if(conflict, " [conflict]", "")'
+_stack_tmpl="$_stack_tmpl"' ++ if(bookmarks, " (" ++ bookmarks ++ ")", "")'
+_stack_tmpl="$_stack_tmpl"' ++ " " ++ if(description, description.first_line(), "(no description)") ++ "\n"'
+stack=$(jj --ignore-working-copy log -r 'trunk()..@' --no-graph -T "$_stack_tmpl" 2>/dev/null || echo "(unable to read stack)")
 if [ -z "$stack" ]; then
   stack="(none — @ is at trunk)"
 fi

--- a/plugins/project-setup-jj/tests/test-jj-session-start.sh
+++ b/plugins/project-setup-jj/tests/test-jj-session-start.sh
@@ -103,18 +103,40 @@ case "$out" in
   *) bad "workspaces" "no workspace section in briefing" ;;
 esac
 
+# Scope every stack assertion to the stack SECTION, for the reason the identity
+# check had to learn: @'s own `json(self)` block sits directly above and already
+# contains the description, so an unscoped grep passes even against a hook that
+# emits no stack at all.
+stack_section=$(printf '%s\n' "$out" | awk '/^Local stack/{f=1;next} /^[[:space:]]*$/{f=0} f')
+
 # The stack is `trunk()..@`, not all of history: it must carry the local change
 # and must NOT carry the trunk change it is measured against. A header with the
 # wrong revset behind it looks identical until you check both halves.
-if printf '%s' "$out" | grep -q '"description":"work'; then
+if [ -z "$stack_section" ]; then
+  bad "stack contents" "no stack section — every assertion below would be vacuous"
+elif printf '%s' "$stack_section" | grep -qF 'work'; then
   ok "stack section carries the local change, not just a header"
 else
-  bad "stack contents" "local change absent from the stack section"
+  bad "stack contents" "local change absent from the stack section: $stack_section"
 fi
-if printf '%s' "$out" | grep -q '"description":"seed'; then
+if printf '%s' "$stack_section" | grep -qF 'seed'; then
   bad "stack revset" "trunk's own change leaked into the stack — revset is not trunk()..@"
 else
   ok "stack excludes trunk itself"
+fi
+
+# Compact, not json(self). A depth-1 stack under JSON duplicated @'s object
+# verbatim — the exact "spends budget on what changes nothing" the briefing
+# exists to avoid — so pin the rendering, not just the contents.
+if printf '%s' "$stack_section" | grep -qE '"(commit_id|description|author)"'; then
+  bad "stack rendering" "stack regressed to json(self) — it duplicates the section above"
+else
+  ok "stack renders compact, not JSON"
+fi
+if printf '%s' "$stack_section" | grep -qF ' @'; then
+  ok "stack marks which entry is the working copy"
+else
+  bad "stack marker" "no @ marker in the stack: $stack_section"
 fi
 
 # --- content: identity trimmed to user.email, config trivia gone ---


### PR DESCRIPTION
Follow-up to #151, found by reading the live briefing it produced.

## The duplication

The stack section rendered `json(self)` per change. At a depth-1 stack — the
common case — it repeated the current-change object directly above it
**verbatim**:

```
Current change (@):
{"commit_id":"2f34060a…","change_id":"qnmwxqnp…","description":"", …}

Local stack (trunk()..@):
{"commit_id":"2f34060a…","change_id":"qnmwxqnp…","description":"", …}   ← identical
```

~350 bytes of exact duplication in the one payload whose entire justification is
*not* spending budget on state that changes nothing. A 5-deep stack cost ~1.7KB.

## Now

One compact line per change, carrying what orientation actually needs:

```
Local stack (trunk()..@):
qnmwxqnp @ [empty] (no description)
yxurtlwx (main) feat(project-setup-jj): session briefing and statusline reach jj workspaces (#151)
```

Markers for the working copy (`@`), `[empty]`, `[conflict]`, and bookmarks. The
same 5-deep stack is now ~250 bytes.

## Why the tests missed it

Every scratch repo the suite builds has `@` distinct from the seed, so the stack
never coincided with the current change. The duplication only appeared in a real
session sitting at a depth-1 stack — which is most sessions.

## Test changes

Assertions are now scoped to the stack **section** rather than the whole
briefing. This is the second time that exact fix was needed: the identity
assertion in #151 had the same flaw, passing against a hook with no Identity
section at all because `author.email` appears in the change JSON regardless.
Here the JSON block for `@` sits directly above and contains the description, so
an unscoped grep would pass against a hook emitting no stack whatsoever.

Two new assertions pin the **rendering**, not just the contents, so a revert to
`json(self)` fails rather than silently regrowing:

- stack renders compact, not JSON
- stack marks which entry is the working copy

18 assertions, up from 16. Four mutations verified red, each on the intended
assertion: revert to `json(self)`, drop the section entirely, widen the revset to
`all()`, drop the `@` marker.

## Layer 3

Also syncs `.claude/hooks/jj-session-start.sh`, this repo's own installed copy.
#151 updated the plugin source only, so the merged change reached nobody —
including this repo — until `/project-setup` was re-run. A new `jj workspace`
materialises the tracked copy, so it has to be committed for side threads to see
it.

Verified: all 12 suites pass under the CI environment (`JJ_USER`/`JJ_EMAIL`
exported), and the briefing was rendered from inside a real probe workspace to
confirm it reports that workspace's own `@`, stack, and the full workspace list.