### PR TITLE
feat: escape C0 controls in the briefing; show session occupancy in /workspace-list

### DIFF
--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/scripts/jj-session-start.sh
+++ b/plugins/project-setup-jj/scripts/jj-session-start.sh
@@ -74,15 +74,46 @@ workspaces=$(jj --ignore-working-copy workspace list 2>/dev/null || echo "(unabl
 
 identity=$(jj --ignore-working-copy config list user.email -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read user.email)")
 
-# Escape string for JSON embedding
+# Escape string for JSON embedding.
+#
+# The five short forms below are NOT sufficient. JSON forbids every control
+# character in U+0000-U+001F unescaped, and this briefing is a single JSON
+# object — so one stray control byte does not corrupt one line, it makes the
+# whole payload unparseable and the session starts with NO briefing at all: no
+# stack, no conflicts, no workspaces, no identity. A jj description picks one up
+# trivially, because pasting colorized terminal output into `jj describe` puts an
+# ESC (0x1B) into description.first_line(), which line 50 interpolates.
+#
+# `local LC_ALL=C` makes every string operation in this function byte-wise:
+# ${#s} counts bytes, ${s:i:1} takes one byte, and the [ - ] range is byte
+# ordering rather than locale collation. Multi-byte UTF-8 therefore survives as
+# a run of individual bytes, each >= 0x80 and so passed through untouched, and
+# reassembles unchanged. Without the C locale the range would collate and the
+# match would be unpredictable.
 escape_for_json() {
-    local s="$1"
+    local LC_ALL=C
+    local s="$1" out="" i ch
     s="${s//\\/\\\\}"
     s="${s//\"/\\\"}"
     s="${s//$'\n'/\\n}"
     s="${s//$'\r'/\\r}"
     s="${s//$'\t'/\\t}"
-    printf '%s' "$s"
+    # Fast path: the overwhelmingly common case has nothing left below 0x20, and
+    # the byte loop below should not run on every description.
+    case "$s" in
+      *[$'\001'-$'\037']*) ;;
+      *) printf '%s' "$s"; return 0 ;;
+    esac
+    i=0
+    while [ "$i" -lt "${#s}" ]; do
+      ch="${s:$i:1}"
+      case "$ch" in
+        [$'\001'-$'\037']) out="$out$(printf '\\u%04x' "'$ch")" ;;
+        *) out="$out$ch" ;;
+      esac
+      i=$((i+1))
+    done
+    printf '%s' "$out"
 }
 
 context="== jj Session Context ==

--- a/plugins/project-setup-jj/tests/test-jj-session-start.sh
+++ b/plugins/project-setup-jj/tests/test-jj-session-start.sh
@@ -260,6 +260,34 @@ else
   bad "ordering" "jj status at line $status_line does not precede first flagged read at $first_read_line"
 fi
 
+# --- control characters in a description must not break the payload ---
+# escape_for_json handled only \ " \n \r \t and passed every other C0 control
+# through raw. JSON forbids ALL of U+0000-U+001F unescaped, and the whole
+# briefing is one JSON object — so a single ESC reaching description.first_line()
+# cost the ENTIRE payload (stack, conflicts, workspaces, identity), not just the
+# offending line. One paste of colorized terminal output into `jj describe` is
+# enough to do it.
+#
+# The emoji rides along deliberately. The fix works byte-wise (LC_ALL=C), so the
+# thing most likely to break next is multi-byte UTF-8 being chopped into bytes
+# and reassembled wrong — which would corrupt descriptions silently rather than
+# loudly, and no JSON parse would catch it. Assert the character survives, not
+# just that the payload parses.
+cd "$WORK/repo"
+jj describe -m "$(printf 'boom\033[31mred \013vt \007bel ship\xf0\x9f\x9a\x80it')" >/dev/null 2>&1
+raw_c0="$(bash "$HOOK" 2>/dev/null || true)"
+if printf '%s' "$raw_c0" | jq -e . >/dev/null 2>&1; then
+  ok "briefing stays valid JSON when a description carries C0 controls"
+  if printf '%s' "$raw_c0" | jq -r '.hookSpecificOutput.additionalContext' | grep -q 'ship🚀it'; then
+    ok "multi-byte UTF-8 survives the byte-wise escape intact"
+  else
+    bad "UTF-8" "emoji did not round-trip through escape_for_json"
+  fi
+else
+  bad "C0 escaping" "hook emitted unparseable JSON for a description with ESC/VT/BEL"
+fi
+jj describe -m work >/dev/null 2>&1
+
 # --- conflicts are surfaced, and loudly ---
 # Two siblings editing the same line, merged: @ is a conflicted merge commit.
 jj new 'trunk()' -m left >/dev/null 2>&1

