### PR TITLE
jj-native shims for the superpowers SDD scripts; template routes serial plans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- jj-project-setup:start hash:27bab007 -->
+<!-- jj-project-setup:start hash:3862b7bf -->
 ## VCS — jj (Jujutsu)
 
 This project uses **jj (Jujutsu)** as its VCS. Never use raw git commands. Use jj equivalents instead (e.g. `jj log`, `jj status`, `jj diff`). The only exceptions are `jj git` subcommands (e.g. `jj git push`) and the `gh` CLI for GitHub operations.
@@ -19,7 +19,27 @@ When superpowers skills reference git-based workflows, use these jj-native repla
 | Superpowers skill | Use instead | Why |
 |---|---|---|
 | `finishing-a-development-branch` | `/finish` | jj-native: bookmarks, `jj git push`, workspace cleanup |
-| `subagent-driven-development` | `workspace-jj:kaisen` | jj-native: wave-based parallel execution with spec review gates |
+| `subagent-driven-development` | `workspace-jj:kaisen` — **for parallel plans** | jj-native: wave-based parallel execution across isolated workspaces with spec review gates |
+
+**The kaisen row is a preference conditional on plan shape, not a blanket override.** Kaisen's value is wave-based *parallel* execution across isolated workspaces, so route to it when the plan's tasks are independent. For a **serial** plan — tasks strictly ordered, or repeatedly touching the same files — waves of one task each buy nothing but workspace setup and reunification overhead. Use `superpowers:subagent-driven-development` directly, in the default workspace.
+
+Three things that serial path needs here.
+
+**Its helper scripts shell out to `git`, which is blocked.** Resolve the jj-native replacements once per run (a local checkout of the plugins repo has them at `plugins/workspace-jj/scripts` instead):
+
+```bash
+SDD=$(ls -d ~/.claude/plugins/cache/*/workspace-jj/*/scripts 2>/dev/null | sort -V | tail -1)
+```
+
+| Superpowers script | Use instead |
+|---|---|
+| `scripts/sdd-workspace` | `"$SDD/sdd-artifacts" <plan>` — same argv, same stdout, same `.superpowers/sdd/<plan>/` layout |
+| `scripts/review-package` | `"$SDD/sdd-review-package" <plan> <BASE> <HEAD> [outfile]` — same sections, plus the guard below |
+| `scripts/task-brief` | works as-is; it only shells out to derive its default path, so pass an explicit outfile: `task-brief <plan> <n> "$("$SDD/sdd-artifacts" <plan>)/task-<n>-brief.md"` |
+
+**Record each task's BASE as a change ID.** This is the change-ID rule above, in the one place it bites hardest. A commit ID captured before a review round is stale after it — and a stale commit ID still *resolves*, merely hidden, so `jj diff` returns a plausible review package built against the code as it was **before** the fix and nothing anywhere errors. A reviewer reads it as current and reports clean. `sdd-review-package` rejects a hidden revision outright, but the change ID is what should have been recorded in the first place.
+
+**Implementers share the default workspace.** Serial SDD deliberately uses no isolation, so an implementer subagent running `jj describe` or `jj new` moves `@` for the orchestrator too. Dispatch one implementer at a time: that constraint is what makes the shared working copy safe, not an incidental scheduling choice.
 <!-- jj-project-setup:end -->
 
 # CLAUDE.md

--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/templates/CLAUDE.md.template
+++ b/plugins/project-setup-jj/templates/CLAUDE.md.template
@@ -1,4 +1,4 @@
-<!-- jj-project-setup:start hash:27bab007 -->
+<!-- jj-project-setup:start hash:3862b7bf -->
 ## VCS — jj (Jujutsu)
 
 This project uses **jj (Jujutsu)** as its VCS. Never use raw git commands. Use jj equivalents instead (e.g. `jj log`, `jj status`, `jj diff`). The only exceptions are `jj git` subcommands (e.g. `jj git push`) and the `gh` CLI for GitHub operations.
@@ -19,5 +19,25 @@ When superpowers skills reference git-based workflows, use these jj-native repla
 | Superpowers skill | Use instead | Why |
 |---|---|---|
 | `finishing-a-development-branch` | `/finish` | jj-native: bookmarks, `jj git push`, workspace cleanup |
