### PR TITLE
fix: pin the workspace-list template at every call site; relabel a dead revset fixture

### DIFF
--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
   "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests — requires project-setup-jj",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/commands/clean_stale.md
+++ b/plugins/commit-commands-jj/commands/clean_stale.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(jj bookmark list:*), Bash(jj workspace:*), Bash(jj git fetch
 ## Context
 
 - Bookmarks **before** the fetch (JSON): !`jj bookmark list --all -T 'json(self) ++ "\n"'`
-- Current workspaces: !`jj workspace list`
+- Current workspaces (`STALE` = directory gone): !`jj workspace list --ignore-working-copy --no-pager -T 'if(self.root(), "live  ", "STALE ") ++ self.name() ++ "\t" ++ self.root() ++ "\n"'`
 
 ## Your Task
 
@@ -50,17 +50,30 @@ you to find anything.**
    *last*: while it exists, the fetch is inert and the work can be verified
    before anything is dropped.
 
-2. **List workspaces to find stale ones**
+2. **List workspaces, with staleness answered rather than guessed**
    ```bash
-   jj workspace list
+   jj workspace list --no-pager \
+     -T 'if(self.root(), "live  ", "STALE ") ++ self.name() ++ "\t" ++ self.root() ++ "\n"'
    ```
 
    This half is real work. A workspace whose directory has been deleted stays
    registered indefinitely — no ordinary jj command clears it, and nothing in
    step 1 touches it.
 
+   **A missing root IS the staleness signal.** `self.root()` returns an
+   `Option`, and for a workspace whose directory is gone it renders as empty
+   rather than erroring — measured on jj 0.44.0, exit 0 with the name still
+   listed. So the template above answers the question outright: every `STALE`
+   row is a candidate for step 3, and no eyeballing of paths is involved.
+
+   Pin the template rather than reading the default output. jj 0.44 changed
+   what `jj workspace list` prints by default (roots were added), and this
+   command's correctness depends on that field being present — a dependency
+   worth stating in the command instead of inheriting from a default that has
+   already moved once.
+
 3. **Forget stale workspaces**
-   For each stale workspace found in step 2 (other than the default workspace):
+   For each `STALE` row from step 2 (other than the default workspace):
    ```bash
    jj workspace forget <workspace-name>
    ```

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/scripts/jj-session-start.sh
+++ b/plugins/project-setup-jj/scripts/jj-session-start.sh
@@ -70,7 +70,18 @@ fi
 # @ and `jj root` are workspace-relative: which workspace this session is
 # attached to determines what @ even means, and a second live workspace means
 # another agent may be editing concurrently.
-workspaces=$(jj --ignore-working-copy workspace list 2>/dev/null || echo "(unable to read workspaces)")
+#
+# The template is PINNED, and that is the point of it. jj 0.44 added workspace
+# roots to this command's default output, so every briefing silently grew a
+# line of reader-relative path noise per workspace at a dependency bump, with
+# all suites green. Nothing here parses the output, but it is read by a model
+# at the top of every session in every workspace — the most-executed prose the
+# plugins ship — so its shape is ours to choose, not jj's to change under us.
+# What the briefing actually needs is the concurrency signal: who else is live,
+# on which change, and whether that change is empty (nobody mid-work) or not.
+workspaces=$(jj --ignore-working-copy workspace list --no-pager \
+  -T 'self.name() ++ ": " ++ self.target().change_id().shortest(8) ++ if(self.target().empty(), " (empty)", "") ++ " " ++ if(self.target().description(), self.target().description().first_line(), "(no description set)") ++ "\n"' \
+  2>/dev/null || echo "(unable to read workspaces)")
 
 identity=$(jj --ignore-working-copy config list user.email -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read user.email)")
 

--- a/plugins/project-setup-jj/tests/test-block-raw-git.sh
+++ b/plugins/project-setup-jj/tests/test-block-raw-git.sh
@@ -218,11 +218,21 @@ assert_passthrough "non-git command"        "ls -la"               "$JJ_DIR"
 # Every case below was measured ALLOWED against the pre-#105 hook and must
 # stay that way.
 echo "=== jj repo: #105 must-allow — parens and prefixes that are not git ==="
-# jj revset and template syntax is parenthesis-heavy, and `git_head()` puts the
-# literal string "git" directly before a paren.
+# jj revset and template syntax is parenthesis-heavy, and a function whose name
+# starts with "git" puts that literal string directly before a paren.
+#
+# SYNTHETIC INPUT, deliberately kept: `git_head()` was REMOVED from revsets and
+# templates in jj 0.43, along with `git_refs()`, and as of 0.44 no revset or
+# template function puts "git" before a paren — so nothing jj can parse
+# currently exercises this case. It is retained as defense-in-depth because the
+# hook gates every jj command an agent runs, and the cost of a future
+# `git_something()` being denied is a wall that blocks correct work with an
+# authoritative-sounding message. Do NOT read this line as live jj syntax:
+# running it against 0.43+ is a parse error, not a revset.
 assert_passthrough "revset: trunk() range"  "jj log -r 'trunk()..@'"               "$JJ_DIR"
 assert_passthrough "revset: bare trunk()"   "jj diff --from trunk() --to @ --stat" "$JJ_DIR"
-assert_passthrough "revset: git_head()"     "jj log -r 'ancestors(git_head())'"    "$JJ_DIR"
+assert_passthrough "revset: git-prefixed function (synthetic; git_head() is gone since 0.43)" \
+                                            "jj log -r 'ancestors(git_head())'"    "$JJ_DIR"
 assert_passthrough "revset: grouped+funcs"  "jj log --ignore-working-copy -r '(trunk()..@) & ~empty()' --no-graph -T 'json(self)'" "$JJ_DIR"
 assert_passthrough "template: if() with strings" "jj log -r @ --no-graph -T 'if(empty, \"empty\", \"has-content\")'" "$JJ_DIR"
 # Substitution and grouping around a jj command — the exemption must stay

--- a/plugins/project-setup-jj/tests/test-jj-session-start.sh
+++ b/plugins/project-setup-jj/tests/test-jj-session-start.sh
@@ -103,6 +103,34 @@ case "$out" in
   *) bad "workspaces" "no workspace section in briefing" ;;
 esac
 