--- a/plugins/workspace-jj/.claude-plugin/plugin.json
+++ b/plugins/workspace-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workspace-jj",
   "description": "Wave-based parallel orchestration with spec review gates for jj (Jujutsu) repositories",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/workspace-jj/commands/workspace-list.md
+++ b/plugins/workspace-jj/commands/workspace-list.md
@@ -1,12 +1,15 @@
 ---
 description: List all jj workspaces with JSON output
-allowed-tools: Bash(jj:*)
+allowed-tools: Bash(jj:*), Bash(jq:*)
 ---
+
+**CRITICAL: This is a jj (Jujutsu) plugin. You MUST NOT use ANY raw git commands. Use jj equivalents instead (e.g. `jj log`, `jj status`, `jj diff`). The only exceptions are `jj git` subcommands (e.g. `jj git push`) and the `gh` CLI for GitHub operations.**
 
 ## Context
 
 - Active workspaces (JSON): !`jj workspace list --ignore-working-copy --no-pager -T 'json(self) ++ "\n"'`
 - Workspace roots: !`jj workspace list --ignore-working-copy --no-pager -T 'self.name() ++ ": " ++ self.root() ++ "\n"'`
+- Live Claude Code sessions on this machine (name, status, cwd): !`jq -r '[.name,.status,.cwd]|@tsv' ~/.claude/sessions/*.json 2>/dev/null`
 
 ## Your Task
 
@@ -17,9 +20,43 @@ Present the workspace list to the user in a clear summary. For each workspace, s
 - **Change ID**: The target change ID
 - **Description**: The change description (or "(no description)" if empty)
 - **Author**: Who created it
+- **Session**: See below
+
+### Session occupancy
+
+The sessions list covers **every project on this machine**, not just this one.
+Attribute a session to a workspace when its `cwd` is that workspace's root or a
+directory under it. That match is also the project filter — a session belonging
+to another repository matches no root here and is simply not shown.
+
+Do not match on the session name. Workspace directory names repeat across
+projects (the same adjective-verb-noun scheme), so names from a different
+repository look exactly like this one's and produce confident wrong answers.
+
+On macOS `/tmp` is a symlink to `/private/tmp`. Treat the two spellings of a path
+as the same location when matching.
+
+Report occupancy in three states, and never let two of them look alike:
+
+- **Occupied** — give the session name **verbatim in backticks, never
+  abbreviated or reformatted**. The trailing suffix (e.g. `-15`) is part of the
+  address. Say this is the name to use when messaging that session.
+- **Unoccupied** — no session matched. Flag it. An unoccupied workspace holding
+  a non-empty change is orphaned work nobody is watching, which is the most
+  useful thing this column surfaces.
+- **Unknown** — the sessions context line was empty or errored. Say occupancy
+  could not be determined. Do **not** report those workspaces as unoccupied.
+
+Close the summary with: this is a point-in-time read. A session that started
+after the command ran does not appear, so an unoccupied workspace means "no
+session was seen just now", never "safe to disturb".
+
+### Stale workspaces
 
 If a root shows an `<Error: Failed to resolve workspace root: ...>` entry, the
 recorded directory no longer exists (moved or deleted) — flag that workspace
