### PR TITLE
fix(commit-commands-jj): delete the remote branch LAST — an early delete hands the abandon to `jj git fetch`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- jj-project-setup:start hash:d01c702b -->
+<!-- jj-project-setup:start hash:27bab007 -->
 ## VCS — jj (Jujutsu)
 
 This project uses **jj (Jujutsu)** as its VCS. Never use raw git commands. Use jj equivalents instead (e.g. `jj log`, `jj status`, `jj diff`). The only exceptions are `jj git` subcommands (e.g. `jj git push`) and the `gh` CLI for GitHub operations.
@@ -8,7 +8,7 @@ In jj, the working copy IS a commit. There is no uncommitted state. Never ask "w
 ### Gotchas that surprise git users
 
 - **Hand revisions between steps as change IDs, not commit IDs.** A change ID (`kouorrnv`) survives `jj squash`, `jj describe` and every other rewrite; a commit ID (`92ef691b`) is replaced by each one, so a value captured before an edit is stale after it. Read one with `jj log -r <rev> --no-graph -T 'change_id.short()'`. Commit IDs are fine for a one-shot query or an immutable record — not for anything held across a step.
-- **`jj abandon` re-parents `@` onto the abandoned change's parent.** After abandoning work that was merged upstream, `@` lands on the *pre-merge* base and every merged file reads as reverted on disk. Fix with `jj new trunk()`. The work is safe; the working copy is looking at the wrong revision.
+- **Abandoning re-parents `@` onto the abandoned change's parent — and `jj git fetch` does the abandoning itself when the remote branch is already gone.** A squash-merge rebuilds your work as a *new* commit, so once the branch is deleted (by hand, or by GitHub's auto-delete-head-branches) the original is unreachable and fetch drops it. Either way `@` lands on the *pre-merge* base and every merged file reads as reverted on disk. Fix with `jj new trunk()`. The work is safe; the working copy is looking at the wrong revision. Corollary: delete the remote branch **last** — while it exists the fetch is inert, and you can still verify the work landed before anything is dropped.
 - **Abandoning `@` always leaves a fresh empty change.** You cannot end up with no working copy, so don't chase the new empty change you just created.
 - **`--ignore-working-copy` skips the snapshot, so it hides edits you just made.** It is correct for background and concurrent tooling — the `jjctx`/`jjstack`/`jjconflicts` helpers bake it in — and wrong for reviewing your own work: `jj diff --from 'trunk()' --to @ --stat` with the flag can omit your most recent edits and still read as a complete answer. Drop it whenever the answer depends on the current working copy. Unlike the two above, this one fails quietly.
 

--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests — requires project-setup-jj",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/commands/clean_stale.md
+++ b/plugins/commit-commands-jj/commands/clean_stale.md
@@ -40,8 +40,15 @@ you to find anything.**
    a no-op that reads like a successful cleanup.
 
    If fetch also reports `Abandoned N commits that are no longer reachable`,
