### PR TITLE
feat: /finish test gate, provenance-aware cleanup, working Option 2; briefing marks the session's workspace

### DIFF
--- a/.claude/hooks/jj-session-start.sh
+++ b/.claude/hooks/jj-session-start.sh
@@ -83,6 +83,26 @@ workspaces=$(jj --ignore-working-copy workspace list --no-pager \
   -T 'self.name() ++ ": " ++ self.target().change_id().shortest(8) ++ if(self.target().empty(), " (empty)", "") ++ " " ++ if(self.target().description(), self.target().description().first_line(), "(no description set)") ++ "\n"' \
   2>/dev/null || echo "(unable to read workspaces)")
 
+# Mark which row is THIS session — the paragraph above says the attached
+# workspace determines what @ means, so the briefing should say which one that
+# is rather than leave it to inference. Match by ROOT, never by name: names
+# repeat across repos while roots cannot, and both sides of the comparison come
+# from jj itself, so the spellings agree (no /tmp vs /private/tmp mismatch).
+# No `exit` inside the awk: under this script's set -euo pipefail, awk exiting
+# on the first match closes the pipe while jj may still be writing later rows,
+# jj dies of EPIPE, and the whole briefing silently vanishes — measured as an
+# intermittent empty payload the moment a second workspace existed.
+current_root=$(jj workspace root --ignore-working-copy 2>/dev/null || true)
+if [ -n "$current_root" ]; then
+  current_ws=$(jj --ignore-working-copy workspace list --no-pager \
+    -T 'self.name() ++ "\t" ++ self.root() ++ "\n"' 2>/dev/null \
+    | awk -F'\t' -v r="$current_root" '!found && $2 == r {print $1; found=1}') || true
+  if [ -n "$current_ws" ]; then
+    workspaces=$(printf '%s\n' "$workspaces" \
+      | awk -v ws="$current_ws" 'index($0, ws ": ") == 1 {$0 = $0 " (this session)"} {print}') || true
+  fi
+fi
+
 identity=$(jj --ignore-working-copy config list user.email -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read user.email)")
 
 # Escape string for JSON embedding.

--- a/plugins/commit-commands-jj/.claude-plugin/plugin.json
+++ b/plugins/commit-commands-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-commands-jj",
-  "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests — requires project-setup-jj",
-  "version": "0.18.2",
+  "description": "Streamline your jj (Jujutsu) workflow with simple commands for committing, pushing, and creating pull requests \u2014 requires project-setup-jj",
+  "version": "0.19.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/commit-commands-jj/README.md
+++ b/plugins/commit-commands-jj/README.md
@@ -114,13 +114,14 @@ Finishes development work by presenting a menu of completion options and executi
 
 **What it does:**
 1. Verifies the target change (current or parent, if `@` is empty) has content against trunk
-2. Presents four options: push and create a PR, squash into trunk (local merge), keep as-is, or discard
-3. Executes the chosen workflow:
+2. Runs the project's test suite — the menu only appears after a green run (skipped when no suite is detected)
+3. Presents four options: push and create a PR, merge into trunk locally, keep as-is, or discard
+4. Executes the chosen workflow:
    - **Push and create PR:** warns about non-target ancestor changes that would be swept into the PR, creates a bookmark if needed (or uses `jj git push --change <target>` for a quick anonymous push), pushes with `jj git push --bookmark`, and opens the PR with `gh pr create`
-   - **Squash into trunk:** fetches, rebases the change onto trunk, and folds it in with `jj squash --into trunk()`
+   - **Merge into trunk locally:** fetches, rebases the change onto trunk, and fast-forwards the trunk bookmark with `jj bookmark move` (not `jj squash --into trunk()` — trunk is immutable, so that form errors)
    - **Keep as-is:** reports the change ID and stops — no cleanup
    - **Discard:** records a restore point from the op log, runs `jj abandon`, and hands back the exact `jj op restore <id>` that undoes it