-as stale and suggest `jj workspace forget <name>` (or `/clean_stale`).
+as stale and suggest `jj workspace forget <name>` (or `/clean_stale`). A stale
+workspace has no resolvable root, so it will also show as unoccupied; that is
+correct, since nothing can run in a directory that is gone.
 
 If there are multiple workspaces, note which ones may be stale (no recent description or activity).


### PR DESCRIPTION
Two related changes to what a session can see about its own project.

## 1. `escape_for_json` dropped the whole briefing on a control character

`escape_for_json` escaped only `\`, `"`, `\n`, `\r` and `\t`, and passed every
other C0 control through raw. JSON forbids all of U+0000–U+001F unescaped.

The briefing is a **single JSON object**, so this was not a corrupted line — the
payload failed to parse and the session started with **no briefing at all**: no
stack, no conflicts, no workspaces, no identity. Nothing reported an error.

Reproduced against the shipped function:

| description contains | result |
|---|---|
| `"` `\` tab newline emoji | valid |
| ESC `0x1B` (ANSI) | **parse failure** |
| FF `0x0C`, VT `0x0B`, BEL `0x07` | **parse failure** |

`jj-session-start.sh:50` already interpolates `description.first_line()`, so one
paste of colorized terminal output into a `jj describe` was enough to trigger it.

The escape is now byte-wise under `local LC_ALL=C`, which makes `${#s}`,
`${s:i:1}` and the `[ - ]` range byte-based rather than locale-collated.
Multi-byte UTF-8 survives as a run of bytes each ≥ `0x80`, passed through
untouched. A fast path skips the loop when nothing below `0x20` remains, which is
the overwhelmingly common case.

Two tests: the payload stays parseable with ESC/VT/BEL present, and an emoji
round-trips. The second matters because a byte-wise fix breaks UTF-8 *silently* —
no parse failure would catch it.

## 2. `/workspace-list` shows session occupancy

Adds one `jq` context line reading the Claude Code session registry, and
instructions to correlate each session's `cwd` against this repo's workspace
roots.

That match doubles as the project filter: the registry lists every session on the
machine, and one belonging to another repository matches no root here.

**Occupancy is not matched on session name.** Workspace directory names repeat
across projects — the same adjective-verb-noun scheme — so a name-based guess
returns confident wrong answers. Measured while developing this: three sessions
whose names were indistinguishable from this project's workspaces belonged to a
different repo entirely.

Three states that must never look alike:

- **occupied** — name reproduced verbatim, since it is the `SendMessage` address
- **unoccupied** — no session matched
- **unknown** — the registry could not be read

An unoccupied workspace holding a non-empty change is orphaned work nobody is
watching, which is the most useful thing the column surfaces. The command states
explicitly that this is a point-in-time read: unoccupied means *no session was
seen just now*, never *safe to disturb*.

Also adds the **CRITICAL jj warning block** — `workspace-list.md` was the only
one of 24 command/agent/skill files missing it, and it now runs a shell command.

## Testing

```
test-jj-session-start.sh        20 passed, 0 failed
test-project-setup-install.sh   89 passed, 0 failed
test-script-copy-parity.sh       2 passed, 0 failed
test-skill-paths.sh              3 passed, 0 failed
```

The new C0 test fails against the old function and passes against the new one.

## Known limitation

`/workspace-list` could **not** be verified end to end. The plugin installs from
the marketplace at a pinned commit, so invoking the command in a dev session
loads the previously installed definition rather than the working copy. Verified
instead by running the three context commands directly and performing the join by
hand against live data — correct workspaces matched, six sessions from other
repositories correctly excluded.

The **unoccupied** path has also not been exercised against a real workspace;
every workspace had a live session at the time of testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