-   that is jj dropping commits the deleted bookmark was the only path to. Work
-   that was merged into trunk stays reachable and is **not** abandoned.
+   that is jj dropping commits the deleted bookmark was the only path to —
+   **including work you just merged, if it was squash-merged.** A squash-merge
+   rebuilds the work as a *new* commit, so your local one is not an ancestor of
+   trunk and the deleted bookmark was indeed its only path; only a true merge
+   commit leaves it reachable. The content is safe in trunk, but `@` re-parents
+   onto the pre-merge base and the merged files read as reverted on disk — run
+   `jj new trunk()`. This is why `/finish` step 6 deletes the remote branch
+   *last*: while it exists, the fetch is inert and the work can be verified
+   before anything is dropped.
 
 2. **List workspaces to find stale ones**
    ```bash

--- a/plugins/commit-commands-jj/commands/finish.md
+++ b/plugins/commit-commands-jj/commands/finish.md
@@ -106,9 +106,35 @@ What would you like to do?
 6. **Post-merge cleanup.** After a successful `gh pr merge`.
 
    Do not pass `--delete-branch` to `gh pr merge`. It tries to delete a local
-   *git* branch and fails with `could not determine current branch`, because a
-   jj working copy is not on one. The merge itself still succeeds — only the
-   branch cleanup fails, and step (e) below handles that.
+   *git* branch and fails (`could not determine current branch`, or `not on any
+   branch` — wording varies by `gh` version), because a jj working copy is not
+   on one. The merge itself still succeeds — only the branch cleanup fails, and
+   step (e) below handles that.
+
+   **Do not delete the remote branch by hand either — not with `--delete-branch`,
+   not with `gh api -X DELETE`.** It must survive until step (e), and the reason
+   is the fetch in (a). While the branch exists on the remote your local change
+   is still reachable from it and the fetch is inert. Once it is gone, that
+   fetch *itself* does the abandoning — `Abandoned 1 commits that are no longer
+   reachable` / `Rebased 1 descendant commits` — dropping `@` onto the
+   **pre-merge base** with every merged file reverted on disk, before step (b)
+   has confirmed anything landed. And (b) can no longer run: the target's
+   *change* id stops resolving. Tidying the branch early buys nothing and costs
+   the one check standing between a bad merge and a destroyed change.
+
+   **Where the repo deletes head branches for you, this is unavoidable.** Check
+   with `gh repo view --json deleteBranchOnMerge`. If `true`, the branch is gone
+   before you can fetch, so trade the gate for a restore point — capture both of
+   these *before* step (a):
+   ```bash
+   jj op log -n 1 --no-graph -T 'id.short()'             # restore point
+   jj log -r <target> --no-graph -T 'commit_id.short()'  # survives the abandon
+   ```
+   The **commit** id is deliberate, and the one place this repo's "hand around
+   change ids" rule inverts: once the fetch abandons the change its change id is
+   gone, while the commit id still resolves — so step (b) can still be asked,
+   as `jj diff --from 'trunk()' --to <commit-id> --stat`. If that is not empty,
+   `jj op restore <op-id>` puts the change back.
 
    a. **Fetch**, so `trunk()` names the merged trunk rather than the state you
       pushed from:
@@ -151,6 +177,10 @@ What would you like to do?
       ```bash
       jj abandon 'ancestors(<target>) & ~ancestors(trunk())'
       ```
+      If (a) already reported `Abandoned N commits that are no longer
+      reachable`, the remote branch was deleted before the fetch and this step
+      has nothing left to do — skip it rather than resolving `<target>`, which
+      no longer exists.
 
    d. **Move the working copy onto the merged trunk:**
       ```bash
@@ -160,7 +190,8 @@ What would you like to do?
       of the stack sat on — the *pre-merge* trunk — so `@` silently lands on a
       stale base and every file you just merged reads as reverted on disk. The
       work is safe in trunk; the working copy is simply looking at the wrong
-      revision, which is far more alarming than it sounds.
+      revision, which is far more alarming than it sounds. Whichever step did
+      the abandoning — (c), or the fetch in (a) — this is the fix.
 
    e. **Delete the bookmark.** Abandoning the target usually takes the local
       bookmark with it (it pointed at an abandoned change), so this is often

--- a/plugins/commit-commands-jj/tests/test-command-prose-claims.sh
+++ b/plugins/commit-commands-jj/tests/test-command-prose-claims.sh
@@ -303,6 +303,110 @@ for mode in immediate after-one-op; do
   fi
 done
 
