### PR TITLE
fix: description() revsets matched nothing; kaisen's divergence recipe errored on jj 0.44

### DIFF
--- a/.github/tests/test-description-revset-pattern.sh
+++ b/.github/tests/test-description-revset-pattern.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# No shipped revset may use the bare `description("…")` form — it matches nothing.
+#
+# jj string patterns default to an EXACT match, and jj stores every description
+# with a trailing newline. So a bare pattern cannot match a real description
+# even when the text is copied perfectly:
+#
+#     stored description, JSON-quoted:   "side A\n"
+#     description("side A")           →  (empty)
+#     description("side A\n")         →  1c1806b7458b
+#     description(substring:"side A") →  1c1806b7458b
+#
+# Measured on jj 0.44.0. The failure is SILENT — an empty result set, not an
+# error — which is what makes it worth a lint. Four call sites shipped the bare
+# form, and in each one "no rows" is indistinguishable from a real answer:
+#
+#   kaisen SKILL.md      recovering a crashed subagent's change → "never created
+#                        a change" → a recoverable task is filed BLOCKED
+#   peer-review SKILL.md + peer-review.md, resumability detection → "no review
+#                        state exists" → the review restarts from scratch
+#
+# This lives in .github/tests/ rather than under a plugin because the bug spans
+# workspace-jj and peer-review-jj, and the behaviour it pins belongs to jj.
+#
+# Mechanism, two halves:
+#   1. measure jj itself in a throwaway repo, so the reason for the rule is
+#      re-verified on every run rather than trusted from this comment
+#   2. grep the shipped prose for the bare form in an executable position
+#
+# Half 1 failing means jj changed, and the prose that calls `substring:`
+# "load-bearing" is now wrong — that is a prose fix, not a lint bug.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+command -v jj >/dev/null 2>&1 || { echo "FAIL - jj is not installed; this lint cannot verify anything"; exit 1; }
+
+# --- Half 1: measure jj -------------------------------------------------------
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+(
+  cd "$TMP" || exit 1
+  jj git init >/dev/null 2>&1
+  jj describe -m "lint probe description" >/dev/null 2>&1
+) || { echo "FAIL - could not create probe repo"; exit 1; }
+
+bare=$(cd "$TMP" && jj log --no-graph --ignore-working-copy \
+  -r 'description("lint probe description")' -T 'commit_id.short() ++ "\n"' 2>/dev/null)
+sub=$(cd "$TMP" && jj log --no-graph --ignore-working-copy \
+  -r 'description(substring:"lint probe description")' -T 'commit_id.short() ++ "\n"' 2>/dev/null)
+
+if [ -z "$bare" ]; then
+  ok "bare description(\"…\") matches nothing (exact match vs. trailing newline)"
+else
+  bad "bare description(\"…\") now MATCHES — jj changed; the 'substring: is load-bearing' prose in kaisen/peer-review is stale and must be re-read"
+fi
+
+if [ -n "$sub" ]; then
+  ok "description(substring:\"…\") matches"
+else
+  bad "description(substring:\"…\") matches nothing — the fix these lints guard no longer works"
+fi
+
+# --- Half 2: lint the shipped prose -------------------------------------------
+
+# Only the executable position (`-r 'description("`) is flagged. Prose that
+# NAMES the broken form while explaining the rule is legitimate and must stay
+# greppable, so a bare mention in backticks is not a hit.
+hits=$(grep -rn -- "-r 'description(\"" "$REPO_ROOT/plugins" 2>/dev/null)
+if [ -z "$hits" ]; then
+  ok "no plugin ships a bare description(\"…\") revset"
+else
+  bad "bare description(\"…\") revset shipped — it silently matches nothing:"
+  printf '%s\n' "$hits" | sed 's/^/       /'
+fi
+
+# Floor: the known call sites must still be using the fixed form. Zero hits
+# would otherwise let the lint above pass by finding nothing at all.
+fixed=$(grep -rc -- "-r 'description(substring:" "$REPO_ROOT"/plugins/*/skills/*/SKILL.md \
+  "$REPO_ROOT"/plugins/*/commands/*.md 2>/dev/null | awk -F: '{ n += $2 } END { print n+0 }')
+if [ "$fixed" -ge 4 ]; then
+  ok "fixed form still present at $fixed call sites (floor 4)"
+else
+  bad "only $fixed description(substring:…) call sites found, expected at least 4 — did they move, or regress?"
+fi
+
+echo "---"
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests — requires project-setup-jj",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/commands/absorb.md
+++ b/plugins/commit-commands-jj/commands/absorb.md
@@ -27,7 +27,9 @@ changes in one sitting."
 
 1. If the current change has no diff, report "nothing to absorb" and stop
 2. Run `jj absorb` (optionally `jj absorb <paths>` if the user scoped it, or
-   `--into <revset>` to restrict target changes)
+   `--into <revset>` to restrict target changes). Never pass `-i`/
+   `--interactive` or `--tool` — jj 0.44 added them, and both open a TUI that
+   hangs a non-interactive session. Scope with paths or `--into` instead.
 3. Report which changes absorbed what, from the command's output
 4. If edits remain in `@` afterward, report them — lines that no single
    ancestor last touched are left behind by design; suggest `/squash` or a

--- a/plugins/peer-review-jj/.claude-plugin/plugin.json
+++ b/plugins/peer-review-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "peer-review-jj",
   "description": "Unified change review for jj repos — generalist-first with emergent specialists, two-phase pipeline, structured findings",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/peer-review-jj/commands/peer-review.md
+++ b/plugins/peer-review-jj/commands/peer-review.md
@@ -70,8 +70,11 @@ jj log -r <rev> --no-graph -T 'self.diff().stat().files().map(|entry| "{ \"path\
 Check for existing review state first:
 
 ```bash
-jj log -r 'description("review: <change-id>")' --no-graph -T 'self.change_id().short(8)'
+jj log -r 'description(substring:"review: <change-id>")' --no-graph -T 'self.change_id().short(8)'
 ```
+
+`substring:` is required: a bare `description("…")` matches exactly, and jj
+stores descriptions with a trailing newline, so it silently returns nothing.
 
 If found, resume from existing state — only dispatch for unreviewed files. Skip setup below.
 

--- a/plugins/peer-review-jj/skills/requesting-change-review/SKILL.md
+++ b/plugins/peer-review-jj/skills/requesting-change-review/SKILL.md
@@ -87,8 +87,14 @@ non-`@` path.
 Check for existing review state first:
 
 ```bash
-jj log -r 'description("review: <change-id>")' --no-graph -T 'self.change_id().short(8)'
+jj log -r 'description(substring:"review: <change-id>")' --no-graph -T 'self.change_id().short(8)'
 ```
+
+`substring:` is load-bearing. A bare `description("…")` is an **exact** match,
+and jj stores descriptions with a trailing newline — so the bare form matches
+nothing even when the text is right, and returns empty rather than erroring.
+Empty reads as "no review state exists", so the review restarts instead of
+resuming.
 
 If found, check which files are already squashed (reviewed) by comparing `jj diff --stat` on the working copy. Only dispatch generalists for files still in the working copy. Skip setup below.
 

--- a/plugins/workspace-jj/.claude-plugin/plugin.json
+++ b/plugins/workspace-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workspace-jj",
   "description": "Wave-based parallel orchestration with spec review gates for jj (Jujutsu) repositories",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/workspace-jj/skills/kaisen/SKILL.md
+++ b/plugins/workspace-jj/skills/kaisen/SKILL.md
@@ -188,7 +188,7 @@ fresh. On resume:
 - Tasks marked `done`/`review-passed` but not `squashed` — their change IDs
   are in the ledger; resume at REVIEW or FAN IN using those IDs
 - Tasks marked `dispatched` with no later line — the agent died mid-flight;
-  check `jj log -r 'description("Task N:")'` and the workspace before
+  check `jj log -r 'description(substring:"Task N:")'` and the workspace before
   re-dispatching
 - Trust the ledger and `jj log` over your own recollection
 
@@ -424,9 +424,11 @@ Agent tool:
 
     CRITICAL: Use only non-interactive jj forms — interactive commands hang
     you. Always pass -m to describe/commit/squash. Never run bare
-    `jj describe`, `jj resolve`, `jj diffedit`, `jj split` without paths, or
-    any command that opens an editor or TUI. To resolve a conflict, edit the
-    conflict markers in the file, then verify with `jj resolve --list`.
+    `jj describe`, `jj resolve`, `jj diffedit`, `jj split` without paths,
+    `jj absorb -i` or `jj absorb --tool`, `jj arrange` (interactive-only —
+    it has no batch form), or any command that opens an editor or TUI. To
+    resolve a conflict, edit the conflict markers in the file, then verify
+    with `jj resolve --list`.
 
     ## Self-Review Before Reporting
 
@@ -575,8 +577,14 @@ Compare against the change ID the agent reported.
 If a subagent crashes or times out before reporting its change ID, the change still exists in jj's DAG — it's just not referenced. Recover it by searching for the task description:
 
 ```bash
-jj log -r 'description("Task N: <short description>")' --no-graph -T 'change_id'
+jj log -r 'description(substring:"Task N: <short description>")' --no-graph -T 'change_id'
 ```
+
+`substring:` is load-bearing, not stylistic. A bare `description("…")` is an
+**exact** match and jj stores descriptions with a trailing newline, so the bare
+form matches nothing even when the text is copied correctly. It returns empty
+rather than erroring — which reads as "the subagent never created a change" and
+sends a recoverable task to BLOCKED.
 
 If multiple matches, use the most recent. If no matches, the subagent likely never created any changes — treat as BLOCKED.
 
@@ -598,9 +606,21 @@ change that a live task workspace still holds as its `@` (e.g. the
 orchestrator running `jj edit`/`jj squash` on a task's change before that
 workspace is forgotten, or two fix subagents amending the same change).
 
-- Detect: `jj log -r '<change-id>'` shows both commits when divergent
-- Fix: inspect both sides, then `jj abandon <unwanted-COMMIT-id>` (commit
-  ID, not change ID — the change ID is ambiguous while divergent)
+- Detect: `jj log -r 'change_id(<change-id>)'` lists both commits. A **bare**
+  `jj log -r '<change-id>'` does not — it fails with `Error: Change ID <id> is
+  divergent`, because the ID no longer resolves to one revision. jj's own hint
+  names the selectors: `change_id(<id>)` for both sides, `<id>/0` and `<id>/1`
+  for one side each.
+- Fix, non-destructive — **prefer this when both sides are agents' work**:
+  `jj metaedit --update-change-id -r <COMMIT-id>` gives that side a fresh
+  change ID. Both commits survive, each addressable by an unambiguous change
+  ID, and the divergence is gone. Descendants of the edited side are rebased
+  onto it, so nothing is stranded.
+- Fix, destructive — only when one side is genuinely unwanted: inspect both,
+  then `jj abandon <unwanted-COMMIT-id>` (commit ID, not change ID — the
+  change ID is ambiguous while divergent). This discards that side's work;
+  in kaisen the two sides are usually two subagents' output, so reach for
+  `metaedit` first and abandon only after reading both.
 - Prevent: never rewrite a task's change while its workspace is still
   registered; fix subagents work only in their own task's workspace
 


### PR DESCRIPTION
Two defects found by exercising jj 0.44.0 against what the plugins actually
ship, plus one footgun list that went stale when 0.44 added an interactive mode.

## 1. `description("…")` revsets matched nothing (4 call sites)

jj string patterns default to an **exact** match, and jj stores every
description with a trailing newline. Measured on 0.44.0:

```
stored description, JSON-quoted:   "side A\n"
description("side A")           →  (empty)
description("side A\n")         →  1c1806b7458b
description(substring:"side A") →  1c1806b7458b
```

So the bare form could never match, no matter how correct the text — and it
fails **silently**, returning an empty set rather than an error:

| call site | what empty meant |
|---|---|
| `kaisen/SKILL.md:191`, `:578` | "the subagent never created a change" → a recoverable task filed BLOCKED |
| `requesting-change-review/SKILL.md:90` | "no review state exists" → a finished review restarts |
| `peer-review.md:73` | same |

Fixed with `substring:` at all four, each with a sentence on why the prefix is
load-bearing rather than stylistic.

**Guard:** `.github/tests/test-description-revset-pattern.sh` — repo-level
because the bug spans two plugins and the behaviour belongs to jj. Two halves:
it re-measures jj in a throwaway repo every run (so the reason is re-verified,
not trusted from a comment), then greps shipped prose for the bare form *in
executable position* (`-r 'description("`), leaving prose that names the broken
form while explaining the rule legal. Mutation-tested: reverting one call site
fails two of four assertions. If jj ever restores substring-by-default, half 1
fails and says the "load-bearing" wording is now stale — the correct outcome.

## 2. kaisen's divergent-change recipe errored on 0.44

`SKILL.md:601` prescribed `jj log -r '<change-id>'` to "show both commits". It
doesn't — a divergent ID no longer resolves to one revision:

```
Error: Change ID wrtrrswnlptq is divergent
Hint: Use change offset to select single revision: wrtrrswnlptq/0, wrtrrswnlptq/1
Hint: Use `change_id(wrtrrswnlptq)` to select all revisions
```

Detection is now `change_id(<id>)`, with the offset selectors named.

The next line prescribed `jj abandon <commit-id>` as *the* fix. In kaisen the
two sides of a divergence are usually two subagents' work, so the recipe told
the orchestrator to throw one away. Added `jj metaedit --update-change-id` as
the non-destructive option and ordered it first — measured:

```
$ jj metaedit --update-change-id -r 67a9e8f8a83d
Modified 1 commits:
  rmzrqsxl 1c1806b7 side A
Rebased 1 descendant commits.
```

Both sides survive with unambiguous change IDs; descendants follow the edited
side. `abandon` stays, marked destructive and second.

## 3. Two interactive footguns

jj 0.44 added `jj absorb -i`/`--tool`, and `jj arrange` is interactive-only
with no batch form. Both hang a non-interactive session. Added to the kaisen
dispatch prompt's CRITICAL block and to `/absorb`, where an agent actually
reads about the command.

## Test plan

- 22/22 suites pass locally on jj 0.44.0 (the CI glob, run the same way)
- new lint mutation-tested in both directions
- version bumps: commit-commands-jj 0.18.0→0.18.1, peer-review-jj 0.6.1→0.6.2,
  workspace-jj 0.1.5→0.1.6 (`require-version-bump.yml`; the plugin cache is
  keyed by version string)

Found while auditing the 0.43 and 0.44 release notes against what the plugins
ship — the reporting-only findings from that pass are #156–#161.