+# The workspace line's SHAPE is pinned, not just its presence. jj 0.44 added
+# roots to `jj workspace list`'s default output, and the briefing inherited a
+# line of reader-relative path noise per workspace at a dependency bump with
+# every suite still green. The hook now passes its own -T; these two assertions
+# are what make dropping that flag fail loudly instead of silently.
+ws_section=$(printf '%s\n' "$out" | awk '/^Workspaces:/{f=1;next} /^[[:space:]]*$/{f=0} f')
+if [ -z "$ws_section" ]; then
+  bad "workspace shape" "no workspace section — the assertions below would be vacuous"
+else
+  # A change ID, so the line still answers "who is on what".
+  if printf '%s' "$ws_section" | grep -qE '^default: [a-z]{8}'; then
+    ok "workspace line carries a short change id"
+  else
+    bad "workspace shape" "no 'default: <change-id>' line: $ws_section"
+  fi
+  # And no COMMIT id. Absence is the half a presence-only check cannot see, but
+  # it has to be an absence that can actually fail here: measured while writing
+  # this, dropping the -T in THIS scaffold renders the root as "." — cwd-
+  # relative — so a "contains no /" check passes against the very mutation it
+  # exists to catch. The default output's commit id (`wknulskk 1b97fdef`) is the
+  # field that is unambiguously present without -T and absent with it.
+  if printf '%s' "$ws_section" | grep -qE '[0-9a-f]{8,}'; then
+    bad "workspace shape" "a commit id leaked into the workspace line — is the -T template still passed? $ws_section"
+  else
+    ok "workspace line carries no commit id (template still pinned)"
+  fi
+fi
+
 # Scope every stack assertion to the stack SECTION, for the reason the identity
 # check had to learn: @'s own `json(self)` block sits directly above and already
 # contains the description, so an unscoped grep passes even against a hook that


### PR DESCRIPTION
Closes #157. Closes #160.

## #157 — pin the workspace-list template at every call site

jj 0.44 added workspace roots to `jj workspace list`'s default output. Nothing
broke; the **shape** of a command three plugins call changed underneath them at
a dependency bump, with all 22 suites green. Version bumps are the ingress path
this repo has no test for.

**Session briefing** (`jj-session-start.sh:73`) — the one payload every session
in every workspace reads, and it silently grew a line of reader-relative path
noise per workspace:

```
default: ../../../../../Users/muloka/projects/sonder-hale/tools/claude-plugins uyrkymnq 2f2d1a36 (empty) (no description set)
```

It now passes its own `-T` carrying what the surrounding comment says the
section is *for* — the concurrency signal: who is live, on which change, and
whether that change is empty (nobody mid-work).

```
default: uyrkymnq (empty) (no description set)
```

Two assertions in `test-jj-session-start.sh` pin the shape in both directions:
a change id must be present, a commit id must be absent. Mutation-tested —
dropping the `-T` fails both.

**The absence half took two tries, which is the interesting part.** The obvious
check — "the workspace line contains no `/`" — *passes* against the very
mutation it exists to catch, because in that scaffold the workspace root
renders as `.` rather than an absolute path. The commit id is the field
unambiguously present without `-T` and absent with it. The test comment records
this, since `no /` is what anyone would reach for next.

**`/clean_stale` got more than a pin.** Measured on 0.44: for a workspace whose
directory is gone, `self.root()` renders **empty** rather than erroring — exit
0, name still listed. So a missing root *is* the staleness signal, and step 2
answers the question outright instead of asking the model to eyeball a list:

```bash
jj workspace list --no-pager \
  -T 'if(self.root(), "live  ", "STALE ") ++ self.name() ++ "\t" ++ self.root() ++ "\n"'
```

```
live  default	/Users/muloka/projects/sonder-hale/tools/claude-plugins
STALE side
```

The command's own prose called that half "real work"; it is a query now, and
step 3 consumes `STALE` rows directly.

`workspace-list.md` needed no change — both its calls were already templated,
so the issue's "redundant second call" note dissolves once pinning is the rule
rather than the default being trusted.

## #160 — the `git_head()` fixture: kept, relabelled

`test-block-raw-git.sh` asserts the raw-git wall lets
`jj log -r 'ancestors(git_head())'` through. jj 0.43 removed `git_head()` and
`git_refs()`, and the case can never go red — the hook is a string matcher that
never invokes jj — so it presented dead syntax as live.

Kept as defense-in-depth: this hook gates every jj command an agent runs, and a
future `git_something()` being denied would block correct work behind an
authoritative-sounding wall. But it is now explicitly marked synthetic, with
the 0.43 removal named and a "do not read this as live jj syntax" line, and the
case label says so too so it is visible in test output.

Both options were laid out in the issue; this is option 1, written down so the
next reader does not re-derive the question.

## Test plan

- 22/22 suites pass locally on jj 0.44.0
- the two new briefing assertions mutation-tested (drop the `-T` → both fail)
- version bumps: project-setup-jj 0.14.1→0.14.2, commit-commands-jj 0.18.1→0.18.2