-4. For push, squash, and discard, cleans up the jj workspace if running in a non-default one (`jj workspace forget`)
+5. For push, merge, and discard, cleans up the jj workspace if running in a non-default one (`jj workspace forget`) — auto-forgetting only ephemeral hook-created workspaces, and asking before ending a durable side thread
 
 **Usage:**
 ```bash
@@ -134,8 +135,9 @@ Finishes development work by presenting a menu of completion options and executi
 
 # Claude will:
 # - Confirm there's work to finish (against trunk)
+# - Run the project's test suite (menu only appears after a green run)
 # - Ask which of the 4 options you want
-# - Execute it (push+PR, squash, keep, or discard)
+# - Execute it (push+PR, local merge, keep, or discard)
 # - Clean up the workspace if applicable
 ```
 
@@ -144,7 +146,8 @@ Finishes development work by presenting a menu of completion options and executi
 - Makes discarding recoverable rather than gating it — captures an op id first, then reports `jj op restore <id>`
 - Detects and warns about ancestor changes not part of the target work before pushing
 - After a PR merges, abandons the now-landed local ancestor changes as part of cleanup
-- Does not run tests or reviews — finishing work is its own concern
+- Gates the menu behind the project's test suite (skipped only when no suite is detected); reviews remain the caller's concern
+- Workspace cleanup respects provenance — auto-forgets only ephemeral hook-created workspaces (`/tmp/jj-workspaces/`), and asks before ending a durable side thread
 
 ### `/describe`
 