+# --- finish.md step 6, post-merge cleanup ORDER. The prose forbids deleting the
+# remote branch before step (a)'s fetch, and the reason is not tidiness: with the
+# branch already gone, `jj git fetch` performs the abandon ITSELF — re-parenting
+# `@` onto the pre-merge base and reverting the merged files on disk — before
+# step (b) can verify the work landed. The target's CHANGE id stops resolving at
+# that point, so (b) cannot even be asked. Measured 2026-08-14 on jj 0.43 after
+# a `gh api -X DELETE` of the head branch did exactly this in a live repo.
+#
+# Two arms, because the claim is causal: the trigger is the remote branch being
+# absent at fetch time, NOT the squash-merge. If a future jj stopped abandoning
+# on fetch, a one-armed check would keep passing while the prose's whole reason
+# for the ordering rule had evaporated.
+for mode in delete-first keep-branch; do
+  mr=$(new_repo)
+  R "$mr" jj git init . --no-colocate >/dev/null 2>&1
+  ( cd "$mr" && env -i PATH="$PATH" HOME="$mr/home" TERM=dumb git init --bare --quiet origin.git )
+  R "$mr" jj git remote add origin "$mr/origin.git" >/dev/null 2>&1
+  printf 'base\n' > "$mr/cwd/README.md"
+  R "$mr" jj describe -m "Initial commit" >/dev/null 2>&1
+  R "$mr" jj bookmark create main -r @ >/dev/null 2>&1
+  R "$mr" jj git push --bookmark main >/dev/null 2>&1
+
+  # The work, pushed as a PR branch...
+  R "$mr" jj new main >/dev/null 2>&1
+  printf 'feature\n' > "$mr/cwd/feature.txt"
+  R "$mr" jj describe -m "The feature" >/dev/null 2>&1
+  R "$mr" jj bookmark create feat -r @ >/dev/null 2>&1
+  R "$mr" jj git push --bookmark feat >/dev/null 2>&1
+  m_change=$(R "$mr" jj log -r @ --no-graph -T 'change_id.short()')
+  m_commit=$(R "$mr" jj log -r @ --no-graph -T 'commit_id.short()')
+  # @ = a CHILD of the pushed work. It needs a description and content: jj
+  # discards an empty, undescribed working copy the moment you move off it, and
+  # a discarded child cannot be edited back to — leaving @ on the merge commit,
+  # where nothing re-parents and the arm silently stops testing anything.
+  R "$mr" jj new >/dev/null 2>&1
+  printf 'wip\n' > "$mr/cwd/wip.txt"
+  R "$mr" jj describe -m "Follow-up work" >/dev/null 2>&1
+  m_wc=$(R "$mr" jj log -r @ --no-graph -T 'change_id.short()')
+
+  # ...and upstream squash-merges it onto main, rebuilding the same content.
+  R "$mr" jj new main >/dev/null 2>&1
+  printf 'feature\n' > "$mr/cwd/feature.txt"
+  R "$mr" jj describe -m "The feature (squash-merged)" >/dev/null 2>&1
+  R "$mr" jj bookmark set main -r @ >/dev/null 2>&1
+  R "$mr" jj git push --bookmark main >/dev/null 2>&1
+  R "$mr" jj edit "$m_wc" >/dev/null 2>&1         # back to where the dev was
+  if [ "$(R "$mr" jj log -r @ --no-graph -T 'change_id.short()')" != "$m_wc" ]; then
+    bad "scaffold ($mode): @ is not the descendant of the merged work — nothing to re-parent"
+    continue
+  fi
+
+  if [ "$mode" = delete-first ]; then             # the `gh api -X DELETE` mistake
+    ( cd "$mr/cwd" && env -i PATH="$PATH" HOME="$mr/home" TERM=dumb \
+        git --git-dir="$mr/origin.git" update-ref -d refs/heads/feat ) >/dev/null 2>&1
+  fi
+
+  R "$mr" jj git fetch >/dev/null 2>&1            # finish.md step (a)
+
+  if R "$mr" jj log -r "$m_change" --no-graph -T 'change_id.short()' >/dev/null 2>&1; then
+    gate=runnable
+  else
+    gate=gone
+  fi
+
+  if [ "$mode" = delete-first ]; then
+    if [ "$gate" = gone ]; then
+      ok "deleting the remote branch before the fetch abandons the change and disables step (b) (finish.md step 6)"
+    else
+      bad "jj git fetch no longer abandons on a deleted remote branch — finish.md's ordering rule has gone stale"
+    fi
+    if [ -e "$mr/cwd/feature.txt" ]; then
+      bad "the fetch left the merged file in place — finish.md's 'reverted on disk' warning is now wrong"
+    else
+      ok "the fetch re-parented @ onto the pre-merge base, reverting the merged file (finish.md step (d))"
+    fi
+    # ...and the documented fallback: the COMMIT id outlives the change id, so
+    # step (b)'s question can still be asked of it. Conditioned on gate=gone on
+    # purpose — against a change that was never abandoned this diff succeeds for
+    # the boring reason, and mutation testing showed the assertion passing with
+    # the branch deletion removed entirely.
+    m_stat=$(R "$mr" jj diff --from 'trunk()' --to "$m_commit" --stat 2>/dev/null)
+    case "$m_stat" in
+      *"0 files changed"*) m_fallback=works ;;
+      *)                   m_fallback=broken ;;
+    esac
+    if [ "$gate" = gone ] && [ "$m_fallback" = works ]; then
+      ok "an abandoned change still resolves by COMMIT id, so the fallback check runs (finish.md step 6)"
+    else
+      bad "jj diff --from trunk() --to <commit-id> no longer works on an abandoned change — finish.md's auto-delete fallback is wrong"
+    fi
+  else
+    if [ "$gate" = runnable ]; then
+      ok "with the remote branch left in place the fetch is inert and step (b) can gate the abandon"
+    else
+      bad "jj git fetch abandoned the change even with the remote branch intact — finish.md's step (b) gate can never run"
+    fi
+    if [ -e "$mr/cwd/feature.txt" ]; then
+      ok "the control fetch left @ and the working copy untouched (the arms disagree, as the claim requires)"
+    else
+      bad "the control arm also lost the working-copy file — the scaffold is not isolating the deletion"
+    fi
+  fi
+done
+
 # --- undo.md recommends `jj op revert <op-id>`; it must still exist.
 if jj op revert --help >/dev/null 2>&1; then
   ok "jj op revert exists (undo.md recommends it over bare jj undo)"

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/templates/CLAUDE.md.template
+++ b/plugins/project-setup-jj/templates/CLAUDE.md.template
@@ -1,4 +1,4 @@
-<!-- jj-project-setup:start hash:d01c702b -->
+<!-- jj-project-setup:start hash:27bab007 -->
 ## VCS — jj (Jujutsu)
 
 This project uses **jj (Jujutsu)** as its VCS. Never use raw git commands. Use jj equivalents instead (e.g. `jj log`, `jj status`, `jj diff`). The only exceptions are `jj git` subcommands (e.g. `jj git push`) and the `gh` CLI for GitHub operations.