-| `subagent-driven-development` | `workspace-jj:kaisen` | jj-native: wave-based parallel execution with spec review gates |
+| `subagent-driven-development` | `workspace-jj:kaisen` — **for parallel plans** | jj-native: wave-based parallel execution across isolated workspaces with spec review gates |
+
+**The kaisen row is a preference conditional on plan shape, not a blanket override.** Kaisen's value is wave-based *parallel* execution across isolated workspaces, so route to it when the plan's tasks are independent. For a **serial** plan — tasks strictly ordered, or repeatedly touching the same files — waves of one task each buy nothing but workspace setup and reunification overhead. Use `superpowers:subagent-driven-development` directly, in the default workspace.
+
+Three things that serial path needs here.
+
+**Its helper scripts shell out to `git`, which is blocked.** Resolve the jj-native replacements once per run (a local checkout of the plugins repo has them at `plugins/workspace-jj/scripts` instead):
+
+```bash
+SDD=$(ls -d ~/.claude/plugins/cache/*/workspace-jj/*/scripts 2>/dev/null | sort -V | tail -1)
+```
+
+| Superpowers script | Use instead |
+|---|---|
+| `scripts/sdd-workspace` | `"$SDD/sdd-artifacts" <plan>` — same argv, same stdout, same `.superpowers/sdd/<plan>/` layout |
+| `scripts/review-package` | `"$SDD/sdd-review-package" <plan> <BASE> <HEAD> [outfile]` — same sections, plus the guard below |
+| `scripts/task-brief` | works as-is; it only shells out to derive its default path, so pass an explicit outfile: `task-brief <plan> <n> "$("$SDD/sdd-artifacts" <plan>)/task-<n>-brief.md"` |
+
+**Record each task's BASE as a change ID.** This is the change-ID rule above, in the one place it bites hardest. A commit ID captured before a review round is stale after it — and a stale commit ID still *resolves*, merely hidden, so `jj diff` returns a plausible review package built against the code as it was **before** the fix and nothing anywhere errors. A reviewer reads it as current and reports clean. `sdd-review-package` rejects a hidden revision outright, but the change ID is what should have been recorded in the first place.
+
+**Implementers share the default workspace.** Serial SDD deliberately uses no isolation, so an implementer subagent running `jj describe` or `jj new` moves `@` for the orchestrator too. Dispatch one implementer at a time: that constraint is what makes the shared working copy safe, not an incidental scheduling choice.
 <!-- jj-project-setup:end -->

--- a/plugins/workspace-jj/.claude-plugin/plugin.json
+++ b/plugins/workspace-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workspace-jj",
   "description": "Wave-based parallel orchestration with spec review gates for jj (Jujutsu) repositories",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/workspace-jj/README.md
+++ b/plugins/workspace-jj/README.md
@@ -106,6 +106,31 @@ Override merge order with `--merge-order task-3,task-1,task-2`. Skip the REVIEW 
 
 See [design spec](../../docs/specs/2026-07-15-kaisen-rename-and-collision-design.md) for full details.
 
