### PR TITLE
Smoke-test what the installers install; unblock the exclusion idioms; run CI on Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,21 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    # Both platforms, because the suites are the only thing that would ever
+    # notice a platform assumption, and for a year they ran on exactly one.
+    # #88 shipped a BSD-only `stat -f` into a script that is dead on GNU
+    # coreutils — copied, registered, announced, and never executed anywhere it
+    # was wrong. macOS-only CI could not have caught it, and did not.
+    #
+    # fail-fast: false is load-bearing here rather than stylistic. The entire
+    # value of this matrix is seeing WHICH platform broke; cancelling the other
+    # leg on the first failure throws away exactly the comparison that makes a
+    # portability failure legible.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     # macOS runners bill at a 10x multiplier and the job default is 6 hours.
     # A hung suite should cost minutes, not a day's budget.
     timeout-minutes: 15
@@ -20,8 +34,37 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install jj
+      - name: Install jj (macOS)
+        if: runner.os == 'macOS'
         run: brew install jj
+
+      # Not `cargo install jj-cli`: that is a multi-minute compile on every run
+      # of a job whose own work takes seconds. Not `brew` on Linux either — it
+      # bootstraps a second package manager to install one static binary.
+      #
+      # The release is resolved at run time rather than pinned. A pin here would
+      # be a THIRD place the jj version is asserted (the other two being the
+      # developer's machine and whatever the suites assume), and #141 is open
+      # precisely because those assertions drift apart unnoticed. Tracking the
+      # latest release means a jj change that breaks the plugins turns this leg
+      # red, which is the signal we want and cannot get from a pin.
+      - name: Install jj (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          tag=$(curl -fsSL https://api.github.com/repos/jj-vcs/jj/releases/latest | jq -r .tag_name)
+          [ -n "$tag" ] && [ "$tag" != null ] || { echo "::error::could not resolve the latest jj release"; exit 1; }
+          echo "installing jj $tag"
+          url="https://github.com/jj-vcs/jj/releases/download/$tag/jj-$tag-x86_64-unknown-linux-musl.tar.gz"
+          # Extract the WHOLE archive rather than naming the binary as a member.
+          # The member is `./jj`, so `tar xz jj` fails with "Not found in
+          # archive" — measured, not assumed, and it would have failed on this
+          # leg's first run. Extracting everything depends on no naming
+          # convention the release is free to change.
+          dir=$(mktemp -d)
+          curl -fsSL "$url" | tar xz -C "$dir"
+          sudo install -m 0755 "$dir/jj" /usr/local/bin/jj
+          jj --version
 
       - name: Run all suites
         run: |

--- a/plugins/agent-helpers-jj/.claude-plugin/plugin.json
+++ b/plugins/agent-helpers-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-helpers-jj",
   "description": "Machine-level jj (Jujutsu) query shortcuts for agents — read-only helpers that bake in --ignore-working-copy so concurrent workspaces don't race",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/agent-helpers-jj/commands/agent-helpers-setup.md
+++ b/plugins/agent-helpers-jj/commands/agent-helpers-setup.md
@@ -29,8 +29,19 @@ The script is idempotent — re-running it will not create duplicates.
 
 ### Step 3: Report and remind
 
-Report what changed (the four targets above). Then, prominently:
+Report what changed (the four targets above), then the `smoke=` line the script
+prints last:
+
+- `smoke=pass:<shell>` — the installed file was sourced under that shell and all
+  four helpers came out defined. This is the only step that proves the install
+  works; everything before it proves only that text was written.
+- `smoke=fail:<detail>` — the file was written and `~/.zshrc` sources it, but the
+  helpers are not defined. Report the detail verbatim and do not present the
+  helpers as available.
+- `smoke=skip:...` — no shell was available to source with; unverified, say so.
+
+Then, prominently:
 
 > **Restart Claude Code (or start a new session) for the helpers to take effect.** They become callable only after the next session regenerates its shell snapshot; the permission allowlist also applies from the next session.
 
-Warn if any of the names `jjctx`, `jjstack`, `jjconflicts`, `jjcheckpoint`, or `_jjq` were already defined in the user's shell (the source line will shadow them). Remove with `/agent-helpers-remove`.
+Warn if any of the names `jjctx`, `jjstack`, `jjconflicts`, or `jjcheckpoint` were already defined in the user's shell (the source line will shadow them). Those four are the whole surface. There is no shared `_jjq` internal to warn about: Claude Code's shell-snapshot capture drops `_`-prefixed functions as zsh completion helpers, so each helper inlines its own query (see the header of `scripts/jj-agent-helpers.sh`). Do not warn about a name the file does not define. Remove with `/agent-helpers-remove`.

--- a/plugins/agent-helpers-jj/scripts/agent-helpers-install.sh
+++ b/plugins/agent-helpers-jj/scripts/agent-helpers-install.sh
@@ -81,6 +81,43 @@ cmd_install() {
   strip_fence "$CLAUDEMD" "$C_BEGIN" "$C_END"
   append_block "$CLAUDEMD" "$(cat "$TEMPLATE")"
   settings_add
+  smoke
+}
+
+# Prove the installed file actually defines the helpers, by sourcing the copy at
+# $HELPER_PATH — the same path ~/.zshrc will source, not $SRC.
+#
+# Sourcing is the whole mechanism here: the install writes a `source` line and
+# then tells the user to restart, so nothing between those two points would ever
+# notice a file that parses but defines nothing, or one whose helpers were
+# renamed out from under the catalog block in CLAUDE.md. That is the shape #88
+# had in the sibling plugin — installed, announced, never executed.
+#
+# zsh first, because zsh is what actually sources this file. bash is the
+# fallback so the check still runs where zsh is absent (CI images, containers).
+smoke() {
+  local shell_bin=""
+  if command -v zsh >/dev/null 2>&1; then shell_bin=zsh
+  elif command -v bash >/dev/null 2>&1; then shell_bin=bash
+  else echo "smoke=skip:no zsh or bash to source with"; return 0
+  fi
+
+  if [ ! -r "$HELPER_PATH" ]; then
+    echo "smoke=fail:not readable: $HELPER_PATH"; return 0
+  fi
+
+  local missing=""
+  for fn in jjctx jjstack jjconflicts jjcheckpoint; do
+    if ! "$shell_bin" -c ". '$HELPER_PATH' >/dev/null 2>&1; command -v $fn >/dev/null 2>&1"; then
+      missing="$missing $fn"
+    fi
+  done
+
+  if [ -n "$missing" ]; then
+    echo "smoke=fail:sourced under $shell_bin but undefined:$missing"
+  else
+    echo "smoke=pass:$shell_bin"
+  fi
 }
 
 cmd_remove() {

--- a/plugins/agent-helpers-jj/tests/test-agent-helpers-install.sh
+++ b/plugins/agent-helpers-jj/tests/test-agent-helpers-install.sh
@@ -56,6 +56,34 @@ HOME="$FAKE2" bash "$INSTALL" install
 grep -qxF '# >>> jj-agent-helpers (managed by agent-helpers-jj) >>>' "$FAKE2/.zshrc" && ok "install creates missing ~/.zshrc" || bad "missing/zshrc" "not created"
 [ "$(jq -r '.permissions.allow | index("Bash(jjctx:*)") != null' "$FAKE2/.claude/settings.json")" = true ] && ok "install creates missing settings.json with allow" || bad "missing/settings" "not created"
 
+# --- smoke: the install must SOURCE what it wrote ---
+# Everything above proves text landed in the right files. None of it proves the
+# helpers exist, and the install ends by telling the user to restart — so a file
+# that parses but defines nothing would be discovered by the user, not by us.
+
+FAKE3="$(mktemp -d)"
+OUT=$(HOME="$FAKE3" bash "$INSTALL" install)
+printf '%s' "$OUT" | grep -q '^smoke=pass:' \
+  && ok "smoke: real helper file sources and defines all four" || bad "smoke" "expected smoke=pass, got: $(printf '%s' "$OUT" | grep '^smoke=' || echo none)"
+
+# Overwrite the INSTALLED copy with a file that parses and defines nothing, then
+# re-run the smoke logic against it by re-installing from a plugin root whose
+# source is that same empty file.
+FAKE4="$(mktemp -d)"; STUBPLUG="$(mktemp -d)"
+mkdir -p "$STUBPLUG/scripts" "$STUBPLUG/templates"
+printf '# defines nothing at all\n' > "$STUBPLUG/scripts/jj-agent-helpers.sh"
+cp "$SCRIPT_DIR/../templates/jj-agent-helpers-claudemd.md" "$STUBPLUG/templates/"
+cp "$INSTALL" "$STUBPLUG/scripts/agent-helpers-install.sh"
+OUT=$(HOME="$FAKE4" bash "$STUBPLUG/scripts/agent-helpers-install.sh" install)
+printf '%s' "$OUT" | grep -q '^smoke=fail:.*jjctx' \
+  && ok "smoke: a file defining nothing reports fail" || bad "smoke" "expected smoke=fail naming jjctx, got: $(printf '%s' "$OUT" | grep '^smoke=' || echo none)"
+
+# A failing smoke is a report, not an abort — the files are already written.
+[ -f "$FAKE4/.config/jj-agent-helpers/jj-agent-helpers.sh" ] \
+  && ok "smoke: failure does not abort the install" || bad "smoke" "install aborted on smoke failure"
+
+rm -rf "$FAKE3" "$FAKE4" "$STUBPLUG"
+
 echo ""
 echo "$pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/plugins/peer-review-jj/.claude-plugin/plugin.json
+++ b/plugins/peer-review-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "peer-review-jj",
   "description": "Unified change review for jj repos — generalist-first with emergent specialists, two-phase pipeline, structured findings",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/peer-review-jj/scripts/block-raw-git.sh
+++ b/plugins/peer-review-jj/scripts/block-raw-git.sh
@@ -181,8 +181,34 @@ fi
 # `.github/`. Still quote-blind, so prose naming the directory is denied; that
 # is pinned as a known-open shape rather than fixed, because telling a path from
 # a quoted mention needs a shell parser.
+#
+# EXCLUSION idioms are stripped before the test, because they are the mirror
+# image of what this branch is for: `find . -path ./REPO -prune -o …` and
+# `grep -r --exclude-dir=REPO` (REPO being the directory named below) mention it
+# in order to STAY OUT of it. Denying those taught nothing and cost a rewrite
+# every time — the wall is a guardrail against habit, and reaching for the
+# directory in order to skip it is not the habit in question.
+#
+# This is a carve-out, not a general answer to the quote-blindness noted above.
+# The shapes below are FLAG-ANCHORED: each strips one option together with its
+# own argument, a fixed token sequence rather than a quoted region needing a
+# parser. Everything else behaves exactly as before, and crucially the strip
+# removes only the exclusion token itself — a command that both excludes the
+# directory and then reads a file inside it still denies, because the second
+# mention survives the strip. A carve-out that cleared every mention once one
+# was benign would be a hole, not a fix.
+#
+# `-prune` is required on the find form deliberately. `-path X -prune` skips the
+# directory; the same test without `-prune` is a SEARCH for it, which is exactly
+# what this branch exists to answer.
+internals_scan=$(printf '%s\n' "$command_normalized" | sed -E \
+  -e "s/--exclude(-dir)?=[${sq}${dq}]?[^[:space:]${sq}${dq}]*\.git[${sq}${dq}]?//g" \
+  -e "s/--exclude(-dir)?[[:space:]]+[${sq}${dq}]?[^[:space:]${sq}${dq}]*\.git[${sq}${dq}]?//g" \
+  -e "s/(!|-not)?[[:space:]]*-(path|wholename|name|iname|regex)[[:space:]]+[${sq}${dq}]?[^[:space:]${sq}${dq}]*\.git[^[:space:]${sq}${dq}]*[${sq}${dq}]?[[:space:]]+-prune//g" \
+  -e "s/(!|-not)[[:space:]]+-(path|wholename|name|iname|regex)[[:space:]]+[${sq}${dq}]?[^[:space:]${sq}${dq}]*\.git[^[:space:]${sq}${dq}]*[${sq}${dq}]?//g")
+
 has_git_internals=false
-if printf '%s\n' "$command_normalized" \
+if printf '%s\n' "$internals_scan" \
    | grep -qE '(^|[^A-Za-z0-9._-])\.git([^A-Za-z0-9_-]|$)'; then
   has_git_internals=true
 fi

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.14.3",
+  "version": "0.15.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/commands/project-setup.md
+++ b/plugins/project-setup-jj/commands/project-setup.md
@@ -54,6 +54,13 @@ Read the script's `key=value` summary and confirm to the user what was set up:
 - `.claude/settings.local.json` — jj/gh allow-list, and in `--local` mode the hooks too — value from `settings=`
 - Legacy `.claude/scripts/` — per the `legacy_scripts=` value: `removed` (migrated and the empty directory cleaned up), `kept_not_empty` (our files removed, directory kept because other files such as `statusline-jj.sh` remain), or `absent` (nothing to migrate)
 - CLAUDE.md — `created`, `updated`, or `already up to date` per the `claude_md=` value
+- Smoke test — value from `smoke=`. `pass` means the copied handlers parse, are
+  executable, and `jj-session-start.sh` actually ran and emitted valid JSON.
+  `fail:<reason>` means the install is written and registered but a handler does
+  not work — report the reason verbatim rather than the summary word, and do not
+  present the setup as ready. This key exists because #88 shipped a handler that
+  was copied, registered, announced, and dead, with every suite green: they
+  covered the installer, not the installed result.
 
 Then remind the user to:
 - **Restart Claude Code** for the hooks to take effect

--- a/plugins/project-setup-jj/commands/statusline-jj-setup.md
+++ b/plugins/project-setup-jj/commands/statusline-jj-setup.md
@@ -79,11 +79,34 @@ the install looks successful) while every workspace stays broken.
   mv .claude/settings.local.json.tmp .claude/settings.local.json
 ```
 
-### Step 6: Confirm to user
+### Step 6: Smoke-test the installed statusline
+
+**Required.** Every step above copies and configures; none of them has run the
+thing being installed. That gap is where #88 lived: the script was copied,
+registered, and announced while being dead on Linux — first render fine, every
+render after it exit 1 with zero output. A missing statusline reads as "not
+configured yet", so nobody connects it to the install that reported success.
+
+```bash
+bash <plugin-scripts-dir>/statusline-smoke.sh "$(jj root)/.claude/hooks/statusline-jj.sh"
+```
+
+It renders **twice** (the #88 crash only appears on the second render, once the
+first has populated the status cache) and checks the cache key is a numeric
+mtime pair (which catches the same bug where no network reaches the status API).
+
+- `statusline_smoke=pass` — say so, then continue to Step 7.
+- `statusline_smoke=fail:<reason>` — **do not tell the user to restart and expect
+  a statusline.** Report the reason verbatim; it names the failing render or the
+  malformed cache key. The install itself is intact — the files are written and
+  the config is correct — so the fix belongs in the script, not in a re-run.
+
+### Step 7: Confirm to user
 
 Show:
 - Statusline script copied to `.claude/hooks/statusline-jj.sh` (tracked — commit it, or workspaces will not see it)
 - `statusLine` config added to `.claude/settings.json`, and removed from `.claude/settings.local.json` if present
+- The smoke result from Step 6
 - **Restart Claude Code** for the statusline to appear
 
 The statusline shows: `[Model] bookmark-or-change-id description | N% ctx | $cost`

--- a/plugins/project-setup-jj/scripts/block-raw-git.sh
+++ b/plugins/project-setup-jj/scripts/block-raw-git.sh
@@ -181,8 +181,34 @@ fi
 # `.github/`. Still quote-blind, so prose naming the directory is denied; that
 # is pinned as a known-open shape rather than fixed, because telling a path from
 # a quoted mention needs a shell parser.
+#
+# EXCLUSION idioms are stripped before the test, because they are the mirror
+# image of what this branch is for: `find . -path ./REPO -prune -o …` and
+# `grep -r --exclude-dir=REPO` (REPO being the directory named below) mention it
+# in order to STAY OUT of it. Denying those taught nothing and cost a rewrite
+# every time — the wall is a guardrail against habit, and reaching for the
+# directory in order to skip it is not the habit in question.
+#
+# This is a carve-out, not a general answer to the quote-blindness noted above.
+# The shapes below are FLAG-ANCHORED: each strips one option together with its
+# own argument, a fixed token sequence rather than a quoted region needing a
+# parser. Everything else behaves exactly as before, and crucially the strip
+# removes only the exclusion token itself — a command that both excludes the
+# directory and then reads a file inside it still denies, because the second
+# mention survives the strip. A carve-out that cleared every mention once one
+# was benign would be a hole, not a fix.
+#
+# `-prune` is required on the find form deliberately. `-path X -prune` skips the
+# directory; the same test without `-prune` is a SEARCH for it, which is exactly
+# what this branch exists to answer.
+internals_scan=$(printf '%s\n' "$command_normalized" | sed -E \
+  -e "s/--exclude(-dir)?=[${sq}${dq}]?[^[:space:]${sq}${dq}]*\.git[${sq}${dq}]?//g" \
+  -e "s/--exclude(-dir)?[[:space:]]+[${sq}${dq}]?[^[:space:]${sq}${dq}]*\.git[${sq}${dq}]?//g" \
+  -e "s/(!|-not)?[[:space:]]*-(path|wholename|name|iname|regex)[[:space:]]+[${sq}${dq}]?[^[:space:]${sq}${dq}]*\.git[^[:space:]${sq}${dq}]*[${sq}${dq}]?[[:space:]]+-prune//g" \
+  -e "s/(!|-not)[[:space:]]+-(path|wholename|name|iname|regex)[[:space:]]+[${sq}${dq}]?[^[:space:]${sq}${dq}]*\.git[^[:space:]${sq}${dq}]*[${sq}${dq}]?//g")
+
 has_git_internals=false
-if printf '%s\n' "$command_normalized" \
+if printf '%s\n' "$internals_scan" \
    | grep -qE '(^|[^A-Za-z0-9._-])\.git([^A-Za-z0-9_-]|$)'; then
   has_git_internals=true
 fi

--- a/plugins/project-setup-jj/scripts/project-setup-install.sh
+++ b/plugins/project-setup-jj/scripts/project-setup-install.sh
@@ -373,4 +373,45 @@ else
 fi
 echo "claude_md=$claude_outcome"
 
+# --- 6. smoke: prove the copied handlers actually run ---
+#
+# The suites cover this INSTALLER thoroughly and covered the INSTALLED RESULT
+# not at all — the gap #88 lived in for a month, where a handler was copied,
+# registered, announced, and dead. An installer that reports success without
+# once executing what it installed is reporting that the copy succeeded, which
+# is not what the user asked.
+#
+# Deliberately NOT fatal: the files are already written and correctly
+# registered, and a failing smoke does not make them less written. It is a
+# summary key like every other, and the command prose relays it — exiting
+# non-zero here would collide with the contract that non-zero means NOTHING was
+# written (invalid JSON, excluded .gitignore).
+smoke_fail=""
+for s in $MANAGED_SCRIPTS; do
+  if ! bash -n "$DST/$s" 2>/dev/null; then smoke_fail="syntax error in $s"; break; fi
+  if [ ! -x "$DST/$s" ]; then smoke_fail="$s is not executable"; break; fi
+done
+
+# Only jj-session-start.sh is actually EXECUTED. It reads nothing from stdin and
+# mutates nothing, so running it is free. require-jj-new.sh expects a tool-call
+# payload and the workspace pair mutates workspaces — for those, syntax and the
+# exec bit is as far as a smoke test can honestly go.
+if [ -z "$smoke_fail" ]; then
+  smoke_out=$( (cd "$PROJECT_ROOT" && bash "$DST/jj-session-start.sh" </dev/null) 2>/dev/null ) \
+    || smoke_fail="jj-session-start.sh exited non-zero"
+  # Empty is legitimate: the handler exits silently outside a jj repo. Non-empty
+  # must parse — a briefing that is not valid JSON is dropped whole, and the
+  # session starts with no context at all rather than with a visible error.
+  if [ -z "$smoke_fail" ] && [ -n "$smoke_out" ]; then
+    printf '%s' "$smoke_out" | jq -e . >/dev/null 2>&1 \
+      || smoke_fail="jj-session-start.sh emitted invalid JSON"
+  fi
+fi
+
+if [ -n "$smoke_fail" ]; then
+  echo "smoke=fail:$smoke_fail"
+else
+  echo "smoke=pass"
+fi
+
 echo "restart_required=true"

--- a/plugins/project-setup-jj/scripts/statusline-smoke.sh
+++ b/plugins/project-setup-jj/scripts/statusline-smoke.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Prove an installed statusline actually renders. Run BY the install path, not
+# by the test suite alone.
+#
+# Why this exists (#88): /statusline-jj-setup copied a script, wrote config, and
+# told the user to restart — without ever executing the thing it installed. The
+# copy it installed was dead on Linux: `stat -f` is BSD-only, GNU prints a
+# filesystem report and exits 0 instead of failing, and the resulting blob
+# reached `$(( ))` where `set -u` aborted the script. 185 assertions covered the
+# INSTALLER; nothing covered the INSTALLED RESULT. The gap cost a feature that
+# silently never appeared — which reads as "not configured yet", not "crashed".
+#
+# Two renders, not one, because one render cannot see #88. The first render
+# populates /tmp/statusline-claude-summary; the crash needs that file to already
+# exist, so it lands on the SECOND render and every one after it. A smoke test
+# that rendered once would have passed over the exact bug it exists to catch.
+#
+# The cache-key check covers the other half of the same bug. Where curl cannot
+# reach the status API the arithmetic is never entered and both renders succeed
+# — while the key silently carries a filesystem report whose free-block counts
+# drift with disk usage, so the cache never validates (#63's pathology). Shape
+# is the tell: two numeric mtimes.
+#
+# Usage: statusline-smoke.sh <path-to-statusline-script>
+# Output: statusline_smoke=pass | statusline_smoke=fail:<reason>
+# Exit:   0 pass, 1 fail
+#
+# bash 3.2-safe (macOS): no globstar, no associative arrays.
+
+# NOT `set -e`: the whole point is to OBSERVE a failing render and report why,
+# rather than inherit its exit status and die with it.
+set -uo pipefail
+
+SL="${1:-}"
+
+fail() { printf 'statusline_smoke=fail:%s\n' "$1"; exit 1; }
+
+[ -n "$SL" ]   || fail "no statusline path given"
+[ -f "$SL" ]   || fail "not found: $SL"
+[ -r "$SL" ]   || fail "not readable: $SL"
+
+bash -n "$SL" 2>/dev/null || fail "syntax error in $SL"
+
+# A payload with the keys the script reads. context_window is what drives the
+# percent badge; the rest keep the jq lookups on their normal paths.
+PAYLOAD='{"model":{"display_name":"Smoke Test"},"context_window":{"used_percentage":7},"cost":{"total_cost_usd":0}}'
+
+CACHE_DIR=$(mktemp -d 2>/dev/null) || fail "cannot create a temp cache dir"
+trap 'rm -rf "$CACHE_DIR"' EXIT
+
+render() {
+  printf '%s' "$PAYLOAD" | STATUSLINE_JJ_CACHE_DIR="$CACHE_DIR" bash "$SL" 2>"$CACHE_DIR/err"
+}
+
+out1=$(render); code1=$?
+[ "$code1" -eq 0 ] || fail "first render exited $code1: $(head -1 "$CACHE_DIR/err" 2>/dev/null)"
+[ -n "$out1" ]     || fail "first render produced no output"
+
+out2=$(render); code2=$?
+[ "$code2" -eq 0 ] || fail "second render exited $code2: $(head -1 "$CACHE_DIR/err" 2>/dev/null)"
+[ -n "$out2" ]     || fail "second render produced no output"
+
+# The cache is only written inside a jj repo — outside one the script renders a
+# two-badge fallback and returns before the cache exists. Absent there is
+# correct, so only check the key where there is one to check.
+if jj root >/dev/null 2>&1; then
+  cache_file=$(find "$CACHE_DIR" -type f ! -name err 2>/dev/null | head -1)
+  [ -n "$cache_file" ] || fail "no cache file written inside a jj repo"
+  key=$(head -1 "$cache_file")
+  case "$key" in
+    *[!0-9.:]*|*:*:*|"") fail "cache key is not a numeric mtime pair: $(printf '%s' "$key" | cut -c1-60)" ;;
+    *:*)                 : ;;
+    *)                   fail "cache key is not a numeric mtime pair: $(printf '%s' "$key" | cut -c1-60)" ;;
+  esac
+fi
+
+printf 'statusline_smoke=pass\n'

--- a/plugins/project-setup-jj/tests/test-block-raw-git.sh
+++ b/plugins/project-setup-jj/tests/test-block-raw-git.sh
@@ -490,6 +490,41 @@ assert_passthrough "relative cwd terminates, passes through" "git status" "some/
 assert_passthrough "bare-dot cwd terminates, passes through" "git status" "."
 cd "$_orig_pwd"
 
+# ---- exclusion idioms: naming the directory in order to SKIP it ----
+# The internals branch is quote-blind by design, but it was also intent-blind in
+# one direction that cost real work: the canonical ways to EXCLUDE the git
+# directory from a search all mention it, so all of them were denied. Each of
+# these is the mirror image of access — the token exists so the tool stays out.
+
+assert_passthrough "find -path … -prune excludes rather than reads" \
+  'find . -path ./.git -prune -o -name "*.md" -print' "$JJ_DIR"
+assert_passthrough "find -path with a glob and -prune" \
+  "find . -path '*/.git' -prune -o -type f -print" "$JJ_DIR"
+assert_passthrough "find -name … -prune" \
+  'find . -name .git -prune -o -name "*.sh" -print' "$JJ_DIR"
+assert_passthrough "grep --exclude-dir=" \
+  'grep -rn "TODO" --exclude-dir=.git .' "$JJ_DIR"
+assert_passthrough "grep --exclude-dir with quotes" \
+  "grep -rn TODO --exclude-dir='.git' ." "$JJ_DIR"
+assert_passthrough "rsync/tar-style --exclude=" \
+  'tar czf out.tgz --exclude=.git .' "$JJ_DIR"
+assert_passthrough "negated -path, no -prune (a filter, still an exclusion)" \
+  "find . -not -path '*/.git/*' -name '*.sh'" "$JJ_DIR"
+assert_passthrough "bang-negated -path" \
+  "find . ! -path './.git/*' -type f" "$JJ_DIR"
+
+# The carve-out must not become a passphrase. An exclusion token neutralises
+# ITSELF and nothing else: a second mention that reads the directory still
+# denies, and a bare -name without -prune is a SEARCH for it, not a skip.
+assert_blocked "exclusion token does not launder a real read in the same command" \
+  'grep -rn x --exclude-dir=.git . && cat .git/config' "$JJ_DIR"
+assert_blocked "exclusion flag followed by a direct read" \
+  'find . -path ./.git -prune -o -name "*.md" -print; ls .git/refs' "$JJ_DIR"
+assert_blocked "-name without -prune is a search for the directory" \
+  'find . -name .git -type d' "$JJ_DIR"
+assert_blocked "plain read still denied with no exclusion present" \
+  'cat .git/HEAD' "$JJ_DIR"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ "$fail" -gt 0 ]; then

--- a/plugins/project-setup-jj/tests/test-project-setup-install.sh
+++ b/plugins/project-setup-jj/tests/test-project-setup-install.sh
@@ -382,6 +382,73 @@ P=$(mktemp -d); printf 'node_modules/\n*.log\n' > "$P/.gitignore"
 bash "$INSTALL" "$PLUG" "$P" >/dev/null 2>&1
 [ -f "$P/.claude/settings.json" ] && ok "gitignore: unrelated rules do not trip the guard" || bad "gitignore" "false positive on unrelated rules"
 
+# ---- smoke=: the installer must EXECUTE what it installed ----
+# #88 shipped a handler that was copied, registered, announced and dead, with
+# every suite green — because the suites covered this installer and nothing
+# covered the installed result. These cases pin the key that closes that gap.
+
+P=$(newproj)
+OUT=$(bash "$INSTALL" $INSTALL_MODE "$PLUG" "$P")
+printf '%s' "$OUT" | grep -q '^smoke=pass$' \
+  && ok "smoke: healthy handlers report pass" || bad "smoke" "expected smoke=pass, got: $(printf '%s' "$OUT" | grep '^smoke=' || echo none)"
+
+# A handler that does not parse. `bash -n` is the cheapest possible check and it
+# is the one the install path never ran.
+BROKEN="$(mktemp -d)"; mkdir -p "$BROKEN/scripts" "$BROKEN/templates"
+cp "$PLUG"/scripts/*.sh "$BROKEN/scripts/"
+cp "$PLUG"/templates/CLAUDE.md.template "$BROKEN/templates/"
+printf '#!/usr/bin/env bash
+if then fi
+' > "$BROKEN/scripts/jj-session-start.sh"
+P=$(newproj)
+OUT=$(bash "$INSTALL" $INSTALL_MODE "$BROKEN" "$P")
+printf '%s' "$OUT" | grep -q '^smoke=fail:syntax error in jj-session-start.sh$' \
+  && ok "smoke: unparseable handler reports fail" || bad "smoke" "expected syntax fail, got: $(printf '%s' "$OUT" | grep '^smoke=' || echo none)"
+
+# A handler that runs but exits non-zero.
+printf '#!/usr/bin/env bash
+exit 3
+' > "$BROKEN/scripts/jj-session-start.sh"
+P=$(newproj)
+OUT=$(bash "$INSTALL" $INSTALL_MODE "$BROKEN" "$P")
+printf '%s' "$OUT" | grep -q '^smoke=fail:jj-session-start.sh exited non-zero$' \
+  && ok "smoke: non-zero handler reports fail" || bad "smoke" "expected exit fail, got: $(printf '%s' "$OUT" | grep '^smoke=' || echo none)"
+
+# A handler that succeeds and emits garbage. This is the mode that matters most:
+# the briefing is ONE JSON object, so a single bad byte does not corrupt a line,
+# it drops the whole payload and the session starts with no context at all.
+printf '#!/usr/bin/env bash
+printf "not json at all\\n"
+' > "$BROKEN/scripts/jj-session-start.sh"
+P=$(newproj)
+OUT=$(bash "$INSTALL" $INSTALL_MODE "$BROKEN" "$P")
+printf '%s' "$OUT" | grep -q '^smoke=fail:jj-session-start.sh emitted invalid JSON$' \
+  && ok "smoke: invalid-JSON handler reports fail" || bad "smoke" "expected JSON fail, got: $(printf '%s' "$OUT" | grep '^smoke=' || echo none)"
+
+# Silence is legitimate — the real handler exits 0 with no output outside a jj
+# repo, and that must not read as a failure.
+printf '#!/usr/bin/env bash
+exit 0
+' > "$BROKEN/scripts/jj-session-start.sh"
+P=$(newproj)
+OUT=$(bash "$INSTALL" $INSTALL_MODE "$BROKEN" "$P")
+printf '%s' "$OUT" | grep -q '^smoke=pass$' \
+  && ok "smoke: silent handler is not a failure" || bad "smoke" "silence misreported: $(printf '%s' "$OUT" | grep '^smoke=' || echo none)"
+
+# A failing smoke must NOT abort the install: the files are already written and
+# correctly registered, and non-zero exit is reserved for "nothing was written".
+printf '#!/usr/bin/env bash
+exit 3
+' > "$BROKEN/scripts/jj-session-start.sh"
+P=$(newproj)
+if bash "$INSTALL" $INSTALL_MODE "$BROKEN" "$P" >/dev/null 2>&1; then
+  [ -f "$P/.claude/settings.local.json" ] \
+    && ok "smoke: failure is reported, not fatal" || bad "smoke" "settings missing after smoke failure"
+else
+  bad "smoke" "a failing smoke aborted the install (exit non-zero)"
+fi
+rm -rf "$BROKEN"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 [ "$fail" -eq 0 ]

--- a/plugins/project-setup-jj/tests/test-statusline-jj.sh
+++ b/plugins/project-setup-jj/tests/test-statusline-jj.sh
@@ -197,6 +197,59 @@ else
   fail=$((fail + 1))
 fi
 
+# ── Tests 10-14: the install-time smoke check ──
+# statusline-smoke.sh is what /statusline-jj-setup runs before telling anyone to
+# restart. These cases are about the SMOKE TOOL, not the statusline: each feeds
+# it a deliberately broken stand-in and pins the diagnosis it produces.
+SMOKE="$SCRIPT_DIR/../scripts/statusline-smoke.sh"
+
+smoke_case() {
+  local test_name="$1" target="$2" want="$3" out
+  out=$(bash "$SMOKE" "$target" 2>&1 || true)
+  if printf '%s' "$out" | grep -q "$want"; then
+    echo "  PASS: $test_name"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $test_name — expected /$want/, got: $out"
+    fail=$((fail + 1))
+  fi
+}
+
+smoke_case "smoke passes the shipped statusline" "$SL" '^statusline_smoke=pass$'
+smoke_case "smoke fails a path that does not exist" "$TMPDIR_ROOT/absent.sh" '^statusline_smoke=fail:not found'
+
+printf 'if then fi\n' > "$TMPDIR_ROOT/nosyntax.sh"
+smoke_case "smoke fails an unparseable script" "$TMPDIR_ROOT/nosyntax.sh" '^statusline_smoke=fail:syntax error'
+
+# The #88 shape, and the reason the smoke renders TWICE. This stand-in succeeds
+# once and dies on every render after — exactly how the real bug presented, since
+# the crash needed the status cache the first render itself created. A smoke that
+# rendered once would call this healthy.
+cat > "$TMPDIR_ROOT/second-render-dies.sh" <<'STUB'
+#!/usr/bin/env bash
+marker="${STATUSLINE_JJ_CACHE_DIR:-/tmp}/seen-one-render"
+if [ -f "$marker" ]; then
+  echo "boom: line 168: File: unbound variable" >&2
+  exit 1
+fi
+: > "$marker"
+printf 'first render only'
+STUB
+smoke_case "smoke catches a script that dies on the SECOND render" \
+  "$TMPDIR_ROOT/second-render-dies.sh" '^statusline_smoke=fail:second render exited 1'
+
+# The other half of #88: renders fine, caches a filesystem report instead of an
+# mtime, so the key drifts with free disk space and the cache never validates.
+# Nothing user-visible fails — only the shape of the key gives it away.
+cat > "$TMPDIR_ROOT/garbage-key.sh" <<'STUB'
+#!/usr/bin/env bash
+cache="${STATUSLINE_JJ_CACHE_DIR:-/tmp}/statusline-jj-fake-cache"
+printf '  File: "/x/.jj/repo/op_heads/heads"\n|a|b|@trunk|healthy' > "$cache"
+printf ' rendered fine '
+STUB
+smoke_case "smoke catches a non-numeric cache key" \
+  "$TMPDIR_ROOT/garbage-key.sh" '^statusline_smoke=fail:cache key is not a numeric mtime pair'
+
 # ── Summary ──
 echo ""
 total=$((pass + fail))


### PR DESCRIPTION
Three changes from using this plugin set on Linux for the first time. They share one theme: **the tested surface was the mechanism, never the result.**

Closes #88 step 3.

## 1. Smoke-test what the installers install

`feat(project-setup-jj,agent-helpers-jj)`

The suites cover the installers thoroughly — every merge case, every gitignore shape, 185 assertions. They covered the *installed result* nowhere, and that is the gap #88 lived in: a handler copied, registered, announced, and dead, with CI green throughout. An installer that never executes what it installed is reporting that a copy succeeded, which is not what anyone asked it.

| Path | New key | What it proves |
|---|---|---|
| `/statusline-jj-setup` | `statusline_smoke=` | the installed statusline renders |
| `/project-setup` | `smoke=` | handlers parse, are executable, and `jj-session-start.sh` emits valid JSON |
| `/agent-helpers-setup` | `smoke=` | the installed file sources and defines all four helpers |

**`statusline-smoke.sh` renders twice, on purpose.** #88's crash needed `/tmp/statusline-claude-summary` to already exist, and the first render is what creates it — so the failure lands on render two and every one after. A single-render smoke would have passed over the exact bug it exists to catch. It then checks the cache key is a numeric mtime pair, which catches the same bug where no network reaches the status API: both renders succeed while the key silently carries a filesystem report that drifts with free disk space.

**None of the three is fatal.** The files are written and correctly registered by the time the check runs, and non-zero exit already means something specific in these scripts — *nothing was written*. A smoke failure is a summary key the command prose relays, with instructions not to present the install as ready.

Fail-first evidence, each stand-in pinned by a test: unparseable script, non-zero exit, valid-but-garbage output, a script that dies only on the second render, and one that renders fine while caching a filesystem report.

Also drops a phantom from the agent-helpers prose — it told the model to warn about shadowing `_jjq`, which the helper file does not define and deliberately never will (Claude Code's shell-snapshot capture drops `_`-prefixed functions as zsh completion helpers, so each helper inlines its own query). Prose describing a mechanism it was never checked against, which is #150's shape one plugin over.

## 2. The git wall denied the idioms that *exclude* git internals

`fix(project-setup-jj,peer-review-jj)`

The internals branch is quote-blind by design — a documented, pinned trade-off. It was also intent-blind in one direction that costs real work:

```
find . -path ./.git -prune -o -name '*.md' -print
grep -rn TODO --exclude-dir=.git .
```

Both denied. Both mention the directory in order to **stay out of it** — the mirror image of the habit the wall exists to interrupt. It hit twice in one session while working on this repo, and it blocked a `jj new -m …` whose message quoted the idiom being fixed.

Three flag-anchored strips run before the test: `--exclude`/`--exclude-dir` (with `=` or a space), `-path`/`-name`/`-wholename`/`-iname`/`-regex` followed by `-prune`, and the negated forms. Flag-anchored is the safety argument: each strip removes one option together with its own argument — a fixed token sequence — rather than trying to understand a quoted region. **The general quote-blindness stands exactly where it was.**

The carve-out neutralises the exclusion token and nothing else, which keeps it from becoming a passphrase. Four assertions pin that: excluding the directory and then reading a file inside it still denies; an exclusion followed by a direct read still denies; `-name` without `-prune` is a *search* and still denies; an ordinary read is untouched.

The drift guard caught the un-synced `peer-review-jj` copy on the first run — precisely its job.

## 3. Run the suites on Linux as well as macOS

`ci:` — this is #88 step 3.

#88 assumed adding this leg would turn other suites red for unrelated reasons, which is why it was deferred. Measured on Linux first: **22/22 suites pass** — all five plugins plus the eight repo-level lints. The assumption was wrong, and the leg is a matrix entry rather than a project.

`fail-fast: false` is load-bearing: the value of a matrix is seeing *which* platform broke, and cancelling the sibling leg throws away that comparison.

jj comes from the release tarball on Linux — `cargo install jj-cli` is a multi-minute compile in a job whose work takes seconds, and brew-on-Linux bootstraps a second package manager for one static binary. The release is resolved at run time rather than pinned: a pin would be a third place the jj version is asserted, and #141 is open because such assertions drift apart unnoticed.

One measured detail: the tarball's member is `./jj`, so `tar xz jj` fails with `Not found in archive`. Extracting the whole archive into a temp dir depends on no naming convention the release is free to change. Found by *running* the step — the same lesson as change 1.

## Verification

```
22/22 suites pass on Linux (5 plugins + 8 repo-level lints)
test-block-raw-git.sh       159 passed, 0 failed  (+12 exclusion assertions)
test-project-setup-install.sh 95 passed, 0 failed  (+6 smoke assertions)
test-statusline-jj.sh        16/16 ALL PASSED     (+5 smoke-tool assertions)
test-agent-helpers-install.sh 18 passed, 0 failed  (+3 smoke assertions)
Linux jj install step: dry-run end to end → jj 0.44.0
```

Versions bumped: `project-setup-jj` 0.14.3→0.15.1, `agent-helpers-jj` 0.2.0→0.3.0, `peer-review-jj` 0.6.2→0.6.3. The macOS leg of this PR is itself the cross-platform check on change 1 and 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
