### PR TITLE
fix(workspace-jj): sdd-review-package accepted a BASE off HEAD's line of history

### DIFF
--- a/plugins/workspace-jj/.claude-plugin/plugin.json
+++ b/plugins/workspace-jj/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workspace-jj",
   "description": "Wave-based parallel orchestration with spec review gates for jj (Jujutsu) repositories",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "muloka",
     "email": "muloka@users.noreply.github.com"

--- a/plugins/workspace-jj/README.md
+++ b/plugins/workspace-jj/README.md
@@ -129,6 +129,8 @@ So a BASE captured before a review round does not error afterwards — it silent
 
 `sdd-review-package` therefore reinstates the guard on jj's terms — a hidden BASE or HEAD is a hard error naming the change ID to use instead, and a commit-ID-shaped argument is a warning rather than a stop, since an immutable record is a legitimate use. Packages are named `review-<baseChange>..<headChange>-<headCommit>.diff`: change IDs carry identity across a review round, the head commit ID keeps each round's package a distinct file.
 
+**BASE must be on HEAD's line of history.** The two halves of a package are built by different machinery: `## Changes` is the revset range `base..head`, while `## Files changed` and `## Diff` compare the two trees directly. Those agree for an ancestral pair and disagree for a sibling pair, and nothing in the output says which you got — measured on two revisions forked off the same root, the package listed one change while the diff deleted a file that change never touched. A non-ancestral BASE is therefore a hard error too, which also catches BASE and HEAD passed the wrong way round.
+
 **Implementers share the default workspace.** Serial SDD deliberately uses no isolation, so implementer subagents running `jj describe` and `jj new` move `@` for the orchestrator too. Dispatch one at a time; that constraint is what makes the shared working copy safe, not an incidental scheduling choice.
 
 ## Author

--- a/plugins/workspace-jj/scripts/sdd-review-package
+++ b/plugins/workspace-jj/scripts/sdd-review-package
@@ -141,6 +141,57 @@ resolved=$(resolve HEAD "$head") || exit 2
 set -- $resolved; head_change=$1; head_commit=$2; head_vis=$3
 check_id HEAD "$head" "$head_change" "$head_commit" "$head_vis"
 
+# BASE MUST BE AN ANCESTOR OF HEAD, or the package contradicts itself.
+#
+# The two halves are built by different machinery: `## Changes` is the revset
+# range `base..head`, while `## Files changed` and `## Diff` are a tree-to-tree
+# comparison of the two revisions. For an ancestral pair those agree. For a
+# sibling pair they do not, and the disagreement is not visible in the output —
+# measured with two revisions forked off the same root:
+#
+#   ## Changes  ->  one entry, "branch B work"
+#   ## Diff     ->  deletes f.txt, a file branch B never touched
+#
+# A reviewer reads that as "this task deleted f.txt". Exit 0, no warning. It is
+# the same silent-wrongness this script exists to stop, arriving by a different
+# road: the hidden-revision guard above catches a BASE that was rewritten, and
+# this one catches a BASE that was never on this line of history at all.
+#
+# Inherited from upstream, which has the identical semantics in
+# `git log BASE..HEAD` beside `git diff BASE..HEAD` — but far more reachable
+# here, because a change id recorded for one task can end up on a different
+# parent after a duplicate, an abandon-and-recreate, or a rebase onto another
+# branch, and it keeps resolving cleanly the whole time.
+#
+# A hard error rather than a warning: the package's entire claim is "here is
+# what this task changed", and a non-ancestral BASE makes that claim false
+# rather than imprecise. This also catches BASE and HEAD passed the wrong way
+# round, since a descendant is not an ancestor either.
+#
+# Matched with `case`, not `| grep -q`: under `set -o pipefail` grep -q exits on
+# first match, jj takes SIGPIPE, and the pipeline reports failure on success.
+ancestral=$(jj log -r "${base_commit} & ::${head_commit}" --no-graph -T '"x"' 2>/dev/null || true)
+case "$ancestral" in
+  *x*) ;;
+  *)
+    cat >&2 <<EOF
+bad BASE: ${base} is not an ancestor of HEAD (${head}).
+
+  BASE  change ${base_change}
+  HEAD  change ${head_change}
+
+The package would contradict itself: '## Changes' lists the revset range
+${base}..${head}, while '## Diff' compares the two trees directly. For revisions
+on different lines of history those describe different work, and nothing in the
+output says so — the diff reports files the listed changes never touched.
+
+If HEAD really is the task's tip, record the BASE from this task's own ancestry
+(\`jj log -r '::${head_change}'\`). If the arguments are the wrong way round,
+swap them.
+EOF
+    exit 2 ;;
+esac
+
 if [ -n "$outfile" ]; then
   out=$outfile
 else

--- a/plugins/workspace-jj/tests/test-sdd-scripts.sh
+++ b/plugins/workspace-jj/tests/test-sdd-scripts.sh
@@ -209,6 +209,50 @@ check_fails "review-package: a revset naming many revisions is exit 2" 2 \
 check_fails "review-package: a revset naming none is exit 2" 2 \
   "$SCRIPTS/sdd-review-package" plan.md 'none()' @
 
+# --- sdd-review-package: BASE must be on HEAD's line of history -------------
+
+# `## Changes` is the revset range base..head; `## Files changed` and `## Diff`
+# are a tree-to-tree comparison. Those agree for an ancestral pair and disagree
+# for a sibling pair — and the output never says which it gave you. Measured
+# before the guard: two revisions forked off the same root produced a package
+# listing one change while the diff deleted a file that change never touched.
+#
+# `--no-edit` is load-bearing. The first cut of this used a plain
+# `jj new 'root()'`, which MOVES the working copy onto the root commit — an
+# empty tree, so plan.md left the disk and every case below failed on "no such
+# plan file" instead. That still exits 2, so the exit-code assertion passed for
+# entirely the wrong reason; only the message assertion noticed. Creating the
+# sibling off to the side keeps the working copy, and its files, where the rest
+# of the suite left them.
+#
+# The siblings are empty on purpose: this guard is about TOPOLOGY, and an empty
+# revision is no more an ancestor than a populated one.
+jj new 'root()' --no-edit -m "sibling work" >/dev/null 2>&1
+SIB_CHANGE=$(jj log -r 'description(substring:"sibling work")' --no-graph -T 'change_id.short()')
+
+check_fails "review-package: a BASE that is not an ancestor of HEAD is exit 2" 2 \
+  "$SCRIPTS/sdd-review-package" plan.md "$T1_CHANGE" "$SIB_CHANGE"
+
+err=$("$SCRIPTS/sdd-review-package" plan.md "$T1_CHANGE" "$SIB_CHANGE" 2>&1 >/dev/null || true)
+case "$err" in
+  *"is not an ancestor of HEAD"*) ok "review-package: non-ancestral BASE names the contradiction" ;;
+  *) bad "review-package: non-ancestral BASE names the contradiction" "stderr was: $err" ;;
+esac
+
+# The same check catches BASE and HEAD passed the wrong way round, since a
+# descendant is not an ancestor either. Without this, a reversed pair produced a
+# clean-looking reverse diff.
+jj new "$SIB_CHANGE" --no-edit -m "sibling child" >/dev/null 2>&1
+SIB_CHILD=$(jj log -r 'description(substring:"sibling child")' --no-graph -T 'change_id.short()')
+
+check_fails "review-package: BASE and HEAD reversed is exit 2" 2 \
+  "$SCRIPTS/sdd-review-package" plan.md "$SIB_CHILD" "$SIB_CHANGE"
+
+# And the ancestral direction of that very pair must still succeed, so the guard
+# is not just rejecting everything it is handed.
+check "review-package: the same pair in ancestral order succeeds" \
+  "$SCRIPTS/sdd-review-package" plan.md "$SIB_CHANGE" "$SIB_CHILD"
+
 echo
 echo "$PASS passed, $FAIL failed"
 test "$FAIL" -eq 0