+## Serial SDD: shims for the superpowers scripts
+
+Kaisen is for plans whose tasks are independent. A **serial** plan — tasks strictly ordered, or repeatedly touching the same files — gets nothing from waves of one task each, so the right tool there is superpowers' own `subagent-driven-development`, run in the default workspace.
+
+Two of that skill's helper scripts shell out to `git` and are denied by `block-raw-git.sh`, the PreToolUse hook project-setup-jj registers in its plugin manifest — so it fires in every jj repo where the plugin is enabled, not through per-project settings anyone can toggle. These are drop-in replacements:
+
+| Superpowers script | Replacement | What changes |
+|---|---|---|
+| `scripts/sdd-workspace` | `scripts/sdd-artifacts` | `jj root` replaces `git rev-parse --show-toplevel`. Same argv, same stdout, same `.superpowers/sdd/<plan>/` layout — a plan mid-flight can switch without moving an artifact. Renamed because in a jj repo "workspace" means `jj workspace add`, and this directory is not one. |
+| `scripts/review-package` | `scripts/sdd-review-package` | Same sections and argv, plus the guard jj needs (below). |
+| `scripts/task-brief` | works as-is | It only shells out when deriving its default path. Pass an explicit outfile: `task-brief <plan> <n> "$(sdd-artifacts <plan>)/task-<n>-brief.md"`. |
+
+**Hand the review package change IDs, not commit IDs.** This is the guard, and it is the reason `sdd-review-package` is more than a port. Upstream protects BASE and HEAD with `git rev-parse --verify`, which fails loudly on a revision that no longer exists. jj offers no equivalent failure, because the revision still exists: a rewrite — `jj describe`, `jj squash`, the rebase of descendants that follows either, and every working-copy snapshot — leaves the old commit reachable and merely *hidden*. Measured on jj 0.44.0:
+
+```
+jj log  -r <stale-commit-id>                    → resolves, hidden=YES, pre-rewrite tree
+jj diff --from <stale-commit-id> --to @ --stat  → exit 0, plausible diff
+```
+
+So a BASE captured before a review round does not error afterwards — it silently produces a package built against the code as it was *before* the fix, which a reviewer reads as current and reports clean. A change ID has no such failure: it follows its change through every rewrite.
+
+`sdd-review-package` therefore reinstates the guard on jj's terms — a hidden BASE or HEAD is a hard error naming the change ID to use instead, and a commit-ID-shaped argument is a warning rather than a stop, since an immutable record is a legitimate use. Packages are named `review-<baseChange>..<headChange>-<headCommit>.diff`: change IDs carry identity across a review round, the head commit ID keeps each round's package a distinct file.
+
+**Implementers share the default workspace.** Serial SDD deliberately uses no isolation, so implementer subagents running `jj describe` and `jj new` move `@` for the orchestrator too. Dispatch one at a time; that constraint is what makes the shared working copy safe, not an incidental scheduling choice.
+
 ## Author
 
 [muloka](https://github.com/muloka)

--- a/plugins/workspace-jj/scripts/sdd-artifacts
+++ b/plugins/workspace-jj/scripts/sdd-artifacts
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# jj-native shim for superpowers' subagent-driven-development `sdd-workspace`.
+#
+# Resolve and ensure the directory one plan's short-lived SDD artifacts live in:
+# task briefs, implementer reports, review packages, and the progress ledger.
+# Prints the directory's absolute path.
+#
+# WHY A SHIM. Upstream's script is one `git rev-parse --show-toplevel` away from
+# working here, and that single call is denied by project-setup-jj's
+# block-raw-git.sh PreToolUse hook — which is registered in plugin.json and so
+# fires in EVERY jj repo where the plugin is enabled, not per-project settings
+# anyone can toggle off. The rest of upstream's design is kept byte-for-byte in
+# behaviour, deliberately: this is a shim, not a redesign. Same argv, same
+# stdout, same directory layout, so a plan mid-flight can switch to it without
+# moving a single artifact.
+#
+# NOT NAMED sdd-workspace. In a jj repo "workspace" is `jj workspace add` — a
+# second working copy sharing one store. This directory is not one, and a script
+# that says otherwise teaches the wrong noun in the one repo where the noun is
+# load-bearing. `kaisen-artifacts` next door already made this call.
+#
+# One directory per plan (.superpowers/sdd/<plan-basename>/) so a follow-up plan
+# in the same working copy can never read or overwrite another plan's artifacts.
+# A stale ledger misread as current progress makes controllers skip whole task
+# sequences — plan-scoping removes that failure structurally.
+#
+# IN THE WORKING COPY, ON PURPOSE — and safe under jj. jj snapshots the working
+# copy automatically, so artifacts written here would land in `@` and ride along
+# into whatever that change becomes. The self-ignoring `.gitignore` (`*`, which
+# matches the .gitignore itself) is what prevents that, and jj honours
+# .gitignore natively: measured on jj 0.44.0, writing a brief under an ignored
+# .superpowers/sdd/ leaves `jj status` reporting no changes and `jj file list`
+# empty. The alternative — /tmp, as kaisen uses — is wrong for THIS path: kaisen
+# artifacts die with the run, while a serial SDD plan spans sessions and its
+# ledger is the thing you come back to days later.
+#
+# Single source of truth for the location, so a brief and its review package
+# cannot drift to different directories.
+#
+# Usage: sdd-artifacts PLAN_FILE
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "usage: sdd-artifacts PLAN_FILE" >&2
+  exit 2
+fi
+
+plan=$1
+[ -f "$plan" ] || { echo "no such plan file: $plan" >&2; exit 2; }
+
+slug=$(basename "$plan" .md)
+[ -n "$slug" ] && [ "$slug" != "." ] && [ "$slug" != ".." ] \
+  || { echo "cannot derive an artifacts directory name from: $plan" >&2; exit 2; }
+
+# `jj root` replaces `git rev-parse --show-toplevel`. No --ignore-working-copy:
+# it is correct for background query tooling, and this is a mkdir on the path
+# the caller is about to write into.
+root=$(jj root) || { echo "not in a jj repo (jj root failed)" >&2; exit 2; }
+
+base="$root/.superpowers/sdd"
+dir="$base/$slug"
+mkdir -p "$dir"
+printf '*\n' > "$base/.gitignore"
+printf '%s\n' "$dir"

--- a/plugins/workspace-jj/scripts/sdd-review-package
+++ b/plugins/workspace-jj/scripts/sdd-review-package
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# jj-native shim for superpowers' subagent-driven-development `review-package`.
+#
+# Generate a review package — change list, stat summary, and the net diff with
+# extended context — written to one file the reviewer reads in a single call.
+#
+# Usage: sdd-review-package PLAN_FILE BASE HEAD [OUTFILE]
+# Default OUTFILE: <artifacts-dir>/review-<baseChange>..<headChange>-<headCommit>.diff
+#
+# ---------------------------------------------------------------------------
+# HAND IT CHANGE IDs, NOT COMMIT IDs. This is the whole reason the shim exists
+# and not just a port of the git plumbing.
+#
+# Upstream takes BASE and HEAD and guards them with
+# `git rev-parse --verify --quiet`, which fails loudly on a revision that no
+# longer exists. jj has no equivalent failure to offer, because in jj the
+# revision still exists: a rewrite (`jj describe`, `jj squash`, the rebase of
+# descendants that follows either, and every working-copy snapshot) leaves the
+# OLD commit reachable and merely hidden. Measured on jj 0.44.0 — describe an
+# earlier change, then feed its pre-rewrite commit id back in:
+#
+#     jj log  -r <stale-commit-id>   -> resolves, hidden=YES, pre-rewrite tree
+#     jj diff --from <stale-commit-id> --to @ --stat   -> exit 0, plausible diff
+#
+# So the git guard's whole job — turn a stale BASE into a loud error — is not
+# merely absent under jj, it is inverted: the stale value succeeds and produces
+# a review package built against the tree as it was BEFORE the fix round, which
+# a reviewer then reads as current and reports clean. Nothing anywhere errors.
+#
+# A change id does not have this failure. It follows its change through every
+# rewrite, so the same token keeps meaning "that task's work" across a review
+# loop that squashes fixes backward and rebases everything above.
+#
+# This script therefore reinstates the missing guard on jj's own terms:
+#   - a BASE or HEAD resolving to a HIDDEN revision is a hard error, because
+#     that is precisely the silent-wrongness case above;
+#   - a commit-id-shaped token is a warning naming the change id to use instead.
+#     Not an error: an immutable record is a legitimate use, and this script is
+#     invoked mid-run by an agent that should be told, not stopped.
+#
+# The shape check is exact rather than heuristic. jj renders change ids in a
+# reverse-hex alphabet using only k-z, and commit ids in ordinary hex 0-9a-f;
+# the two sets are disjoint, so `^[0-9a-f]+$` identifies a commit id with no
+# false positives against change ids. The warning additionally requires the
+# token to be a prefix of the resolved commit id and NOT of the resolved change
+# id, so a bookmark that happens to spell hex (`bad`, `face`) cannot trip it.
+#
+# NO --ignore-working-copy ANYWHERE BELOW. The helpers bake that flag in and it
+# is right for them, but a review package's HEAD is normally `@` — the change an
+# implementer just finished writing. Skipping the snapshot omits their most
+# recent edits and still produces a complete-looking package. It is the failure
+# mode this repo's CLAUDE.md flags as the one that fails quietly, and a reviewer
+# reading a truncated diff is exactly how it would cash out here.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+if [ $# -lt 3 ] || [ $# -gt 4 ]; then
+  echo "usage: sdd-review-package PLAN_FILE BASE HEAD [OUTFILE]" >&2
+  exit 2
+fi
+
+plan=$1
+base=$2
+head=$3
+# Captured BEFORE the `set --` calls below, which reuse the positional
+# parameters to split `resolve`'s output and would otherwise eat $4.
+outfile=${4:-}
+[ -f "$plan" ] || { echo "no such plan file: $plan" >&2; exit 2; }
+
+jj root >/dev/null 2>&1 || { echo "not in a jj repo (jj root failed)" >&2; exit 2; }
+
+# resolve LABEL REV -> prints "change_id commit_id hidden|visible"
+# Exits 2 with a keyed message when the revset names anything other than
+# exactly one revision, which is what --from/--to require.
+resolve() {
+  local label=$1 rev=$2 out n
+  if ! out=$(jj log -r "$rev" --no-graph \
+        -T 'change_id ++ " " ++ commit_id ++ " " ++ if(hidden,"hidden","visible") ++ "\n"' 2>/dev/null); then
+    echo "bad ${label}: ${rev} — no such revision" >&2
+    exit 2
+  fi
+  n=$(printf '%s' "$out" | grep -c . || true)
+  if [ "$n" -eq 0 ]; then
+    echo "bad ${label}: ${rev} — resolves to no revision" >&2
+    exit 2
+  fi
+  if [ "$n" -gt 1 ]; then
+    echo "bad ${label}: ${rev} — resolves to ${n} revisions; --from/--to need exactly one" >&2
+    exit 2
+  fi
+  printf '%s\n' "$out" | head -n 1
+}
+
+# check_id LABEL TOKEN CHANGE_ID COMMIT_ID VISIBILITY
+check_id() {
+  local label=$1 token=$2 change=$3 commit=$4 vis=$5 lower
+
+  if [ "$vis" = "hidden" ]; then
+    cat >&2 <<EOF
+bad ${label}: ${token} resolves to a HIDDEN revision (${commit}).
+
+A hidden revision is the pre-rewrite copy of a change that has since been
+described, squashed, or rebased. Diffing against it silently produces a review
+package for the code as it was BEFORE that rewrite.
+
+Use the change id, which followed the rewrite:  ${change}
+EOF
+    exit 2
+  fi
+
+  lower=$(printf '%s' "$token" | tr '[:upper:]' '[:lower:]')
+  case "$lower" in
+    *[!0-9a-f]*) return 0 ;;   # not commit-id-shaped; nothing to say
+    '')          return 0 ;;
+  esac
+  # Hex-shaped. Only warn when it really is this revision's commit id and not
+  # its change id, so a hex-spelled bookmark cannot trip the check.
+  case "$commit" in "$lower"*) ;; *) return 0 ;; esac
+  case "$change" in "$lower"*) return 0 ;; esac
+
+  cat >&2 <<EOF
+warning: ${label}=${token} is a COMMIT id. It is replaced by every jj describe,
+         squash, and rebase-of-descendants, so a value captured before a review
+         round is stale after it — and a stale commit id still resolves, so the
+         package would be built silently against the old tree.
+         Prefer the change id: ${change}
+EOF
+}
+
+# `resolve` runs in a command substitution, so its `exit 2` ends the SUBSHELL,
+# not this script. Without checking the status here the failure printed its
+# message and then fell through to `set -- ` on empty output, where `set -u`
+# raised "$1: unbound variable" and the script exited 1 — the right diagnosis
+# followed by the wrong exit code and a spurious second error. Test the status
+# and re-raise it.
+resolved=$(resolve BASE "$base") || exit 2
+set -- $resolved; base_change=$1; base_commit=$2; base_vis=$3
+check_id BASE "$base" "$base_change" "$base_commit" "$base_vis"
+
+resolved=$(resolve HEAD "$head") || exit 2
+set -- $resolved; head_change=$1; head_commit=$2; head_vis=$3
+check_id HEAD "$head" "$head_change" "$head_commit" "$head_vis"
+
+if [ -n "$outfile" ]; then
+  out=$outfile
+else
+  dir=$("$(cd "$(dirname "$0")" && pwd)/sdd-artifacts" "$plan")
+  # Named by CHANGE ids for identity and the head COMMIT id for the round.
+  # Change ids alone would make a re-review after fixes overwrite the package it
+  # is meant to be compared against — same change, same filename. The commit id
+  # is what a rewrite moves, so appending it yields the distinct fresh file per
+  # round that upstream got from its commit-range name, without giving up the
+  # stable identity in the first half. This is the CLAUDE.md rule applied in
+  # both directions at once: change ids to carry identity across a step, commit
+  # ids for an immutable record of one.
+  out="$dir/review-${base_change:0:8}..${head_change:0:8}-${head_commit:0:8}.diff"
+fi
+
+# Internally the range is built from the RESOLVED commit ids, not the caller's
+# tokens: they were resolved once, above, and a one-shot query is exactly where
+# a commit id is the correct currency. It also stops a compound revset token
+# from re-associating inside the `..` below.
+{
+  echo "# Review package: ${base} .. ${head}"
+  echo "#"
+  echo "# BASE  change ${base_change}  commit ${base_commit}"
+  echo "# HEAD  change ${head_change}  commit ${head_commit}"
+  echo
+  echo "## Changes"
+  jj log -r "${base_commit}..${head_commit}" --no-graph \
+    -T 'change_id.short() ++ " " ++ commit_id.short() ++ " " ++ if(empty,"[empty] ","") ++ description.first_line() ++ "\n"'
+  echo
+  echo "## Files changed"
+  jj diff --from "$base_commit" --to "$head_commit" --stat
+  echo
+  echo "## Diff"
+  jj diff --git --context 10 --from "$base_commit" --to "$head_commit"
+} > "$out"
+
+changes=$(jj log -r "${base_commit}..${head_commit}" --no-graph -T '"x\n"' | grep -c . || true)
+echo "wrote ${out}: ${changes} change(s), $(wc -c < "$out" | tr -d ' ') bytes"