@@ -8,7 +8,7 @@ In jj, the working copy IS a commit. There is no uncommitted state. Never ask "w
 ### Gotchas that surprise git users
 
 - **Hand revisions between steps as change IDs, not commit IDs.** A change ID (`kouorrnv`) survives `jj squash`, `jj describe` and every other rewrite; a commit ID (`92ef691b`) is replaced by each one, so a value captured before an edit is stale after it. Read one with `jj log -r <rev> --no-graph -T 'change_id.short()'`. Commit IDs are fine for a one-shot query or an immutable record — not for anything held across a step.
-- **`jj abandon` re-parents `@` onto the abandoned change's parent.** After abandoning work that was merged upstream, `@` lands on the *pre-merge* base and every merged file reads as reverted on disk. Fix with `jj new trunk()`. The work is safe; the working copy is looking at the wrong revision.
+- **Abandoning re-parents `@` onto the abandoned change's parent — and `jj git fetch` does the abandoning itself when the remote branch is already gone.** A squash-merge rebuilds your work as a *new* commit, so once the branch is deleted (by hand, or by GitHub's auto-delete-head-branches) the original is unreachable and fetch drops it. Either way `@` lands on the *pre-merge* base and every merged file reads as reverted on disk. Fix with `jj new trunk()`. The work is safe; the working copy is looking at the wrong revision. Corollary: delete the remote branch **last** — while it exists the fetch is inert, and you can still verify the work landed before anything is dropped.
 - **Abandoning `@` always leaves a fresh empty change.** You cannot end up with no working copy, so don't chase the new empty change you just created.
 - **`--ignore-working-copy` skips the snapshot, so it hides edits you just made.** It is correct for background and concurrent tooling — the `jjctx`/`jjstack`/`jjconflicts` helpers bake it in — and wrong for reviewing your own work: `jj diff --from 'trunk()' --to @ --stat` with the flag can omit your most recent edits and still read as a complete answer. Drop it whenever the answer depends on the current working copy. Unlike the two above, this one fails quietly.
 


