### PR TITLE
fix(project-setup-jj): the briefing's (this session) marker was dead wherever a workspace root is unrecorded

### DIFF
--- a/plugins/project-setup-jj/.claude-plugin/plugin.json
+++ b/plugins/project-setup-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-setup-jj",
   "description": "Bootstrap jj (Jujutsu) workflow enforcement for any Claude Code project with a single /project-setup command",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/project-setup-jj/scripts/jj-session-start.sh
+++ b/plugins/project-setup-jj/scripts/jj-session-start.sh
@@ -69,7 +69,8 @@ fi
 
 # @ and `jj root` are workspace-relative: which workspace this session is
 # attached to determines what @ even means, and a second live workspace means
-# another agent may be editing concurrently.
+# another agent may be editing concurrently. The row for THIS session is marked
+# so the briefing states which one that is instead of leaving it to inference.
 #
 # The template is PINNED, and that is the point of it. jj 0.44 added workspace
 # roots to this command's default output, so every briefing silently grew a
@@ -79,29 +80,35 @@ fi
 # plugins ship — so its shape is ours to choose, not jj's to change under us.
 # What the briefing actually needs is the concurrency signal: who else is live,
 # on which change, and whether that change is empty (nobody mid-work) or not.
+#
+# THE MARKER ASKS jj DIRECTLY, rather than reconstructing the answer. It used
+# to read `jj workspace root` and match that path against each row's
+# `self.root()` in awk. That comparison is unsound: `WorkspaceRef.root()` is
+# optional and renders EMPTY in two ordinary situations jj documents — a
+# workspace created before jj 0.38.0, which recorded no root at all, and a
+# workspace whose directory was later moved, which makes the recorded path
+# stale and drops it. Measured on 0.44.0 in both shapes: `self.root()` comes
+# back empty while `jj workspace root` still returns the true path, so the
+# equality never held, `current_ws` stayed empty, and the marker was silently
+# omitted — the briefing showed a bare `default: <id>` and read as correct.
+# Installed, registered, announced, and dead, in every repo whose workspace
+# predates 0.38.0. The installer's smoke test cannot see it either, because the
+# script goes on emitting perfectly valid JSON.
+#
+# `current_working_copy()` is jj answering the one question it alone can
+# answer: true for the working-copy commit of the CURRENT workspace, with no
+# dependence on a recorded path. Verified in a two-workspace repo from both
+# sides, and in the moved-directory case that defeats root matching. Folding it
+# into the display template also retires a second `jj workspace list` call, the
+# `jj workspace root` call, and the awk pipeline — the last of which had to be
+# written without `exit` to stop jj dying of EPIPE mid-write.
+#
+# Were two workspaces ever to share a working-copy commit, both rows would be
+# marked. jj gives each workspace its own, so this does not arise; and marking
+# both would still be truer than silently picking one.
 workspaces=$(jj --ignore-working-copy workspace list --no-pager \
-  -T 'self.name() ++ ": " ++ self.target().change_id().shortest(8) ++ if(self.target().empty(), " (empty)", "") ++ " " ++ if(self.target().description(), self.target().description().first_line(), "(no description set)") ++ "\n"' \
+  -T 'self.name() ++ ": " ++ self.target().change_id().shortest(8) ++ if(self.target().empty(), " (empty)", "") ++ " " ++ if(self.target().description(), self.target().description().first_line(), "(no description set)") ++ if(self.target().current_working_copy(), " (this session)", "") ++ "\n"' \
   2>/dev/null || echo "(unable to read workspaces)")
-
-# Mark which row is THIS session — the paragraph above says the attached
-# workspace determines what @ means, so the briefing should say which one that
-# is rather than leave it to inference. Match by ROOT, never by name: names
-# repeat across repos while roots cannot, and both sides of the comparison come
-# from jj itself, so the spellings agree (no /tmp vs /private/tmp mismatch).
-# No `exit` inside the awk: under this script's set -euo pipefail, awk exiting
-# on the first match closes the pipe while jj may still be writing later rows,
-# jj dies of EPIPE, and the whole briefing silently vanishes — measured as an
-# intermittent empty payload the moment a second workspace existed.
-current_root=$(jj workspace root --ignore-working-copy 2>/dev/null || true)
-if [ -n "$current_root" ]; then
-  current_ws=$(jj --ignore-working-copy workspace list --no-pager \
-    -T 'self.name() ++ "\t" ++ self.root() ++ "\n"' 2>/dev/null \
-    | awk -F'\t' -v r="$current_root" '!found && $2 == r {print $1; found=1}') || true
-  if [ -n "$current_ws" ]; then
-    workspaces=$(printf '%s\n' "$workspaces" \
-      | awk -v ws="$current_ws" 'index($0, ws ": ") == 1 {$0 = $0 " (this session)"} {print}') || true
-  fi
-fi
 
 identity=$(jj --ignore-working-copy config list user.email -T 'json(self) ++ "\n"' 2>/dev/null || echo "(unable to read user.email)")
 

--- a/plugins/project-setup-jj/tests/test-jj-session-start.sh
+++ b/plugins/project-setup-jj/tests/test-jj-session-start.sh
@@ -163,6 +163,51 @@ fi
 jj workspace forget second >/dev/null 2>&1
 rm -rf ../ws2
 