--- a/plugins/workspace-jj/tests/test-sdd-scripts.sh
+++ b/plugins/workspace-jj/tests/test-sdd-scripts.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Tests for sdd-artifacts and sdd-review-package — the jj-native shims for
+# superpowers' subagent-driven-development scripts.
+#
+# Runs in a throwaway jj repo under mktemp; requires jj on PATH.
+# bash 3.2-safe: no globstar, no associative arrays.
+#
+# The guard tests here are the point of the suite, not padding. The bug these
+# scripts exist to prevent is SILENT: a stale commit id resolves, diffs, and
+# produces a plausible review package built against the pre-rewrite tree. So
+# every guard is asserted in BOTH directions — the hidden revision must fail
+# and a live one must not — because a guard that merely rejected everything
+# would pass a one-sided test while breaking every real run.
+set -euo pipefail
+
+SCRIPTS="$(cd "$(dirname "$0")/../scripts" && pwd)"
+PASS=0
+FAIL=0
+
+ok()  { echo "PASS: $1"; PASS=$((PASS+1)); }
+bad() { echo "FAIL: $1${2:+ — $2}"; FAIL=$((FAIL+1)); }
+
+check() { # check DESCRIPTION COMMAND...
+  local desc=$1; shift
+  if "$@" >/dev/null 2>&1; then ok "$desc"; else bad "$desc"; fi
+}
+
+check_fails() { # check_fails DESCRIPTION EXPECTED_EXIT COMMAND...
+  local desc=$1 expected=$2; shift 2
+  local actual=0
+  "$@" >/dev/null 2>&1 || actual=$?
+  if [ "$actual" -eq "$expected" ]; then ok "$desc"
+  else bad "$desc" "exit $actual, expected $expected"; fi
+}
+
+tmp=$(mktemp -d)
+repo="$tmp/sdd-test-$$"
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$repo"
+# Normalise to the PHYSICAL path before anything compares against it. On macOS
+# /var is a symlink to /private/var, so mktemp -d hands back the unresolved
+# /var/folders/... while `jj root` reports the resolved /private/var/folders/...
+# — and the equality assertion below fails on a script that is behaving
+# correctly. Linux has no such symlink, so this is invisible there; the macOS
+# leg of CI is what caught it.
+repo=$(cd "$repo" && pwd -P)
+# Non-colocated on purpose: `jj git init` colocates by default since 0.43, and
+# a fixture that materialises the git backing directory invites a stray mention
+# of it in a later test to meet block-raw-git.sh's internals matcher. Nothing
+# here needs the git side.
+(cd "$repo" && jj git init --config git.colocate=false >/dev/null 2>&1)
+
+cat > "$repo/plan.md" <<'EOF'
+# Example Plan
+
+### Task 1: First thing
+
+### Task 2: Second thing
+EOF
+
+cd "$repo"
+
+# Two described changes plus an empty working copy on top, so BASE..HEAD spans
+# a real diff rather than an empty range.
+echo "one" > f.txt
+jj describe -m "task 1 work" >/dev/null 2>&1
+jj new >/dev/null 2>&1
+echo "two" >> f.txt
+jj describe -m "task 2 work" >/dev/null 2>&1
+jj new >/dev/null 2>&1
+
+# description() is an EXACT match in jj, and descriptions carry a trailing
+# newline, so the bare form matches nothing. substring: is the working spelling.
+T1_CHANGE=$(jj log -r 'description(substring:"task 1 work")' --no-graph -T 'change_id.short()')
+T1_COMMIT=$(jj log -r 'description(substring:"task 1 work")' --no-graph -T 'commit_id.short()')
+
+# --- sdd-artifacts ---------------------------------------------------------
+
+check_fails "sdd-artifacts: no arguments is exit 2" 2 "$SCRIPTS/sdd-artifacts"
+check_fails "sdd-artifacts: two arguments is exit 2" 2 "$SCRIPTS/sdd-artifacts" a b
+check_fails "sdd-artifacts: missing plan file is exit 2" 2 "$SCRIPTS/sdd-artifacts" nope.md
+
+DIR=$("$SCRIPTS/sdd-artifacts" plan.md)
+[ "$DIR" = "$repo/.superpowers/sdd/plan" ] \
+  && ok "sdd-artifacts: prints <root>/.superpowers/sdd/<plan-basename>" \
+  || bad "sdd-artifacts: path" "got $DIR"
+
+[ -d "$DIR" ] && ok "sdd-artifacts: creates the directory" \
+             || bad "sdd-artifacts: creates the directory"
+
+[ "$(cat "$repo/.superpowers/sdd/.gitignore")" = "*" ] \
+  && ok "sdd-artifacts: writes the self-ignoring ignore file" \
+  || bad "sdd-artifacts: writes the self-ignoring ignore file"
+
+# The reason that ignore file exists: jj snapshots the working copy, so without
+# it every brief and package would ride into the change under review.
+echo "an artifact" > "$DIR/task-1-brief.md"
+# Matched with `case`, not `jj status | grep -q`. Under `set -o pipefail` that
+# pipeline reports FAILURE on a match: grep -q exits the moment it matches, jj
+# gets SIGPIPE, and pipefail surfaces jj's death as the pipeline's status. The
+# assertion then inverts — it passes only when the snapshot is dirty, which is
+# the bug this line exists to catch. Every match below is pipe-free for the
+# same reason.
+status=$(jj status 2>/dev/null || true)
+case "$status" in
+  *"no changes"*) ok "sdd-artifacts: artifacts stay out of the working-copy snapshot" ;;
+  *) bad "sdd-artifacts: artifacts stay out of the working-copy snapshot" "$status" ;;
+esac
+
+# --- sdd-review-package: argument handling ---------------------------------
+
+check_fails "review-package: too few arguments is exit 2" 2 \
+  "$SCRIPTS/sdd-review-package" plan.md "$T1_CHANGE"
+check_fails "review-package: too many arguments is exit 2" 2 \
+  "$SCRIPTS/sdd-review-package" plan.md "$T1_CHANGE" @ out.diff extra
+check_fails "review-package: missing plan file is exit 2" 2 \
+  "$SCRIPTS/sdd-review-package" nope.md "$T1_CHANGE" @
+
+# --- sdd-review-package: the happy path ------------------------------------
+
+check "review-package: change ids succeed" \
+  "$SCRIPTS/sdd-review-package" plan.md "$T1_CHANGE" @
+
+PKG=$(ls "$DIR"/review-*.diff 2>/dev/null | head -n 1)
+if [ -n "$PKG" ]; then
+  ok "review-package: writes a package into the artifacts directory"
+else
+  bad "review-package: writes a package into the artifacts directory"
+fi
+
+for section in "## Changes" "## Files changed" "## Diff"; do
+  if grep -qF "$section" "$PKG" 2>/dev/null; then
+    ok "review-package: package contains '$section'"
+  else
+    bad "review-package: package contains '$section'"
+  fi
+done
+
+# Both ids recorded in the header: the change id carries identity across a
+# rewrite, the commit id pins which round this package was cut from.
+grep -qE '^# BASE  change [k-z]+  commit [0-9a-f]+$' "$PKG" \
+  && ok "review-package: header records BASE change id and commit id" \
+  || bad "review-package: header records BASE change id and commit id"
+
+# The default filename must distinguish re-review rounds. Change ids alone
+# would collide with the package a fix round is meant to be compared against.
+case "$(basename "$PKG")" in
+  review-*..*-*.diff) ok "review-package: default filename carries both change ids and the head commit id" ;;
+  *) bad "review-package: default filename shape" "got $(basename "$PKG")" ;;
+esac
+
+# Regression: OUTFILE is read before `set --` reuses the positional parameters
+# to split the resolver's output. It used to be eaten there, silently sending
+# every package to the default path instead of where the caller asked.
+"$SCRIPTS/sdd-review-package" plan.md "$T1_CHANGE" @ "$repo/explicit.diff" >/dev/null 2>&1
+[ -f "$repo/explicit.diff" ] \
+  && ok "review-package: honours an explicit OUTFILE" \
+  || bad "review-package: honours an explicit OUTFILE"
+
+# --- sdd-review-package: the guards ----------------------------------------
+
+# A LIVE commit id is a warning, not a failure — an immutable record is a
+# legitimate use, and stopping an agent mid-run over it would be wrong.
+warn=$("$SCRIPTS/sdd-review-package" plan.md "$T1_COMMIT" @ 2>&1 >/dev/null || true)
+case "$warn" in
+  *"is a COMMIT id"*) ok "review-package: live commit id warns" ;;
+  *) bad "review-package: live commit id warns" "stderr was: $warn" ;;
+esac
+check "review-package: live commit id still succeeds" \
+  "$SCRIPTS/sdd-review-package" plan.md "$T1_COMMIT" @
+
+# A change id must NOT warn. Without this the warning could fire on everything
+# and the assertion above would still pass.
+warn=$("$SCRIPTS/sdd-review-package" plan.md "$T1_CHANGE" @ 2>&1 >/dev/null || true)
+case "$warn" in
+  *"is a COMMIT id"*) bad "review-package: change id does not warn" "stderr was: $warn" ;;
+  *) ok "review-package: change id does not warn" ;;
+esac
+
+# The core case. Rewrite task 1 the way a review round does, then feed back the
+# commit id captured before it. jj resolves it, reports it hidden, and would
+# otherwise diff happily against the pre-rewrite tree.
+jj describe -r 'description(substring:"task 1 work")' -m "task 1 work (review round 1)" >/dev/null 2>&1
+
+check_fails "review-package: hidden BASE is a hard error" 2 \
+  "$SCRIPTS/sdd-review-package" plan.md "$T1_COMMIT" @
+err=$("$SCRIPTS/sdd-review-package" plan.md "$T1_COMMIT" @ 2>&1 >/dev/null || true)
+case "$err" in
+  *"HIDDEN revision"*) ok "review-package: hidden BASE names the hazard" ;;
+  *) bad "review-package: hidden BASE names the hazard" "stderr was: $err" ;;
+esac
+case "$err" in
+  *"$T1_CHANGE"*) ok "review-package: hidden BASE hands back the change id to use instead" ;;
+  *) bad "review-package: hidden BASE hands back the change id to use instead" ;;
+esac
+
+# The same change id still works after the rewrite — that is the property the
+# whole shim argues for, so assert it rather than implying it.
+check "review-package: the change id survives the rewrite" \
+  "$SCRIPTS/sdd-review-package" plan.md "$T1_CHANGE" @
+
+# --- sdd-review-package: revset arity --------------------------------------
+
+check_fails "review-package: unresolvable revision is exit 2" 2 \
+  "$SCRIPTS/sdd-review-package" plan.md zzzznotarev @
+check_fails "review-package: a revset naming many revisions is exit 2" 2 \
+  "$SCRIPTS/sdd-review-package" plan.md 'all()' @
+check_fails "review-package: a revset naming none is exit 2" 2 \
+  "$SCRIPTS/sdd-review-package" plan.md 'none()' @
+
+echo
+echo "$PASS passed, $FAIL failed"
+test "$FAIL" -eq 0