### PR DESCRIPTION
## The bug

The two halves of a review package are built by different machinery:

- `## Changes` is the revset range `base..head`
- `## Files changed` and `## Diff` compare the two trees directly

For an ancestral pair those agree. For a sibling pair they do not, and nothing in the output says which one you got. Measured on two revisions forked off the same root:

```
## Changes
korrrnzkouxl 68a25fc3a675 branch B work     <- one change

## Diff
diff --git a/f.txt b/f.txt
deleted file mode 100644                     <- deletes a file branch B never touched
```

A reviewer reads that as "this task deleted f.txt". Exit 0, no warning.

This is the same silent-wrongness the hidden-revision guard exists to stop, arriving by a different road: that guard catches a BASE that was *rewritten*, this one catches a BASE that was *never on this line of history*.

The semantics are inherited — `git log BASE..HEAD` beside `git diff BASE..HEAD` behaves identically upstream. It is far more reachable here, because a change ID recorded for one task can end up on a different parent after a duplicate, an abandon-and-recreate, or a rebase onto another branch, and it keeps resolving cleanly the whole time.

Found while poking at the shims after they merged in #168; neither the 28 tests nor CI covered it.

## The fix

Require BASE to be an ancestor of HEAD:

```bash
ancestral=$(jj log -r "${base_commit} & ::${head_commit}" --no-graph -T '"x"' 2>/dev/null || true)
```

A hard error rather than a warning: the package's entire claim is "here is what this task changed", and a non-ancestral BASE makes that claim false rather than imprecise. It also catches BASE and HEAD passed the wrong way round, since a descendant is no more an ancestor than a sibling.

Matched with `case`, not `| grep -q` — under `set -o pipefail` grep -q exits on first match, jj takes SIGPIPE, and the pipeline reports failure on success. That inversion already bit this suite once.

## Testing

Three new cases (32 total). Fail-first verified — without the guard:

```
FAIL: a BASE that is not an ancestor of HEAD is exit 2 — exit 0, expected 2
FAIL: non-ancestral BASE names the contradiction — stderr was:
FAIL: BASE and HEAD reversed is exit 2 — exit 0, expected 2
29 passed, 3 failed
```

The third case asserts the *same pair in ancestral order still succeeds*, so the guard cannot pass by rejecting everything.

One fixture note worth recording: the first cut created the sibling with a plain `jj new 'root()'`, which moves the working copy to an empty tree — `plan.md` left the disk and the cases failed on "no such plan file", which also exits 2. The exit-code assertion passed for entirely the wrong reason; only the message assertion noticed. The fixture now uses `jj new --no-edit`, leaving the working copy where the rest of the suite left it.

All 23 suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeoWzwa6oNxtzcEfGDYmvY