+# The marker must not depend on a RECORDED workspace root. `WorkspaceRef.root()`
+# is optional: jj records nothing for workspaces created before 0.38.0, and
+# drops the recorded path once a workspace directory is moved. The briefing used
+# to match `jj workspace root` against that field, so in either shape the
+# comparison ran against an empty string, never matched, and the marker was
+# silently dropped — a bare `default: <id>` that reads as correct. Whole repos
+# shipped with the marker installed, registered, announced, and dead.
+#
+# Moving the directory is the reproducible half of that pair: it produces the
+# same empty `self.root()` on a current jj, with no pre-0.38.0 repo to conjure.
+# This case fails against root matching and passes against
+# `current_working_copy()`, which is the whole point of the change.
+jj workspace add ../ws3 --name third >/dev/null 2>&1
+mv ../ws3 ../ws3-moved
+# The precondition is NOT "the field renders empty" — that spelling is
+# platform- and version-dependent. Linux renders an empty string; macOS on a
+# newer jj renders `<Error: Failed to resolve workspace root: ...>`, because the
+# recorded path is stored relative to the repo and no longer resolves after the
+# move. Asserting emptiness failed there on a fix that was working correctly.
+#
+# What has to hold is the property root matching depended on: the recorded root
+# must no longer equal the workspace's live path, so an equality test against
+# `jj workspace root` cannot succeed. Empty, an error placeholder, and a stale
+# path all satisfy that; a live matching path would make the case vacuous.
+moved_root=$(cd ../ws3-moved && jj workspace root --ignore-working-copy 2>/dev/null || true)
+root_field=$(jj --ignore-working-copy workspace list --no-pager \
+  -T 'self.name() ++ "\t" ++ self.root() ++ "\n"' 2>/dev/null \
+  | awk -F'\t' '$1 == "third" {print $2}')
+if [ -n "$moved_root" ] && [ "$root_field" != "$moved_root" ]; then
+  ok "fixture is honest: the recorded root no longer identifies the moved workspace"
+else
+  bad "marker" "fixture is vacuous — recorded root still matches the live path: [$root_field] vs [$moved_root]"
+fi
+
+out4="$(cd ../ws3-moved && bash "$HOOK" 2>/dev/null | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || true)"
+ws4_section=$(printf '%s\n' "$out4" | awk '/^Workspaces:/{f=1;next} /^[[:space:]]*$/{f=0} f')
+if printf '%s' "$ws4_section" | grep -q '^third: .*(this session)$' \
+   && ! printf '%s' "$ws4_section" | grep -q '^default: .*(this session)$'; then
+  ok "marker survives a workspace whose recorded root is gone"
+else
+  bad "marker" "marker lost when the recorded root is empty: $ws4_section"
+fi
+jj workspace forget third >/dev/null 2>&1
+rm -rf ../ws3-moved
+
 # Scope every stack assertion to the stack SECTION, for the reason the identity
 # check had to learn: @'s own `json(self)` block sits directly above and already
 # contains the description, so an unscoped grep passes even against a hook that


### PR DESCRIPTION
## The bug

`WorkspaceRef.root()` is optional, and jj documents two ordinary cases where it is empty:

> This is optional because workspaces created before jj 0.38.0 did not record workspace root paths, and a recorded path can also become stale if the workspace directory is moved or deleted.

The briefing reconstructed "which row is this session" by reading `jj workspace root` and matching that path against each row's `self.root()` in awk. In either case above the comparison runs against an empty string, never matches, `current_ws` stays empty, and the `(this session)` marker is silently omitted — leaving a bare `default: <id>` that reads as perfectly correct.

Measured on jj 0.44.0, comparing a repo whose default workspace predates 0.38.0 against one that does not:

```
self.root()          -> []                  # the pre-0.38.0 repo
jj workspace root    -> /path/to/repo       # the true path, same repo
```

So in every such repo the marker was installed, registered, announced, and dead. The installer's smoke test cannot see it either: the script goes on emitting valid JSON, which is all that check asks.

Reported from a downstream repo whose post-restart briefing showed a bare `default:` row; confirmed here by querying both repos side by side.

## The fix

Ask jj the question instead of reconstructing the answer. `current_working_copy()` is true for the working-copy commit of the *current* workspace and depends on no recorded path:

```
if(self.target().current_working_copy(), " (this session)", "")
```

Verified in a two-workspace repo from both sides, and in the moved-directory case that defeats root matching.

Folding the marker into the display template also retires a second `jj workspace list` invocation, the `jj workspace root` call, and the awk pipeline — the last of which had to be written without `exit` to keep jj from dying of EPIPE mid-write. Net: one jj call where there were three, and no path arithmetic.

## Testing

The regression test moves a workspace directory, which reproduces the same empty `self.root()` on a current jj with no pre-0.38.0 repo to conjure. Fail-first verified — against the previous script:

```
FAIL: marker — marker lost when the recorded root is empty: default: zmvxqqrx (empty) work
26 passed, 1 failed
```

and 27/0 with the fix. The case is guarded by a companion assertion that the fixture is honest (the moved workspace really does report no recorded root), so it cannot quietly go vacuous if jj changes that behaviour.

All 23 suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeoWzwa6oNxtzcEfGDYmvY