### PR DESCRIPTION
## Why

superpowers' `subagent-driven-development` is the right tool for a **serial** plan — kaisen's waves buy nothing when tasks are strictly ordered or repeatedly touch the same files. But two of its helper scripts shell out to `git`, which `block-raw-git.sh` denies in every jj repo where project-setup-jj is enabled. The hook is registered in `plugin.json`, not in per-project settings, so there is no toggle — a shim is the only route.

Field report from a real serial SDD run: the workaround was to hand-roll review packages keyed on **commit IDs**. That picks the one jj identifier rewrites replace.

## The guard, and why this is more than a port

Upstream protects `BASE`/`HEAD` with `git rev-parse --verify`, which fails loudly on a revision that no longer exists. jj has no equivalent failure to offer, because the revision still exists: a rewrite — `jj describe`, `jj squash`, the rebase of descendants that follows either, and every working-copy snapshot — leaves the old commit reachable and merely *hidden*. Measured on jj 0.44.0:

```
jj log  -r <stale-commit-id>                    -> resolves, hidden=YES, pre-rewrite tree
jj diff --from <stale-commit-id> --to @ --stat  -> exit 0, plausible diff
```

So the git guard's whole job is not merely absent under jj — it is inverted. A `BASE` captured before a review round silently produces a package built against the code as it was **before** the fix, which a reviewer reads as current and reports clean. Nothing anywhere errors.