### PR DESCRIPTION
## Summary

Deleting a merged PR's head branch **before** `jj git fetch` makes the fetch abandon the local change itself: `@` lands on the pre-merge base, every merged file reads as reverted on disk, and the target's *change* id stops resolving — so `/finish` step (b), the verify-before-abandon gate, cannot run at all. The destructive step happens before the check that guards it.

That early delete is the natural workaround for `gh pr merge --delete-branch` failing on jj's detached HEAD, which `finish.md` already tells you to avoid without saying what to do instead. Hit live in another repo; reproduced and pinned here.

**Measured** with a two-arm ablation on jj 0.43 — the trigger is the remote branch being *absent at fetch time*, not the squash-merge:

| | branch deleted before fetch | control: branch left in place |
|---|---|---|
| `jj git fetch` | `Abandoned 1 commits that are no longer reachable` + `Rebased 1 descendant commits` | `bookmark: main@origin [updated] tracked` |
| `@` after fetch | pre-merge base, merged file reverted on disk | untouched |
| step (b)'s `jj diff --from 'trunk()' --to <target>` | `Revision doesn't exist` | runs, reports 0 files changed |

## Changes

- **`finish.md` step 6** — forbid deleting the remote branch early (`--delete-branch` *or* `gh api -X DELETE`); it must survive until step (e). Documents the unavoidable case (`gh repo view --json deleteBranchOnMerge` = `true`), where the gate is replaced by a restore point plus the target's **commit** id — which outlives the abandon where the change id does not, so `jj diff --from 'trunk()' --to <commit-id> --stat` still answers step (b)'s question. Step (c) now says to skip itself when (a) already abandoned; step (d) applies whichever step did it.
- **`clean_stale.md`** — corrects "work that was merged into trunk stays reachable and is **not** abandoned". False for a squash-merge: it rebuilds the work as a new commit, so the local one is not an ancestor of trunk and the deleted bookmark really was its only path.
- **`CLAUDE.md` + `project-setup-jj/templates/CLAUDE.md.template`** — the gotcha named only `jj abandon` as the trigger. `jj git fetch` does it too. Template `hash:` recomputed to `27bab007`, else `/project-setup` reports "already up to date" and the fix reaches nobody (#86/#87).
- **`test-command-prose-claims.sh`** — both arms pinned, in the file's existing two-arm style.

Bumps: `commit-commands-jj` 0.17.0 → 0.18.0, `project-setup-jj` 0.13.0 → 0.14.0.

## Test plan

- [x] `test-command-prose-claims.sh` — 20 passed, 0 failed (3 new assertions)
- [x] **Mutation-tested**: removing the branch deletion from the scaffold kills all three new delete-first assertions (17 passed, 3 failed). One assertion was vacuous on the first pass — it passed under the mutation because an un-abandoned change diffs fine for boring reasons — and is now conditioned on the abandon having actually happened.
- [x] Scaffold guard: `@` must really be the descendant of the merged work after `jj edit`, else the arm silently tests nothing (jj discards an empty undescribed working copy the moment you move off it — caught in review of the first draft).
- [x] All 21 repo suites pass, incl. `test-template-hash.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)