--- a/plugins/commit-commands-jj/commands/finish.md
+++ b/plugins/commit-commands-jj/commands/finish.md
@@ -12,7 +12,8 @@ allowed-tools: Bash(jj:*), Bash(jj git push:*), Bash(gh pr create:*), Bash(gh pr
 - Current diff stats: !`jj diff --stat`
 - Current status: !`jj status`
 - Bookmarks on current change: !`jj log -r @ --no-graph -T 'bookmarks'`
-- Is this a workspace?: !`jj workspace list --no-pager -T 'self.name() ++ "\n"'`
+- Current workspace root: !`jj workspace root`
+- All workspaces (name, root): !`jj workspace list --no-pager -T 'self.name() ++ "\t" ++ self.root() ++ "\n"'`
 
 ## Overview
 
@@ -20,7 +21,7 @@ allowed-tools: Bash(jj:*), Bash(jj git push:*), Bash(gh pr create:*), Bash(gh pr
 
 Guide completion of development work by presenting clear options and executing the chosen workflow.
 
-**Core principle:** Verify work exists → Present options → Execute choice → Clean up.
+**Core principle:** Verify work exists → Verify tests → Present options → Execute choice → Clean up.
 
 **Announce at start:** "I'm using the /finish skill to complete this work."
 
@@ -40,7 +41,36 @@ Finishing: <description or summary of changes>
 <N> files changed, +<additions>, -<deletions>
 ```
 
-## Step 2: Present options
+## Step 2: Verify tests
+
+The menu comes after a green suite — integrating untested work is how bad
+merges happen.
+
+1. **Find the project's test command.** In order of authority: project
+   instructions (CLAUDE.md), CI config (`.github/workflows/`), then standard
+   manifests (`package.json` scripts.test, `Cargo.toml`, `pyproject.toml`,
+   `Makefile` test target, `go.mod`).
+
+   If none of these yields a test command, report:
+   ```
+   No test suite detected — skipping test gate.
+   ```
+   and continue to Step 3.
+
+2. **Run the suite on the tree being finished.** A green run earlier in the
+   session only proves the tree it ran on — if `@` has changed since, run it
+   again. (The test command is usually outside this command's pre-approved
+   tools, so expect a permission prompt.)
+
+3. **If tests fail**, report the failures and stop:
+   ```
+   Tests failing (<N> failures). Must fix before finishing:
+   <failures>
+   ```
+   Do not present the menu. If the user explicitly says to discard the work
+   anyway, Option 4 remains available on that request.
+
+## Step 3: Present options
 
 Present exactly these 4 options:
 
@@ -48,12 +78,12 @@ Present exactly these 4 options:
 What would you like to do?
 
 1. Push and create a Pull Request
-2. Squash into trunk (local merge)
+2. Merge into trunk locally (fast-forward)
 3. Keep as-is (I'll handle it later)
 4. Discard this work
 ```
 
-## Step 3: Execute choice
+## Step 4: Execute choice
 
 ### Option 1: Push and create PR (most common)
 
@@ -201,27 +231,49 @@ What would you like to do?
       jj git push --deleted
       ```
 
-7. Then: Workspace cleanup (Step 4).
+7. Then: Workspace cleanup (Step 5).
 
-### Option 2: Squash into trunk (local merge)
+### Option 2: Merge into trunk locally (fast-forward)
+
+Do NOT reach for `jj squash --into trunk()`. Measured on jj 0.44.0: `--into`
+and `-r` are mutually exclusive (the command errors before doing anything),
+and the corrected `--from <target> --into trunk()` form is then rejected with
+`Error: Commit ... is immutable` — trunk is in `builtin_immutable_heads()`.
+The jj-native local merge is a rebase plus a bookmark fast-forward, which
+rewrites nothing that is shared:
 
 1. Fetch latest trunk:
    ```bash
    jj git fetch
    ```
 
-2. Rebase the work onto trunk and squash:
+2. Rebase the work onto trunk:
    ```bash
    jj rebase -r <target> -d trunk()
-   jj squash --into trunk() -r <target>
    ```
+   The ancestor concern from Option 1 applies here too: moving the bookmark
+   to the target brings every ancestor with it, so if the ancestor check
+   shows unrelated changes between trunk and the target, surface them first.
 
-3. Verify the squash landed:
+3. Fast-forward the trunk bookmark (read its name — usually `main` — from
+   `jj log -r 'trunk()' --no-graph -T 'bookmarks'` before the move):
    ```bash
-   jj log -r 'trunk()' --limit 3 --no-graph
+   jj bookmark move <trunk-bookmark> --to <target>
    ```
 
-4. Then: Workspace cleanup (Step 4).
+4. Verify against the **local bookmark, not `trunk()`**:
+   ```bash
+   jj log -r <trunk-bookmark> --limit 3 --no-graph
+   ```
+   `trunk()` keeps resolving to the *remote* bookmark (`main@origin`) until a
+   push happens, so it still shows the pre-merge state on a successful local
+   merge — checking it here reports a false failure.
+
+5. Report that the merge is local only: the remote is unchanged until
+   `jj git push --bookmark <trunk-bookmark>` (measured: the push is a clean
+   `[move forward ...]`, no force needed). Push only if the user asks.
+
+6. Then: Workspace cleanup (Step 5).
 
 ### Option 3: Keep as-is
 
@@ -288,35 +340,51 @@ it to the user, not to gate the discard behind a typed keyword.
    then re-publish:     jj git push --bookmark <name>
    ```
 
-Then: Workspace cleanup (Step 4).
+Then: Workspace cleanup (Step 5).
 
-## Step 4: Workspace cleanup
+## Step 5: Workspace cleanup
 
 **For Options 1, 2, and 4 only.**
 
-Check if running inside a jj workspace (from context above — if workspace list shows more than just "default"):
+1. **Identify the current workspace by root, not by name.** Read the two
+   workspace lines from Context: the current workspace is the row of the
+   list whose root equals the current workspace root. (The list template is
+   pinned deliberately — jj 0.44 changed what `jj workspace list` prints by
+   default, and this step depends on the root field being present.) On macOS,
+   `/tmp` is a symlink to `/private/tmp` — treat the two spellings of a path
+   as the same location when matching.
 
-```bash
-jj workspace list --no-pager -T 'self.name() ++ "\n"'
-```
+   If the current workspace is `default`, no cleanup is needed. Stop here.
 
-If in a non-default workspace:
-```bash
-# Get the workspace name
-# Forget the workspace from the repo
-jj workspace forget <workspace-name>
-```
+2. **Branch on provenance — who created the workspace decides who ends it:**
 
-Report what was cleaned up. If the worktree directory should be removed, note it but do NOT remove it automatically — the WorktreeRemove hook handles that.
+   - **Root under `/tmp/jj-workspaces/`** — an ephemeral workspace the
+     WorktreeCreate hook made (`claude --worktree`, `EnterWorktree`). Ours to
+     clean up:
+     ```bash
+     jj workspace forget <workspace-name>
+     ```
+   - **Any other root** — a durable side thread (e.g. a `jjtab` sibling
+     directory). Ending one with `/finish` is a documented use, but the thread
+     outlives any single change, so ending it is the user's call, not a side
+     effect — ask:
+     ```
+     This session is in the durable workspace <name> (<root>).
+     Finish the side thread too (forget the workspace), or keep it for more work?
+     ```
+     Forget only on a yes. Keeping it is not a failure — report the change as
+     finished and the workspace as kept.
 
-If in the default workspace, no cleanup needed.
+3. **Report what was cleaned up.** Never remove the workspace directory
+   itself — the WorktreeRemove hook owns ephemeral directories, and a durable
+   directory's removal is the user's to do by hand.
 
 ## Quick Reference
 
-| Option | Push | Squash | Keep Workspace | Cleanup |
+| Option | Push | Merge | Keep Workspace | Cleanup |
 |--------|------|--------|----------------|---------|
 | 1. PR | ✓ | - | ✓ | bookmark only |
-| 2. Squash | - | ✓ | - | ✓ |
+| 2. Local merge | - | ✓ | - | ✓ |
 | 3. Keep | - | - | ✓ | - |
 | 4. Discard | - | - | - | ✓ |
 
@@ -327,7 +395,8 @@ If in the default workspace, no cleanup needed.
 - **Make discard recoverable; don't gate it.** Capture `jj op log -n 1 --no-graph -T 'id.short()'` before abandoning, then hand back `jj op restore <id>`. A typed-confirmation prompt is a git habit — in jj the op log is the safety net, and it works whether or not anyone was asked.
 - **If the discard removed a pushed bookmark from the remote, the recovery command is `jj op restore <id> --what repo`.** The bare form restores remote-tracking refs too, and the following `jj git push` reports `Nothing changed.` over a remote that is still empty.
 - **Don't auto-remove worktree directories.** Let the WorktreeRemove hook handle it.
-- **Keep it focused.** This skill finishes work. It does not run tests or do reviews — those are the caller's responsibility.
+- **Provenance gates workspace cleanup.** Auto-forget only ephemeral workspaces (root under `/tmp/jj-workspaces/`); a durable workspace is forgotten only after the user says so.
+- **Menu after green.** Run the project's test suite (Step 2) before presenting options; skip the gate only when no suite is detected. Reviews remain the caller's responsibility.
 
 ## Integration
 

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/scripts/jj-session-start.sh
+++ b/plugins/project-setup-jj/scripts/jj-session-start.sh
@@ -83,6 +83,26 @@ workspaces=$(jj --ignore-working-copy workspace list --no-pager \
   -T 'self.name() ++ ": " ++ self.target().change_id().shortest(8) ++ if(self.target().empty(), " (empty)", "") ++ " " ++ if(self.target().description(), self.target().description().first_line(), "(no description set)") ++ "\n"' \
   2>/dev/null || echo "(unable to read workspaces)")
 
+# Mark which row is THIS session — the paragraph above says the attached
+# workspace determines what @ means, so the briefing should say which one that
+# is rather than leave it to inference. Match by ROOT, never by name: names
+# repeat across repos while roots cannot, and both sides of the comparison come
+# from jj itself, so the spellings agree (no /tmp vs /private/tmp mismatch).
+# No `exit` inside the awk: under this script's set -euo pipefail, awk exiting
+# on the first match closes the pipe while jj may still be writing later rows,
+# jj dies of EPIPE, and the whole briefing silently vanishes — measured as an
+# intermittent empty payload the moment a second workspace existed.
+current_root=$(jj workspace root --ignore-working-copy 2>/dev/null || true)
+if [ -n "$current_root" ]; then
+  current_ws=$(jj --ignore-working-copy workspace list --no-pager \
+    -T 'self.name() ++ "\t" ++ self.root() ++ "\n"' 2>/dev/null \
+    | awk -F'\t' -v r="$current_root" '!found && $2 == r {print $1; found=1}') || true
+  if [ -n "$current_ws" ]; then
+    workspaces=$(printf '%s\n' "$workspaces" \
+      | awk -v ws="$current_ws" 'index($0, ws ": ") == 1 {$0 = $0 " (this session)"} {print}') || true
+  fi
+fi
+
 identity=$(jj --ignore-working-copy config list user.email -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read user.email)")
 
 # Escape string for JSON embedding.

--- a/plugins/project-setup-jj/tests/test-jj-session-start.sh
+++ b/plugins/project-setup-jj/tests/test-jj-session-start.sh
@@ -131,6 +131,38 @@ else
   fi
 fi
 
+# --- current-workspace marker: the briefing says which row is THIS session ---
+# Root-matched, not name-matched. The single-workspace scaffold marks default;
+# with a second workspace the marker must sit on the session's row and only
+# there, from either side.
+if printf '%s' "$ws_section" | grep -q '^default: .*(this session)$'; then
+  ok "default row carries the (this session) marker"
+else
+  bad "marker" "no (this session) marker on the default row: $ws_section"
+fi
+
+jj workspace add ../ws2 --name second >/dev/null 2>&1
+out2="$(ctx)"
+ws2_section=$(printf '%s\n' "$out2" | awk '/^Workspaces:/{f=1;next} /^[[:space:]]*$/{f=0} f')
+if printf '%s' "$ws2_section" | grep -q '^default: .*(this session)$' \
+   && printf '%s' "$ws2_section" | grep -q '^second: ' \
+   && ! printf '%s' "$ws2_section" | grep -q '^second: .*(this session)$'; then
+  ok "with a second workspace, only the session's row is marked"
+else
+  bad "marker" "marker misplaced with two workspaces: $ws2_section"
+fi
+
+out3="$(cd ../ws2 && bash "$HOOK" 2>/dev/null | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || true)"
+ws3_section=$(printf '%s\n' "$out3" | awk '/^Workspaces:/{f=1;next} /^[[:space:]]*$/{f=0} f')
+if printf '%s' "$ws3_section" | grep -q '^second: .*(this session)$' \
+   && ! printf '%s' "$ws3_section" | grep -q '^default: .*(this session)$'; then
+  ok "marker follows the session into a non-default workspace"
+else
+  bad "marker" "marker did not follow into the second workspace: $ws3_section"
+fi
+jj workspace forget second >/dev/null 2>&1
+rm -rf ../ws2
+
 # Scope every stack assertion to the stack SECTION, for the reason the identity
 # check had to learn: @'s own `json(self)` block sits directly above and already
 # contains the description, so an unscoped grep passes even against a hook that


### PR DESCRIPTION
## Summary

**commit-commands-jj 0.19.0**
- `/finish` gains **Step 2: Verify tests** — detect the project's test command (CLAUDE.md > CI config > manifests), run it on the tree being finished, and stop before the menu on a red suite. No suite detected = gate skipped with a notice; discard stays reachable on explicit request.
- **Step 5 workspace cleanup is provenance-aware**: the current workspace is identified by root-match against the pinned name+root list template (finish.md was the last unpinned call site after #157). Ephemeral hook-created workspaces (root under `/tmp/jj-workspaces/`) are auto-forgotten; a durable side thread (jjtab sibling dir) is forgotten only after asking — ending one via `/finish` is documented in workspace-jj's README, but it's the user's call, not a side effect.
- **Option 2 never worked and is rewritten.** Measured on jj 0.44.0: `jj squash --into trunk() -r <target>` errors (`--into` and `-r` are mutually exclusive), and the corrected `--from/--into` form is rejected because trunk is in `builtin_immutable_heads()`. The local merge is now rebase + `jj bookmark move` fast-forward, verified against the local bookmark — `trunk()` tracks the remote until a push and would report a false failure.

**project-setup-jj 0.16.0**
- The session-start briefing marks which workspace row is **this session** (`(this session)`), root-matched never name-matched. The hook's own rationale says the attached workspace determines what `@` means; now the briefing says which one that is.
- The marker's awk must not `exit` on first match: under `set -euo pipefail` that closes the pipe mid-write, jj dies of EPIPE, and the whole briefing intermittently vanishes once a second workspace exists (measured ~1 in 5 suite runs; 30/30 clean after the fix). Comment in the hook pins the reason.

## Test plan
- [x] test-jj-session-start.sh: 25/25, five consecutive runs (3 new marker assertions incl. two-workspace and inside-workspace cases)
- [x] 30-iteration workspace-add repro loop clean (previously failed by iteration 3)
- [x] test-project-setup-install.sh: 95/95
- [x] test-command-invocations.sh: 121/121 (validates new `jj bookmark move --to` fenced commands)
- [x] test-command-prose-claims.sh: 20/20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ipJgAK75edbgnJWaFXEZz