## What's here

| Upstream script | Replacement | What changes |
|---|---|---|
| `scripts/sdd-workspace` | `sdd-artifacts` | `jj root` for `git rev-parse --show-toplevel`; otherwise identical behaviour, so a plan mid-flight switches without moving an artifact. Renamed because in a jj repo "workspace" means `jj workspace add`, and this directory is not one. |
| `scripts/review-package` | `sdd-review-package` | Same sections and argv, plus the guard: a hidden `BASE`/`HEAD` is a hard error naming the change ID to use instead; a commit-ID-shaped argument warns rather than stops, since an immutable record is a legitimate use. |
| `scripts/task-brief` | unchanged | It only shells out to derive its default path — an explicit outfile is enough. Documented, not duplicated. |

Packages are named `review-<baseChange>..<headChange>-<headCommit>.diff`: change IDs carry identity across a review round, the head commit ID keeps each round's package a distinct file. Upstream got the second property from its commit-range name and would have lost it under change IDs alone.

Verified that jj honours the self-ignoring `.gitignore`, so upstream's in-tree artifacts location is safe here and is kept rather than moved to `/tmp` as kaisen does — a serial plan's ledger outlives the run.

## Template

The `subagent-driven-development -> kaisen` row becomes a preference conditional on plan shape rather than a blanket override, and carries the two constraints the serial path needs: record `BASE` as a change ID, and dispatch one implementer at a time (they share the default workspace and move `@` under the orchestrator).

Folded **inside** the managed block so it survives `/project-setup` regeneration — the equivalent guidance in a downstream repo had to live outside the block and would have been dropped. Hash recomputed and this repo's own CLAUDE.md synced; #87 was that copy going stale.

## Testing

28 new tests, discovered by the CI glob. All 23 suites green.

Mutation-checked rather than assumed:

- neutering the hidden guard -> 2 failures
- dropping the ignore-file write -> 2 failures

One honest limit: the "change ID does not warn" assertion is protected by three independent discriminators, so no single-line mutation defeats it. It would catch a rewrite that removed the discrimination wholesale, not a narrower regression.

Two bugs caught during development, both in this PR's own code: `set --` ate the `OUTFILE` argument (silently redirecting every package to the default path — now a regression test), and `pipefail` + `grep -q`'s early exit inverted the snapshot assertion so it passed only when the working copy was *dirty*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeoWzwa6oNxtzcEfGDYmvY